### PR TITLE
Fix mobile viewport, scrolling, and modal display

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌿</text></svg>" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -305,7 +305,7 @@ function AppContent() {
 
   return (
     <ThemeContext.Provider value={theme}>
-    <div className="flex flex-col h-screen bg-gray-950">
+    <div className="flex flex-col h-[100dvh] bg-gray-950">
       <a href="#plant-sidebar" className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-3 focus:py-1.5 focus:rounded-lg focus:bg-emerald-600 focus:text-white focus:text-sm">
         Skip to plant list
       </a>
@@ -349,8 +349,8 @@ function AppContent() {
 
             {/* Sidebar panel — controlled by mobileTab on mobile, sidebarOpen on md+ */}
             <div className={[
-              'flex-col',
-              mobileTab === 'floorplan' ? 'hidden' : 'flex w-full',
+              'flex-col min-h-0',
+              mobileTab === 'floorplan' ? 'hidden' : 'flex w-full overflow-hidden',
               sidebarOpen ? 'md:flex md:flex-shrink-0 md:w-72' : 'md:hidden',
             ].join(' ')}>
               <PlantSidebar
@@ -484,11 +484,11 @@ function AppContent() {
 
       {showHelp && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-fade-in"
+          className="fixed inset-0 z-50 flex flex-col md:items-center md:justify-center md:p-4 animate-fade-in"
           style={{ background: 'rgba(0,0,0,0.7)', backdropFilter: 'blur(4px)' }}
           onClick={() => setShowHelp(false)}
         >
-          <div className="animate-fade-in-up bg-gray-900 border border-gray-800 rounded-2xl shadow-2xl shadow-black/40 p-6 max-w-sm w-full" onClick={e => e.stopPropagation()} style={{ background: 'linear-gradient(180deg, var(--tw-gray-900) 0%, #0f1925 100%)' }}>
+          <div className="animate-fade-in-up bg-gray-900 md:border md:border-gray-800 md:rounded-2xl shadow-2xl shadow-black/40 p-6 max-w-sm w-full mx-auto my-auto" onClick={e => e.stopPropagation()} style={{ background: 'linear-gradient(180deg, var(--tw-gray-900) 0%, #0f1925 100%)' }}>
             <div className="flex items-center gap-2 mb-4">
               <Keyboard size={18} className="text-emerald-400" />
               <h2 className="text-sm font-semibold text-white">Keyboard Shortcuts</h2>

--- a/src/components/AnalyticsModal.jsx
+++ b/src/components/AnalyticsModal.jsx
@@ -583,7 +583,7 @@ export default function AnalyticsPage({ plants }) {
   const [tab, setTab] = useState('overview')
 
   return (
-    <div className="flex flex-col h-full bg-gray-950">
+    <div className="flex flex-col h-full min-h-0 bg-gray-950">
       {/* Tabs */}
       <div className="flex border-b border-gray-800 flex-shrink-0 px-4">
         {[

--- a/src/components/CareCalendar.jsx
+++ b/src/components/CareCalendar.jsx
@@ -73,12 +73,12 @@ export default function CareCalendar({ plants, weather, floors, onClose }) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-fade-in"
+      className="fixed inset-0 z-50 flex flex-col md:items-center md:justify-center md:p-4 animate-fade-in"
       style={{ background: 'rgba(0,0,0,0.7)', backdropFilter: 'blur(4px)' }}
       onClick={onClose}
     >
       <div
-        className="animate-fade-in-up w-full max-w-md bg-gray-900 border border-gray-800 rounded-2xl shadow-2xl shadow-black/40 flex flex-col max-h-[calc(100vh-2rem)]"
+        className="animate-fade-in-up w-full flex-1 md:flex-none md:max-w-md bg-gray-900 md:border md:border-gray-800 md:rounded-2xl shadow-2xl shadow-black/40 flex flex-col md:max-h-[calc(100vh-2rem)]"
         style={{ background: 'linear-gradient(180deg, var(--tw-gray-900) 0%, #0f1925 100%)' }}
         onClick={e => e.stopPropagation()}
       >

--- a/src/components/PlantSidebar.jsx
+++ b/src/components/PlantSidebar.jsx
@@ -376,7 +376,7 @@ export default function PlantSidebar({ plants, floors, activeFloorId, onPlantCli
   }, [duePlantIds, onBatchWater, toast, exitSelectMode])
 
   return (
-    <div id="plant-sidebar" className="flex flex-col bg-gray-900 border-l border-gray-800 w-full h-full" style={{ background: 'linear-gradient(180deg, var(--tw-gray-900) 0%, var(--tw-gray-950) 100%)' }}>
+    <div id="plant-sidebar" className="flex flex-col bg-gray-900 border-l border-gray-800 w-full h-full min-h-0" style={{ background: 'linear-gradient(180deg, var(--tw-gray-900) 0%, var(--tw-gray-950) 100%)' }}>
       {/* Weather */}
       <WeatherSection
         weather={weather}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -291,11 +291,11 @@ export default function SettingsModal({ floors: initialFloors, onSaveFloors, onC
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-fade-in"
+      className="fixed inset-0 z-50 flex flex-col md:items-center md:justify-center md:p-4 animate-fade-in"
       style={{ background: 'rgba(0,0,0,0.7)', backdropFilter: 'blur(4px)' }}
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="animate-fade-in-up w-full max-w-lg bg-gray-900 border border-gray-800 rounded-2xl shadow-2xl shadow-black/40 flex flex-col max-h-[calc(100vh-2rem)]" style={{ background: 'linear-gradient(180deg, var(--tw-gray-900) 0%, #0f1925 100%)' }}>
+      <div className="animate-fade-in-up w-full flex-1 md:flex-none md:max-w-lg bg-gray-900 md:border md:border-gray-800 md:rounded-2xl shadow-2xl shadow-black/40 flex flex-col md:max-h-[calc(100vh-2rem)]" style={{ background: 'linear-gradient(180deg, var(--tw-gray-900) 0%, #0f1925 100%)' }}>
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-gray-800 flex-shrink-0">
           <div className="flex items-center gap-2">

--- a/src/index.css
+++ b/src/index.css
@@ -22,14 +22,19 @@
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
     margin: 0;
     padding: 0;
-    height: 100vh;
+    height: 100dvh; /* dynamic viewport height — accounts for mobile browser chrome */
+    height: 100vh; /* fallback for older browsers */
     overflow: hidden;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    /* iOS safe areas */
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
   }
 
   #root {
-    height: 100vh;
+    height: 100dvh;
+    height: 100vh; /* fallback */
     display: flex;
     flex-direction: column;
   }


### PR DESCRIPTION
## Summary
- Make SettingsModal and CareCalendar full-screen on mobile (matching PlantModal pattern)
- Fix sidebar/plant list not scrolling on mobile by adding `min-h-0` and `overflow-hidden` to flex containers
- Use `100dvh` (dynamic viewport height) to account for mobile browser chrome
- Add `viewport-fit=cover` and safe area inset padding for iOS notched devices

## Test plan
- [x] All 343 frontend tests pass
- [x] Build succeeds
- [ ] Settings modal is viewable and scrollable on mobile
- [ ] Plant list scrolls properly on mobile
- [ ] Modals dismiss correctly on mobile

https://claude.ai/code/session_017cmGbJDS9W7Ee26ZtW5HZT