### PR TITLE
Add sun exposure and daily sun hours tracking to plants

### DIFF
--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -423,6 +423,17 @@ describe('POST /plants', () => {
     expect(res.body.imageBase64).toBeUndefined();
     expect(store[plantPath(res.body.id)].imageBase64).toBeUndefined();
   });
+
+  it('stores sunExposure and sunHoursPerDay fields', async () => {
+    const res = await request(app)
+      .post('/plants').set('Authorization', authHeader())
+      .send({ name: 'Cactus', floor: 'ground', x: 50, y: 50, sunExposure: 'full-sun', sunHoursPerDay: 8 });
+    expect(res.status).toBe(201);
+    expect(res.body.sunExposure).toBe('full-sun');
+    expect(res.body.sunHoursPerDay).toBe(8);
+    expect(store[plantPath(res.body.id)].sunExposure).toBe('full-sun');
+    expect(store[plantPath(res.body.id)].sunHoursPerDay).toBe(8);
+  });
 });
 
 // ── GET /plants/:id ───────────────────────────────────────────────────────────
@@ -478,6 +489,16 @@ describe('PUT /plants/:id', () => {
       .put('/plants/p1').set('Authorization', authHeader())
       .send({ name: 'Fern', imageBase64: 'huge-data' });
     expect(store[plantPath('p1')].imageBase64).toBeUndefined();
+  });
+
+  it('updates sunExposure and sunHoursPerDay via PUT', async () => {
+    store[plantPath('p1')] = { name: 'Cactus', createdAt: '2026-01-01T00:00:00.000Z' };
+    const res = await request(app)
+      .put('/plants/p1').set('Authorization', authHeader())
+      .send({ sunExposure: 'shade', sunHoursPerDay: 2 });
+    expect(res.status).toBe(200);
+    expect(res.body.sunExposure).toBe('shade');
+    expect(res.body.sunHoursPerDay).toBe(2);
   });
 
   it('uses merge semantics — preserves untouched fields', async () => {

--- a/api/plants/package-lock.json
+++ b/api/plants/package-lock.json
@@ -23,7 +23,7 @@
         "vitest": "^4.1.2"
       },
       "engines": {
-        "node": "20"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -449,9 +449,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -469,9 +466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -489,9 +483,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -509,9 +500,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -529,9 +517,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -549,9 +534,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2499,9 +2481,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2523,9 +2502,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2547,9 +2523,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2571,9 +2544,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -327,6 +327,43 @@
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
@@ -3922,7 +3959,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
       "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@csstools/css-color-parser": {
       "version": "4.0.2",
@@ -3938,13 +3976,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@csstools/css-syntax-patches-for-csstree": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
       "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@csstools/css-tokenizer": {
       "version": "4.0.0",
@@ -3957,11 +3997,46 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="
     },
+    "@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "@exodus/bytes": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -4036,7 +4111,8 @@
     "@react-oauth/google": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.2.tgz",
-      "integrity": "sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg=="
+      "integrity": "sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg==",
+      "requires": {}
     },
     "@react-spring/animated": {
       "version": "9.7.5",
@@ -4145,7 +4221,8 @@
         "zustand": {
           "version": "3.7.2",
           "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
-          "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA=="
+          "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+          "requires": {}
         }
       }
     },
@@ -4184,7 +4261,8 @@
         "uncontrollable": {
           "version": "8.0.4",
           "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
-          "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ=="
+          "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+          "requires": {}
         }
       }
     },
@@ -4367,7 +4445,8 @@
       "version": "14.6.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
       "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@tweenjs/tween.js": {
       "version": "23.1.3",
@@ -4440,7 +4519,8 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@types/react-reconciler": {
       "version": "0.26.7",
@@ -4453,7 +4533,8 @@
     "@types/react-transition-group": {
       "version": "4.4.12",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w=="
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "requires": {}
     },
     "@types/stats.js": {
       "version": "0.17.4",
@@ -4686,7 +4767,8 @@
     "bootstrap": {
       "version": "5.3.8",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
-      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg=="
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+      "requires": {}
     },
     "braces": {
       "version": "3.0.3",
@@ -4708,7 +4790,8 @@
     "camera-controls": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
-      "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w=="
+      "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==",
+      "requires": {}
     },
     "chai": {
       "version": "6.2.2",
@@ -5048,7 +5131,8 @@
         "@types/react-reconciler": {
           "version": "0.28.9",
           "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
-          "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg=="
+          "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+          "requires": {}
         }
       }
     },
@@ -5223,7 +5307,8 @@
     "lucide-react": {
       "version": "0.344.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.344.0.tgz",
-      "integrity": "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ=="
+      "integrity": "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ==",
+      "requires": {}
     },
     "lz-string": {
       "version": "1.5.0",
@@ -5234,7 +5319,8 @@
     "maath": {
       "version": "0.10.8",
       "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
-      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g=="
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "requires": {}
     },
     "magic-string": {
       "version": "0.30.21",
@@ -5282,7 +5368,8 @@
     "meshline": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
-      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ=="
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "requires": {}
     },
     "meshoptimizer": {
       "version": "1.0.1",
@@ -5549,7 +5636,8 @@
     "react-use-measure": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
-      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg=="
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "requires": {}
     },
     "readdirp": {
       "version": "3.6.0",
@@ -5738,7 +5826,8 @@
     "suspend-react": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
-      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ=="
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "requires": {}
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -5754,7 +5843,8 @@
     "three-mesh-bvh": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.7.8.tgz",
-      "integrity": "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw=="
+      "integrity": "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==",
+      "requires": {}
     },
     "three-stdlib": {
       "version": "2.36.1",
@@ -5802,7 +5892,8 @@
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "picomatch": {
           "version": "4.0.4",
@@ -5879,7 +5970,8 @@
     "troika-three-utils": {
       "version": "0.52.4",
       "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
-      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A=="
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "requires": {}
     },
     "troika-worker-utils": {
       "version": "0.52.0",
@@ -5929,7 +6021,8 @@
     "use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "requires": {}
     },
     "utility-types": {
       "version": "3.11.0",
@@ -6077,7 +6170,8 @@
     "zustand": {
       "version": "5.0.12",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
-      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "requires": {}
     }
   }
 }

--- a/src/__tests__/PlantModal.test.jsx
+++ b/src/__tests__/PlantModal.test.jsx
@@ -426,6 +426,51 @@ describe('PlantModal', () => {
     await waitFor(() => expect(onSave).toHaveBeenCalled())
   })
 
+  // ── Sun exposure fields ────────────────────────────────────────────────────
+
+  it('shows Sun Exposure dropdown in the edit form', () => {
+    renderModal()
+    selectMode('manual')
+    expect(screen.getByText('Sun Exposure')).toBeInTheDocument()
+  })
+
+  it('renders sun exposure options: Full Sun, Part Sun, Shade', () => {
+    renderModal()
+    selectMode('manual')
+    expect(screen.getByRole('option', { name: 'Full Sun' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Part Sun' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Shade' })).toBeInTheDocument()
+  })
+
+  it('shows Sun Hours / Day slider in the edit form', () => {
+    renderModal()
+    selectMode('manual')
+    expect(screen.getByText(/sun hours \/ day/i)).toBeInTheDocument()
+  })
+
+  it('pre-fills sun exposure when editing a plant with sunExposure set', () => {
+    const plant = { ...existingPlant, sunExposure: 'part-sun' }
+    renderModal({ plant })
+    const sunSelect = screen.getByRole('option', { name: 'Part Sun' }).closest('select')
+    expect(sunSelect).toHaveValue('part-sun')
+  })
+
+  it('includes sunExposure and sunHoursPerDay in saved data', async () => {
+    const onSave = vi.fn()
+    renderModal({ onSave })
+    selectMode('manual')
+    fireEvent.change(screen.getByPlaceholderText(/living room fern/i), {
+      target: { value: 'Cactus' },
+    })
+    const sunSelect = screen.getByRole('option', { name: 'Full Sun' }).closest('select')
+    fireEvent.change(sunSelect, { target: { value: 'full-sun' } })
+    fireEvent.click(screen.getByRole('button', { name: /add plant/i }))
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce())
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ sunExposure: 'full-sun' })
+    )
+  })
+
   it('shows a watering status badge in the header when viewing an existing plant', () => {
     renderModal({ plant: existingPlant })
     // Check that a Badge element exists in the modal title area

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -25,6 +25,11 @@ const WATER_METHODS = [
   { value: 'irrigation', label: 'Irrigation System' },
   { value: 'drip', label: 'Drip System' },
 ]
+const SUN_EXPOSURE_OPTIONS = [
+  { value: 'full-sun', label: 'Full Sun' },
+  { value: 'part-sun', label: 'Part Sun' },
+  { value: 'shade', label: 'Shade' },
+]
 const DAYS_OF_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 function today() { return new Date().toISOString().split('T')[0] }
@@ -41,6 +46,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
     maturity: null, potSize: null, recommendations: [],
     waterAmount: null, waterMethod: null,
     irrigationDuration: null, irrigationSchedule: null,
+    sunExposure: null, sunHoursPerDay: null,
   })
   const [isSaving, setIsSaving] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
@@ -63,6 +69,8 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
         waterAmount: plant.waterAmount || null, waterMethod: plant.waterMethod || null,
         irrigationDuration: plant.irrigationDuration || null,
         irrigationSchedule: plant.irrigationSchedule || null,
+        sunExposure: plant.sunExposure || null,
+        sunHoursPerDay: plant.sunHoursPerDay ?? null,
       })
     }
   }, [plant, activeFloorId])
@@ -109,6 +117,8 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       waterAmount: form.waterAmount, waterMethod: form.waterMethod,
       irrigationDuration: form.irrigationDuration ? Number(form.irrigationDuration) : null,
       irrigationSchedule: form.irrigationSchedule,
+      sunExposure: form.sunExposure,
+      sunHoursPerDay: form.sunHoursPerDay ? Number(form.sunHoursPerDay) : null,
     })
     setIsSaving(false)
   }, [form, onSave])
@@ -259,6 +269,24 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
                   <option value="">— Select —</option>
                   {MATURITY_OPTIONS.map((m) => <option key={m} value={m}>{m}</option>)}
                 </Form.Select>
+              </Form.Group>
+            </Col>
+          </Row>
+          <Row className="mb-3">
+            <Col md={6}>
+              <Form.Group>
+                <Form.Label>Sun Exposure</Form.Label>
+                <Form.Select value={form.sunExposure || ''} onChange={(e) => update('sunExposure', e.target.value || null)}>
+                  <option value="">— Select —</option>
+                  {SUN_EXPOSURE_OPTIONS.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+                </Form.Select>
+              </Form.Group>
+            </Col>
+            <Col md={6}>
+              <Form.Group>
+                <Form.Label>Sun Hours / Day{form.sunHoursPerDay ? `: ${form.sunHoursPerDay}h` : ''}</Form.Label>
+                <Form.Range min={0} max={16} value={form.sunHoursPerDay || 0} onChange={(e) => update('sunHoursPerDay', Number(e.target.value) || null)} className="mt-2" />
+                <div className="d-flex justify-content-between fs-xs text-muted"><span>0h</span><span>16h</span></div>
               </Form.Group>
             </Col>
           </Row>


### PR DESCRIPTION
Add sunExposure (full-sun, part-sun, shade) dropdown and sunHoursPerDay
(0-16h) slider to the plant edit form. Fields are persisted to Firestore
via the existing spread-based backend and included in frontend/backend tests.

https://claude.ai/code/session_01MRNXaagUgwDveQobSZ23jc