### PR TITLE
feat: add Vertex AI client module and /ml/status endpoint (#95)

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -755,9 +755,10 @@ app.post('/plants/:id/water', requireUser, async (req, res) => {
     const { amount, method } = req.body || {};
     const wateringLog = [...(existing.wateringLog || []), { date: now, note: '', amount: amount || null, method: method || null }];
 
-    // Invalidate ML cache on new watering event
+    // Invalidate ML caches on new watering event
     const mlCache = { ...(existing.mlCache || {}) };
     delete mlCache.wateringPattern;
+    delete mlCache.wateringRecommendation;
     await ref.set({ lastWatered: now, wateringLog, updatedAt: now, mlCache }, { merge: true });
 
     const updated = await ref.get();
@@ -880,6 +881,107 @@ app.get('/plants/:id/watering-pattern', requireUser, async (req, res) => {
     // Cache the result
     await ref.set({
       mlCache: { ...mlCache, wateringPattern: { result, cachedAt: new Date().toISOString() } }
+    }, { merge: true });
+
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ── Smart watering recommendations ──────────────────────────────────────────
+
+const RECOMMENDATION_CACHE_TTL_MS = 48 * 60 * 60 * 1000; // 48 hours
+
+app.get('/plants/:id/watering-recommendation', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const plant = doc.data();
+    const mlCache = plant.mlCache || {};
+
+    // Return cached result if fresh (48h TTL)
+    if (mlCache.wateringRecommendation) {
+      const age = Date.now() - new Date(mlCache.wateringRecommendation.cachedAt).getTime();
+      if (age < RECOMMENDATION_CACHE_TTL_MS) {
+        return res.status(200).json(mlCache.wateringRecommendation.result);
+      }
+    }
+
+    const endpointId = process.env.WATERING_RECOMMENDATION_ENDPOINT;
+    let result;
+
+    if (endpointId && (plant.wateringLog || []).length >= 5) {
+      try {
+        const featureRows = buildFeatureRows(plant);
+        if (featureRows.length > 0) {
+          const latest = featureRows[featureRows.length - 1];
+          const predictions = await vertexai.predict(endpointId, [{
+            ...latest,
+            current_health: plant.health || '',
+            pot_size: plant.potSize || '',
+          }]);
+
+          if (predictions.length > 0 && predictions[0].recommendedFrequencyDays) {
+            const pred = predictions[0];
+            const lastWatered = plant.lastWatered || plant.wateringLog?.slice(-1)[0]?.date;
+            const nextDate = lastWatered
+              ? new Date(new Date(lastWatered).getTime() + pred.recommendedFrequencyDays * 86400000).toISOString().slice(0, 10)
+              : null;
+
+            result = {
+              recommendedFrequencyDays: pred.recommendedFrequencyDays,
+              confidenceInterval: pred.confidenceInterval || [pred.recommendedFrequencyDays - 1, pred.recommendedFrequencyDays + 1],
+              basis: pred.basis || `Based on care history for ${plant.species || plant.name}`,
+              nextWateringDate: nextDate,
+              source: 'vertex_ai',
+            };
+          }
+        }
+      } catch (err) {
+        log.warn('Vertex AI watering recommendation failed, using heuristic', { error: err.message });
+      }
+    }
+
+    // Heuristic fallback: use current frequencyDays with minor adjustments based on health
+    if (!result) {
+      const freq = plant.frequencyDays || 7;
+      const healthLog = plant.healthLog || [];
+      const lastHealth = healthLog.length > 0 ? healthLog[healthLog.length - 1].health : plant.health;
+
+      let recommended = freq;
+      let note = `Based on your current ${freq}-day schedule`;
+      if (lastHealth === 'Poor' || lastHealth === 'Fair') {
+        // Check if over- or under-watering via pattern analysis
+        const pattern = analyseWateringPattern(plant);
+        if (pattern.pattern === 'over_watered') {
+          recommended = Math.min(30, Math.round(freq * 1.3));
+          note = `${plant.species || plant.name} may be over-watered — try extending to every ${recommended} days`;
+        } else if (pattern.pattern === 'under_watered') {
+          recommended = Math.max(1, Math.round(freq * 0.7));
+          note = `${plant.species || plant.name} may need more water — try every ${recommended} days`;
+        }
+      }
+
+      const lastWatered = plant.lastWatered || plant.wateringLog?.slice(-1)[0]?.date;
+      const nextDate = lastWatered
+        ? new Date(new Date(lastWatered).getTime() + recommended * 86400000).toISOString().slice(0, 10)
+        : null;
+
+      result = {
+        recommendedFrequencyDays: recommended,
+        confidenceInterval: [Math.max(1, recommended - 1), recommended + 1],
+        basis: note,
+        nextWateringDate: nextDate,
+        source: 'heuristic',
+      };
+    }
+
+    // Cache the result
+    await ref.set({
+      mlCache: { ...mlCache, wateringRecommendation: { result, cachedAt: new Date().toISOString() } }
     }, { merge: true });
 
     res.status(200).json(result);

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -727,6 +727,12 @@ app.put('/plants/:id', requireUser, async (req, res) => {
         reason: body.healthReason || '',
       }];
       updates.healthLog = healthLog;
+
+      // Invalidate health-related ML caches
+      const mlCache = { ...(existing.mlCache || {}) };
+      delete mlCache.healthPrediction;
+      delete mlCache.wateringPattern;
+      updates.mlCache = mlCache;
     }
 
     // Delete old GCS image when replaced with a new one
@@ -759,6 +765,7 @@ app.post('/plants/:id/water', requireUser, async (req, res) => {
     const mlCache = { ...(existing.mlCache || {}) };
     delete mlCache.wateringPattern;
     delete mlCache.wateringRecommendation;
+    delete mlCache.healthPrediction;
     await ref.set({ lastWatered: now, wateringLog, updatedAt: now, mlCache }, { merge: true });
 
     const updated = await ref.get();
@@ -982,6 +989,126 @@ app.get('/plants/:id/watering-recommendation', requireUser, async (req, res) => 
     // Cache the result
     await ref.set({
       mlCache: { ...mlCache, wateringRecommendation: { result, cachedAt: new Date().toISOString() } }
+    }, { merge: true });
+
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ── Plant health prediction ──────────────────────────────────────────────────
+
+const HEALTH_RANK = { Excellent: 4, Good: 3, Fair: 2, Poor: 1 };
+const HEALTH_FROM_RANK = { 4: 'Excellent', 3: 'Good', 2: 'Fair', 1: 'Poor' };
+
+function predictHealthHeuristic(plant) {
+  const healthLog = (plant.healthLog || []).sort((a, b) => new Date(a.date) - new Date(b.date));
+  const currentHealth = healthLog.length > 0 ? healthLog[healthLog.length - 1].health : plant.health || 'Good';
+  const currentRank = HEALTH_RANK[currentHealth] || 3;
+
+  const keyRisks = [];
+  let trendSlope = 0;
+
+  if (healthLog.length >= 2) {
+    const recent = healthLog.slice(-5);
+    const ranks = recent.map(h => HEALTH_RANK[h.health] || 3);
+    trendSlope = (ranks[ranks.length - 1] - ranks[0]) / recent.length;
+  }
+
+  // Check watering adherence
+  const pattern = analyseWateringPattern(plant);
+  if (pattern.pattern === 'over_watered') {
+    keyRisks.push('Over-watering may lead to root rot');
+    trendSlope -= 0.2;
+  } else if (pattern.pattern === 'under_watered') {
+    keyRisks.push('Under-watering is stressing the plant');
+    trendSlope -= 0.2;
+  } else if (pattern.pattern === 'inconsistent') {
+    keyRisks.push('Inconsistent watering schedule causes stress');
+    trendSlope -= 0.1;
+  }
+
+  // Check days since last watered
+  const lastWatered = plant.lastWatered || (plant.wateringLog || []).slice(-1)[0]?.date;
+  if (lastWatered) {
+    const daysSince = (Date.now() - new Date(lastWatered).getTime()) / 86400000;
+    const freq = plant.frequencyDays || 7;
+    if (daysSince > freq * 2) {
+      keyRisks.push(`Not watered in ${Math.round(daysSince)} days (recommended: every ${freq} days)`);
+      trendSlope -= 0.3;
+    }
+  }
+
+  if (keyRisks.length === 0) keyRisks.push('No significant risk factors detected');
+
+  // Project health 14 days out
+  const projectedRank = Math.max(1, Math.min(4, Math.round(currentRank + trendSlope * 2)));
+  const predictedHealth = HEALTH_FROM_RANK[projectedRank];
+  const trend = trendSlope > 0.1 ? 'improving' : trendSlope < -0.1 ? 'declining' : 'stable';
+
+  return {
+    predictedHealth,
+    probability: trendSlope === 0 ? 0.7 : Math.min(0.85, 0.5 + Math.abs(trendSlope) * 0.5),
+    horizon: '14d',
+    trend,
+    keyRisks,
+    source: 'heuristic',
+  };
+}
+
+app.get('/plants/:id/health-prediction', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const plant = doc.data();
+    const mlCache = plant.mlCache || {};
+
+    // Return cached result if fresh
+    if (isCacheValid(mlCache, 'healthPrediction')) {
+      return res.status(200).json(mlCache.healthPrediction.result);
+    }
+
+    const endpointId = process.env.HEALTH_PREDICTION_ENDPOINT;
+    let result;
+
+    if (endpointId && (plant.wateringLog || []).length >= 3) {
+      try {
+        const featureRows = buildFeatureRows(plant);
+        if (featureRows.length > 0) {
+          const latest = featureRows[featureRows.length - 1];
+          const predictions = await vertexai.predict(endpointId, [{
+            ...latest,
+            current_health: plant.health || '',
+            health_trend_30d: (plant.healthLog || []).length >= 2 ? 'available' : 'insufficient',
+          }]);
+
+          if (predictions.length > 0 && predictions[0].predictedHealth) {
+            const pred = predictions[0];
+            result = {
+              predictedHealth: pred.predictedHealth,
+              probability: pred.probability || 0.75,
+              horizon: '14d',
+              trend: pred.trend || 'stable',
+              keyRisks: pred.keyRisks || [],
+              source: 'vertex_ai',
+            };
+          }
+        }
+      } catch (err) {
+        log.warn('Vertex AI health prediction failed, falling back to heuristic', { error: err.message });
+      }
+    }
+
+    if (!result) {
+      result = predictHealthHeuristic(plant);
+    }
+
+    // Cache for 24 hours
+    await ref.set({
+      mlCache: { ...mlCache, healthPrediction: { result, cachedAt: new Date().toISOString() } }
     }, { merge: true });
 
     res.status(200).json(result);

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1117,6 +1117,114 @@ app.get('/plants/:id/health-prediction', requireUser, async (req, res) => {
   }
 });
 
+// ── Seasonal pattern recognition ─────────────────────────────────────────────
+
+function getSeasonForHemisphere(date, hemisphere) {
+  const month = new Date(date).getMonth(); // 0-indexed
+  const isNorth = hemisphere !== 'south';
+
+  if (isNorth) {
+    if (month >= 2 && month <= 4) return 'spring';
+    if (month >= 5 && month <= 7) return 'summer';
+    if (month >= 8 && month <= 10) return 'autumn';
+    return 'winter';
+  }
+  // Southern hemisphere: seasons are reversed
+  if (month >= 2 && month <= 4) return 'autumn';
+  if (month >= 5 && month <= 7) return 'winter';
+  if (month >= 8 && month <= 10) return 'spring';
+  return 'summer';
+}
+
+// Default seasonal multipliers per season (species-independent baseline)
+const SEASONAL_MULTIPLIERS = {
+  spring: 1.0,
+  summer: 1.3,
+  autumn: 0.85,
+  winter: 0.7,
+};
+
+function computeSeasonalAdjustment(plant, hemisphere) {
+  const now = new Date();
+  const season = getSeasonForHemisphere(now, hemisphere);
+  const multiplier = SEASONAL_MULTIPLIERS[season];
+  const freq = plant.frequencyDays || 7;
+  const adjustedFreq = Math.max(1, Math.round(freq * (1 / multiplier)));
+  // multiplier > 1 means plant needs MORE water → shorter interval
+  // multiplier < 1 means plant needs LESS water → longer interval
+
+  const species = plant.species || plant.name;
+  const notes = {
+    spring: `${species} is entering active growth — maintain regular watering`,
+    summer: `${species} typically needs ~30% more water in summer due to heat and growth`,
+    autumn: `${species} is slowing down — reduce watering by ~15%`,
+    winter: `${species} typically needs ~30% less water in winter dormancy`,
+  };
+
+  return {
+    season,
+    multiplier,
+    adjustedFrequencyDays: adjustedFreq,
+    note: notes[season],
+    source: 'heuristic',
+  };
+}
+
+app.get('/plants/:id/seasonal-adjustment', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const plant = doc.data();
+
+    // Get hemisphere from user config or default to north
+    let hemisphere = 'north';
+    try {
+      const configDoc = await userConfig(req.userId).doc('preferences').get();
+      if (configDoc.exists && configDoc.data().hemisphere) {
+        hemisphere = configDoc.data().hemisphere;
+      }
+    } catch { /* default to north */ }
+
+    const endpointId = process.env.SEASONAL_ADJUSTMENT_ENDPOINT;
+    let result;
+
+    if (endpointId && (plant.wateringLog || []).length >= 5) {
+      try {
+        const season = getSeasonForHemisphere(new Date(), hemisphere);
+        const predictions = await vertexai.predict(endpointId, [{
+          species: plant.species || plant.name || '',
+          season,
+          hemisphere,
+        }]);
+
+        if (predictions.length > 0 && predictions[0].multiplier) {
+          const pred = predictions[0];
+          const freq = plant.frequencyDays || 7;
+          result = {
+            season,
+            multiplier: pred.multiplier,
+            adjustedFrequencyDays: Math.max(1, Math.round(freq * (1 / pred.multiplier))),
+            note: pred.note || `Seasonal adjustment for ${plant.species || plant.name}`,
+            source: 'vertex_ai',
+          };
+        }
+      } catch (err) {
+        log.warn('Vertex AI seasonal adjustment failed, using heuristic', { error: err.message });
+      }
+    }
+
+    if (!result) {
+      result = computeSeasonalAdjustment(plant, hemisphere);
+    }
+
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Anomaly detection ────────────────────────────────────────────────────────
 
 function computeAnomalyFeatures(plant) {

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -755,7 +755,10 @@ app.post('/plants/:id/water', requireUser, async (req, res) => {
     const { amount, method } = req.body || {};
     const wateringLog = [...(existing.wateringLog || []), { date: now, note: '', amount: amount || null, method: method || null }];
 
-    await ref.set({ lastWatered: now, wateringLog, updatedAt: now }, { merge: true });
+    // Invalidate ML cache on new watering event
+    const mlCache = { ...(existing.mlCache || {}) };
+    delete mlCache.wateringPattern;
+    await ref.set({ lastWatered: now, wateringLog, updatedAt: now, mlCache }, { merge: true });
 
     const updated = await ref.get();
     const data = { id: updated.id, ...updated.data() };
@@ -825,11 +828,61 @@ function analyseWateringPattern(plant) {
   return { pattern, confidence: +confidence.toFixed(2), contributingFactors: factors };
 }
 
+const ML_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function isCacheValid(cache, key) {
+  if (!cache || !cache[key]) return false;
+  const age = Date.now() - new Date(cache[key].cachedAt).getTime();
+  return age < ML_CACHE_TTL_MS;
+}
+
 app.get('/plants/:id/watering-pattern', requireUser, async (req, res) => {
   try {
-    const doc = await userPlants(req.userId).doc(req.params.id).get();
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
     if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
-    res.status(200).json(analyseWateringPattern(doc.data()));
+
+    const plant = doc.data();
+    const mlCache = plant.mlCache || {};
+
+    // Return cached result if fresh
+    if (isCacheValid(mlCache, 'wateringPattern')) {
+      return res.status(200).json(mlCache.wateringPattern.result);
+    }
+
+    // Try Vertex AI prediction if endpoint is configured
+    const endpointId = process.env.WATERING_PATTERN_ENDPOINT;
+    let result;
+    if (endpointId && (plant.wateringLog || []).length >= 3) {
+      try {
+        const featureRows = buildFeatureRows(plant);
+        if (featureRows.length > 0) {
+          const predictions = await vertexai.predict(endpointId, [featureRows[featureRows.length - 1]]);
+          if (predictions.length > 0 && predictions[0].pattern) {
+            result = {
+              pattern: predictions[0].pattern,
+              confidence: predictions[0].confidence || 0.8,
+              contributingFactors: predictions[0].contributingFactors || [],
+              source: 'vertex_ai',
+            };
+          }
+        }
+      } catch (err) {
+        log.warn('Vertex AI watering pattern prediction failed, falling back to heuristic', { error: err.message });
+      }
+    }
+
+    // Fall back to heuristic
+    if (!result) {
+      result = { ...analyseWateringPattern(plant), source: 'heuristic' };
+    }
+
+    // Cache the result
+    await ref.set({
+      mlCache: { ...mlCache, wateringPattern: { result, cachedAt: new Date().toISOString() } }
+    }, { merge: true });
+
+    res.status(200).json(result);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -5,6 +5,7 @@ const { Firestore } = require('@google-cloud/firestore');
 const { Storage } = require('@google-cloud/storage');
 const { GoogleGenerativeAI, SchemaType } = require('@google/generative-ai');
 const { jsonrepair } = require('jsonrepair');
+const vertexai = require('./vertexai');
 const express = require('express');
 const cors = require('cors');
 const rateLimit = require('express-rate-limit');
@@ -321,6 +322,18 @@ Rules:
 
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok' });
+});
+
+// ── ML status ────────────────────────────────────────────────────────────────
+
+app.get('/ml/status', async (req, res) => {
+  try {
+    const status = await vertexai.checkStatus();
+    const httpCode = status.status === 'ok' ? 200 : status.status === 'unconfigured' ? 503 : 502;
+    res.status(httpCode).json(status);
+  } catch (err) {
+    res.status(500).json({ status: 'error', error: err.message });
+  }
 });
 
 // ── ML feature engineering ────────────────────────────────────────────────────

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1225,6 +1225,98 @@ app.get('/plants/:id/seasonal-adjustment', requireUser, async (req, res) => {
   }
 });
 
+// ── Species clustering ───────────────────────────────────────────────────────
+
+// Default cluster assignments based on common plant care patterns
+const DEFAULT_CLUSTERS = {
+  'thirsty_tropicals': {
+    id: 'thirsty_tropicals', label: 'Thirsty Tropicals',
+    species: ['fern', 'calathea', 'peace lily', 'spathiphyllum', 'nephrolepis', 'maidenhair', 'boston fern', 'bird of paradise', 'alocasia'],
+    careProfile: { avgFrequency: 5, droughtTolerance: 'low', humidityNeed: 'high' },
+  },
+  'forgiving_foliage': {
+    id: 'forgiving_foliage', label: 'Forgiving Foliage',
+    species: ['pothos', 'philodendron', 'monstera', 'zz plant', 'zamioculcas', 'rubber plant', 'ficus', 'spider plant', 'dracaena', 'dieffenbachia'],
+    careProfile: { avgFrequency: 8, droughtTolerance: 'medium', humidityNeed: 'medium' },
+  },
+  'drought_tolerant': {
+    id: 'drought_tolerant', label: 'Drought Tolerant',
+    species: ['cactus', 'succulent', 'snake plant', 'sansevieria', 'aloe', 'jade', 'crassula', 'echeveria', 'haworthia', 'agave'],
+    careProfile: { avgFrequency: 14, droughtTolerance: 'high', humidityNeed: 'low' },
+  },
+  'seasonal_bloomers': {
+    id: 'seasonal_bloomers', label: 'Seasonal Bloomers',
+    species: ['orchid', 'phalaenopsis', 'christmas cactus', 'cyclamen', 'african violet', 'begonia', 'anthurium', 'bromeliad'],
+    careProfile: { avgFrequency: 7, droughtTolerance: 'medium', humidityNeed: 'high' },
+  },
+};
+
+function findClusterForSpecies(speciesName) {
+  if (!speciesName) return null;
+  const lower = speciesName.toLowerCase();
+  for (const cluster of Object.values(DEFAULT_CLUSTERS)) {
+    if (cluster.species.some(s => lower.includes(s) || s.includes(lower))) {
+      const similarSpecies = cluster.species.filter(s => s !== lower).slice(0, 5);
+      return {
+        clusterId: cluster.id,
+        clusterLabel: cluster.label,
+        similarSpecies,
+        clusterCareProfile: cluster.careProfile,
+        source: 'default',
+      };
+    }
+  }
+  return null;
+}
+
+app.get('/species/:name/cluster', requireUser, async (req, res) => {
+  try {
+    const speciesName = decodeURIComponent(req.params.name);
+
+    // Check GCS cluster assignments if available
+    const endpointId = process.env.SPECIES_CLUSTER_ENDPOINT;
+    if (endpointId) {
+      try {
+        const predictions = await vertexai.predict(endpointId, [{ species: speciesName }]);
+        if (predictions.length > 0 && predictions[0].clusterId) {
+          return res.status(200).json({ ...predictions[0], source: 'vertex_ai' });
+        }
+      } catch (err) {
+        log.warn('Vertex AI species cluster lookup failed, using defaults', { error: err.message });
+      }
+    }
+
+    // Check Firestore config/clusters for cached assignments
+    try {
+      const clusterDoc = await db.collection('config').doc('clusters').get();
+      if (clusterDoc.exists) {
+        const assignments = clusterDoc.data().assignments || {};
+        const lower = speciesName.toLowerCase();
+        if (assignments[lower]) {
+          return res.status(200).json({ ...assignments[lower], source: 'trained' });
+        }
+      }
+    } catch { /* fall through to defaults */ }
+
+    // Default cluster lookup
+    const result = findClusterForSpecies(speciesName);
+    if (result) {
+      return res.status(200).json(result);
+    }
+
+    // Unknown species — return no cluster
+    res.status(200).json({
+      clusterId: null,
+      clusterLabel: 'Unknown',
+      similarSpecies: [],
+      clusterCareProfile: null,
+      source: 'none',
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Anomaly detection ────────────────────────────────────────────────────────
 
 function computeAnomalyFeatures(plant) {

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1117,6 +1117,162 @@ app.get('/plants/:id/health-prediction', requireUser, async (req, res) => {
   }
 });
 
+// ── Anomaly detection ────────────────────────────────────────────────────────
+
+function computeAnomalyFeatures(plant) {
+  const wlog = (plant.wateringLog || []).sort((a, b) => new Date(a.date) - new Date(b.date));
+  if (wlog.length < 3) return null;
+
+  // Rolling 30-day window
+  const thirtyDaysAgo = Date.now() - 30 * 86400000;
+  const recent = wlog.filter(w => new Date(w.date).getTime() > thirtyDaysAgo);
+  const gaps = [];
+  const sorted = [...wlog].sort((a, b) => new Date(a.date) - new Date(b.date));
+  for (let i = 1; i < sorted.length; i++) {
+    gaps.push((new Date(sorted[i].date) - new Date(sorted[i - 1].date)) / 86400000);
+  }
+
+  if (gaps.length === 0) return null;
+  const mean = gaps.reduce((a, b) => a + b, 0) / gaps.length;
+  const std = Math.sqrt(gaps.reduce((a, b) => a + (b - mean) ** 2, 0) / gaps.length);
+  const maxGap = Math.max(...gaps);
+  const freq = plant.frequencyDays || 7;
+  const adherence = mean / freq;
+
+  return {
+    mean_days_between_waterings: +mean.toFixed(1),
+    std_days_between_waterings: +std.toFixed(1),
+    max_gap_days: +maxGap.toFixed(1),
+    waterings_in_last_14d: wlog.filter(w => new Date(w.date).getTime() > Date.now() - 14 * 86400000).length,
+    adherence_ratio_30d: +adherence.toFixed(3),
+  };
+}
+
+function detectAnomalyHeuristic(plant) {
+  const features = computeAnomalyFeatures(plant);
+  if (!features) return { isAnomaly: false, score: 0, flags: [], detectedAt: null };
+
+  const freq = plant.frequencyDays || 7;
+  const flags = [];
+  let score = 0;
+
+  // Check for extreme gap
+  if (features.max_gap_days > freq * 2.5) {
+    score += 0.3;
+    flags.push(`Longest gap was ${features.max_gap_days} days (recommended: every ${freq} days)`);
+  }
+
+  // Check for low recent activity
+  if (features.waterings_in_last_14d === 0 && freq <= 14) {
+    score += 0.3;
+    flags.push('No watering events in the last 14 days');
+  }
+
+  // Check for high variance
+  if (features.std_days_between_waterings > freq * 0.8) {
+    score += 0.2;
+    flags.push(`High watering variability (${features.std_days_between_waterings} day std dev)`);
+  }
+
+  // Check adherence
+  if (features.adherence_ratio_30d > 2) {
+    score += 0.2;
+    flags.push(`Watering ${features.adherence_ratio_30d.toFixed(1)}x less often than recommended`);
+  }
+
+  score = Math.min(1, score);
+  const threshold = parseFloat(process.env.ANOMALY_THRESHOLD) || 0.8;
+  const isAnomaly = score >= threshold;
+
+  return {
+    isAnomaly,
+    score: +score.toFixed(2),
+    flags: flags.slice(0, 3),
+    detectedAt: isAnomaly ? new Date().toISOString() : null,
+  };
+}
+
+// Background job: scan all plants for anomalies (Cloud Scheduler target)
+app.post('/ml/anomaly-scan', async (req, res) => {
+  const adminToken = req.headers['x-admin-token'];
+  const expectedToken = process.env.ML_ADMIN_TOKEN;
+  if (!expectedToken || adminToken !== expectedToken) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  try {
+    const endpointId = process.env.ANOMALY_DETECTION_ENDPOINT;
+    const usersSnap = await db.collection('users').get();
+    let scanned = 0;
+    let anomalies = 0;
+
+    for (const userDoc of usersSnap.docs) {
+      const plantsSnap = await db.collection('users').doc(userDoc.id).collection('plants').get();
+      for (const plantDoc of plantsSnap.docs) {
+        const plant = plantDoc.data();
+        let result;
+
+        if (endpointId) {
+          try {
+            const features = computeAnomalyFeatures(plant);
+            if (features) {
+              const predictions = await vertexai.predict(endpointId, [features]);
+              if (predictions.length > 0) {
+                const threshold = parseFloat(process.env.ANOMALY_THRESHOLD) || 0.8;
+                result = {
+                  isAnomaly: (predictions[0].score || 0) >= threshold,
+                  score: predictions[0].score || 0,
+                  flags: predictions[0].flags || [],
+                  detectedAt: new Date().toISOString(),
+                };
+              }
+            }
+          } catch (err) {
+            log.warn('Vertex AI anomaly detection failed for plant, using heuristic', { plantId: plantDoc.id, error: err.message });
+          }
+        }
+
+        if (!result) {
+          result = detectAnomalyHeuristic(plant);
+        }
+
+        // Update mlCache
+        const ref = db.collection('users').doc(userDoc.id).collection('plants').doc(plantDoc.id);
+        await ref.set({
+          mlCache: { ...(plant.mlCache || {}), anomaly: { result, cachedAt: new Date().toISOString() } }
+        }, { merge: true });
+
+        scanned++;
+        if (result.isAnomaly) anomalies++;
+      }
+    }
+
+    res.status(200).json({ scanned, anomalies });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// User-facing anomaly status
+app.get('/plants/:id/anomaly', requireUser, async (req, res) => {
+  try {
+    const doc = await userPlants(req.userId).doc(req.params.id).get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const plant = doc.data();
+    const cached = plant.mlCache?.anomaly?.result;
+    if (cached) {
+      return res.status(200).json(cached);
+    }
+
+    // Compute on-demand if no cached result
+    const result = detectAnomalyHeuristic(plant);
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 app.delete('/plants/:id', requireUser, async (req, res) => {
   try {
     const ref = userPlants(req.userId).doc(req.params.id);

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -398,7 +398,22 @@ function buildFeatureRows(plant) {
   return rows;
 }
 
-// Admin-gated ML export — produces NDJSON feature table
+const CSV_COLUMNS = [
+  'species', 'days_between_waterings', 'recommended_frequency',
+  'adherence_ratio', 'health_at_watering', 'health_7d_after',
+  'season', 'consecutive_overdue_days', 'pot_size', 'room',
+];
+
+function rowToCsv(row) {
+  return CSV_COLUMNS.map(c => {
+    const v = row[c] ?? '';
+    const s = String(v);
+    return s.includes(',') || s.includes('"') || s.includes('\n')
+      ? `"${s.replace(/"/g, '""')}"` : s;
+  }).join(',');
+}
+
+// Admin-gated ML export — produces NDJSON or CSV, optionally writes to GCS
 app.get('/ml/export', async (req, res) => {
   const adminToken = req.headers['x-admin-token'];
   const expectedToken = process.env.ML_ADMIN_TOKEN;
@@ -406,21 +421,51 @@ app.get('/ml/export', async (req, res) => {
     return res.status(403).json({ error: 'Forbidden' });
   }
 
-  try {
-    // Stream all users' plant data
-    const usersSnap = await db.collection('users').get();
-    res.setHeader('Content-Type', 'application/x-ndjson');
-    res.setHeader('Content-Disposition', `attachment; filename="features-${new Date().toISOString().slice(0, 10)}.ndjson"`);
+  const format = (req.query.format || 'ndjson').toLowerCase();
+  if (format !== 'ndjson' && format !== 'csv') {
+    return res.status(400).json({ error: 'format must be "ndjson" or "csv"' });
+  }
+  const dest = (req.query.dest || 'stream').toLowerCase();
 
+  try {
+    // Collect all feature rows
+    const allRows = [];
+    const usersSnap = await db.collection('users').get();
     for (const userDoc of usersSnap.docs) {
       const plantsSnap = await db.collection('users').doc(userDoc.id).collection('plants').get();
       for (const plantDoc of plantsSnap.docs) {
-        const rows = buildFeatureRows(plantDoc.data());
-        for (const row of rows) {
-          res.write(JSON.stringify(row) + '\n');
-        }
+        allRows.push(...buildFeatureRows(plantDoc.data()));
       }
     }
+
+    const dateStr = new Date().toISOString().slice(0, 10);
+    let body;
+    let contentType;
+    let ext;
+
+    if (format === 'csv') {
+      const header = CSV_COLUMNS.join(',');
+      body = header + '\n' + allRows.map(rowToCsv).join('\n') + (allRows.length ? '\n' : '');
+      contentType = 'text/csv';
+      ext = 'csv';
+    } else {
+      body = allRows.map(r => JSON.stringify(r)).join('\n') + (allRows.length ? '\n' : '');
+      contentType = 'application/x-ndjson';
+      ext = 'ndjson';
+    }
+
+    // Write to GCS if requested
+    if (dest === 'gcs') {
+      const bucket = process.env.ML_DATA_BUCKET || 'plant-tracker-ml-data';
+      const filePath = `exports/${dateStr}.${ext}`;
+      await storage.bucket(bucket).file(filePath).save(body, { contentType });
+      return res.status(200).json({ written: `gs://${bucket}/${filePath}`, rows: allRows.length, format });
+    }
+
+    // Stream to response
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Content-Disposition', `attachment; filename="features-${dateStr}.${ext}"`);
+    res.write(body);
     res.end();
   } catch (err) {
     if (!res.headersSent) res.status(500).json({ error: err.message });

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1225,6 +1225,155 @@ app.get('/plants/:id/seasonal-adjustment', requireUser, async (req, res) => {
   }
 });
 
+// ── Care optimisation score ──────────────────────────────────────────────────
+
+function computeCareScore(plant) {
+  const wlog = (plant.wateringLog || []).sort((a, b) => new Date(a.date) - new Date(b.date));
+  const healthLog = (plant.healthLog || []).sort((a, b) => new Date(a.date) - new Date(b.date));
+  const freq = plant.frequencyDays || 7;
+
+  // Consistency (30%): low variance in watering intervals
+  let consistency = 50;
+  if (wlog.length >= 3) {
+    const gaps = [];
+    for (let i = 1; i < wlog.length; i++) {
+      gaps.push((new Date(wlog[i].date) - new Date(wlog[i - 1].date)) / 86400000);
+    }
+    const mean = gaps.reduce((a, b) => a + b, 0) / gaps.length;
+    const std = Math.sqrt(gaps.reduce((a, b) => a + (b - mean) ** 2, 0) / gaps.length);
+    const cv = mean > 0 ? std / mean : 0;
+    consistency = Math.max(0, Math.min(100, Math.round(100 * (1 - cv))));
+  }
+
+  // Timing (30%): adherence to recommended frequency
+  let timing = 50;
+  if (wlog.length >= 2) {
+    const gaps = [];
+    for (let i = 1; i < wlog.length; i++) {
+      gaps.push((new Date(wlog[i].date) - new Date(wlog[i - 1].date)) / 86400000);
+    }
+    const mean = gaps.reduce((a, b) => a + b, 0) / gaps.length;
+    const deviation = Math.abs(mean - freq) / freq;
+    timing = Math.max(0, Math.min(100, Math.round(100 * (1 - deviation))));
+  }
+
+  // Health outcome (25%): recent health trend
+  let healthOutcome = 50;
+  if (healthLog.length >= 1) {
+    const recent = healthLog.slice(-3);
+    const avg = recent.reduce((sum, h) => sum + (HEALTH_RANK[h.health] || 3), 0) / recent.length;
+    healthOutcome = Math.round((avg / 4) * 100);
+  }
+
+  // Responsiveness (15%): how quickly issues are addressed
+  let responsiveness = 70; // default: assume OK
+  if (healthLog.length >= 2) {
+    const declines = [];
+    for (let i = 1; i < healthLog.length; i++) {
+      const prev = HEALTH_RANK[healthLog[i - 1].health] || 3;
+      const curr = HEALTH_RANK[healthLog[i].health] || 3;
+      if (curr > prev) {
+        // Recovery detected
+        const recoveryTime = (new Date(healthLog[i].date) - new Date(healthLog[i - 1].date)) / 86400000;
+        declines.push(recoveryTime);
+      }
+    }
+    if (declines.length > 0) {
+      const avgRecovery = declines.reduce((a, b) => a + b, 0) / declines.length;
+      responsiveness = Math.max(0, Math.min(100, Math.round(100 * Math.max(0, 1 - avgRecovery / 30))));
+    }
+  }
+
+  const score = Math.round(consistency * 0.3 + timing * 0.3 + healthOutcome * 0.25 + responsiveness * 0.15);
+
+  let grade;
+  if (score >= 90) grade = 'A';
+  else if (score >= 75) grade = 'B';
+  else if (score >= 60) grade = 'C';
+  else if (score >= 45) grade = 'D';
+  else grade = 'F';
+
+  return {
+    score,
+    grade,
+    dimensions: { consistency, timing, healthOutcome, responsiveness },
+    trend: 0,
+    scoredAt: new Date().toISOString(),
+    source: 'heuristic',
+  };
+}
+
+app.get('/plants/:id/care-score', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const plant = doc.data();
+    const mlCache = plant.mlCache || {};
+
+    // Return cached result if fresh
+    if (isCacheValid(mlCache, 'careScore')) {
+      return res.status(200).json(mlCache.careScore.result);
+    }
+
+    const endpointId = process.env.CARE_SCORE_ENDPOINT;
+    let result;
+
+    if (endpointId && (plant.wateringLog || []).length >= 3) {
+      try {
+        const featureRows = buildFeatureRows(plant);
+        if (featureRows.length > 0) {
+          const predictions = await vertexai.predict(endpointId, [featureRows[featureRows.length - 1]]);
+          if (predictions.length > 0 && typeof predictions[0].score === 'number') {
+            result = { ...predictions[0], source: 'vertex_ai', scoredAt: new Date().toISOString() };
+          }
+        }
+      } catch (err) {
+        log.warn('Vertex AI care score failed, using heuristic', { error: err.message });
+      }
+    }
+
+    if (!result) {
+      result = computeCareScore(plant);
+    }
+
+    // Cache
+    await ref.set({
+      mlCache: { ...mlCache, careScore: { result, cachedAt: new Date().toISOString() } }
+    }, { merge: true });
+
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Aggregate care scores for all plants (worst-first)
+app.get('/ml/care-scores', requireUser, async (req, res) => {
+  try {
+    const snapshot = await userPlants(req.userId).get();
+    const scores = [];
+
+    for (const doc of snapshot.docs) {
+      const plant = doc.data();
+      const cached = plant.mlCache?.careScore?.result;
+      const score = cached || computeCareScore(plant);
+      scores.push({
+        plantId: doc.id,
+        name: plant.name,
+        species: plant.species,
+        ...score,
+      });
+    }
+
+    scores.sort((a, b) => a.score - b.score); // worst first
+    res.status(200).json(scores);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Species clustering ───────────────────────────────────────────────────────
 
 // Default cluster assignments based on common plant care patterns

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -70,6 +70,7 @@ let storageDeleteFn;
 let storageDeletedPaths;
 let storageSavedFiles;
 let vertexaiCheckStatusFn;
+let vertexaiPredictFn;
 
 // ── Load the express app via proxyquire ───────────────────────────────────────
 
@@ -110,7 +111,7 @@ beforeAll(() => {
     },
     './vertexai': {
       checkStatus: function() { return vertexaiCheckStatusFn(); },
-      predict: async () => [],
+      predict: function() { return vertexaiPredictFn.apply(this, arguments); },
       batchPredict: async () => ({}),
     },
   });
@@ -124,6 +125,7 @@ beforeEach(() => {
   storageDeletedPaths = [];
   storageSavedFiles = [];
   vertexaiCheckStatusFn = async () => ({ status: 'ok', project: 'test', location: 'us-central1', endpointCount: 0 });
+  vertexaiPredictFn = async () => [];
 });
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
@@ -857,6 +859,107 @@ describe('GET /plants/:id/watering-pattern — under_watered with health decline
     expect(res.body.confidence).toBeGreaterThan(0.5);
     expect(res.body.contributingFactors.some(f => f.includes('Health'))).toBe(true);
     expect(res.body.contributingFactors.some(f => f.includes('vs recommended'))).toBe(true);
+  });
+});
+
+// ── Watering pattern — ML integration & caching ────────────────────────────
+
+describe('GET /plants/:id/watering-pattern — ML & cache', () => {
+  it('includes source: heuristic when no ML endpoint configured', async () => {
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-08T00:00:00.000Z' },
+        { date: '2026-01-15T00:00:00.000Z' },
+      ],
+    };
+    const res = await request(app).get('/plants/p1/watering-pattern').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.source).toBe('heuristic');
+  });
+
+  it('uses Vertex AI when endpoint is configured', async () => {
+    process.env.WATERING_PATTERN_ENDPOINT = 'ep-123';
+    vertexaiPredictFn = async () => [{ pattern: 'over_watered', confidence: 0.92, contributingFactors: ['ML detected overwatering'] }];
+    store[plantPath('p1')] = {
+      name: 'Fern', species: 'Nephrolepis', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-04T00:00:00.000Z' },
+        { date: '2026-01-07T00:00:00.000Z' },
+      ],
+      healthLog: [{ date: '2026-01-01T00:00:00.000Z', health: 'Good' }],
+    };
+    const res = await request(app).get('/plants/p1/watering-pattern').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.pattern).toBe('over_watered');
+    expect(res.body.source).toBe('vertex_ai');
+    expect(res.body.confidence).toBe(0.92);
+    delete process.env.WATERING_PATTERN_ENDPOINT;
+  });
+
+  it('falls back to heuristic when Vertex AI prediction fails', async () => {
+    process.env.WATERING_PATTERN_ENDPOINT = 'ep-123';
+    vertexaiPredictFn = async () => { throw new Error('Vertex AI down'); };
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-08T00:00:00.000Z' },
+        { date: '2026-01-15T00:00:00.000Z' },
+      ],
+    };
+    const res = await request(app).get('/plants/p1/watering-pattern').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.source).toBe('heuristic');
+    delete process.env.WATERING_PATTERN_ENDPOINT;
+  });
+
+  it('returns cached result within TTL', async () => {
+    const cachedResult = { pattern: 'optimal', confidence: 0.85, contributingFactors: ['Cached'], source: 'vertex_ai' };
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7,
+      wateringLog: [{ date: '2026-01-01T00:00:00.000Z' }],
+      mlCache: { wateringPattern: { result: cachedResult, cachedAt: new Date().toISOString() } },
+    };
+    const res = await request(app).get('/plants/p1/watering-pattern').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.pattern).toBe('optimal');
+    expect(res.body.source).toBe('vertex_ai');
+    expect(res.body.contributingFactors).toEqual(['Cached']);
+  });
+
+  it('ignores expired cache and recomputes', async () => {
+    const expired = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(); // 25h ago
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-08T00:00:00.000Z' },
+        { date: '2026-01-15T00:00:00.000Z' },
+      ],
+      mlCache: { wateringPattern: { result: { pattern: 'stale' }, cachedAt: expired } },
+    };
+    const res = await request(app).get('/plants/p1/watering-pattern').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.pattern).not.toBe('stale');
+    expect(res.body.source).toBe('heuristic');
+  });
+});
+
+describe('POST /plants/:id/water — ML cache invalidation', () => {
+  it('clears wateringPattern cache on new watering event', async () => {
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7,
+      wateringLog: [{ date: '2026-01-01T00:00:00.000Z' }],
+      mlCache: { wateringPattern: { result: { pattern: 'optimal' }, cachedAt: new Date().toISOString() } },
+    };
+    const res = await request(app).post('/plants/p1/water').set('Authorization', authHeader()).send({});
+    expect(res.status).toBe(200);
+    // Verify cache was cleared
+    const data = store[plantPath('p1')];
+    expect(data.mlCache.wateringPattern).toBeUndefined();
   });
 });
 

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -1409,6 +1409,105 @@ describe('GET /plants/:id/health-prediction', () => {
   });
 });
 
+// ── POST /ml/anomaly-scan ────────────────────────────────────────────────────
+
+describe('POST /ml/anomaly-scan', () => {
+  it('returns 403 without admin token', async () => {
+    const res = await request(app).post('/ml/anomaly-scan');
+    expect(res.status).toBe(403);
+  });
+
+  it('scans plants and detects anomalies', async () => {
+    process.env.ML_ADMIN_TOKEN = 'test-token';
+    store['users/u1'] = {};
+    store['users/u1/plants/p1'] = {
+      name: 'Fern', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-08T00:00:00.000Z' },
+        { date: '2026-01-15T00:00:00.000Z' },
+      ],
+    };
+    const res = await request(app).post('/ml/anomaly-scan').set('x-admin-token', 'test-token');
+    expect(res.status).toBe(200);
+    expect(res.body.scanned).toBe(1);
+    expect(typeof res.body.anomalies).toBe('number');
+    // Verify cache was written
+    const data = store['users/u1/plants/p1'];
+    expect(data.mlCache.anomaly).toBeTruthy();
+    delete process.env.ML_ADMIN_TOKEN;
+  });
+});
+
+// ── GET /plants/:id/anomaly ─────────────────────────────────────────────────
+
+describe('GET /plants/:id/anomaly', () => {
+  it('returns 404 for non-existent plant', async () => {
+    const res = await request(app).get('/plants/missing/anomaly').set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns cached anomaly result', async () => {
+    const cached = { isAnomaly: true, score: 0.9, flags: ['Big gap'], detectedAt: '2026-03-01T00:00:00.000Z' };
+    store[plantPath('p1')] = {
+      name: 'Fern',
+      mlCache: { anomaly: { result: cached, cachedAt: new Date().toISOString() } },
+    };
+    const res = await request(app).get('/plants/p1/anomaly').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.isAnomaly).toBe(true);
+    expect(res.body.score).toBe(0.9);
+    expect(res.body.flags).toEqual(['Big gap']);
+  });
+
+  it('computes on-demand when no cache exists', async () => {
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-08T00:00:00.000Z' },
+        { date: '2026-01-15T00:00:00.000Z' },
+      ],
+    };
+    const res = await request(app).get('/plants/p1/anomaly').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(typeof res.body.isAnomaly).toBe('boolean');
+    expect(typeof res.body.score).toBe('number');
+    expect(res.body.flags).toBeInstanceOf(Array);
+  });
+
+  it('detects anomaly for severely under-watered plant', async () => {
+    const longAgo = new Date(Date.now() - 60 * 86400000).toISOString();
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7,
+      wateringLog: [
+        { date: new Date(Date.now() - 90 * 86400000).toISOString() },
+        { date: new Date(Date.now() - 60 * 86400000).toISOString() },
+        { date: longAgo },
+      ],
+    };
+    const res = await request(app).get('/plants/p1/anomaly').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.score).toBeGreaterThan(0);
+    expect(res.body.flags.length).toBeGreaterThan(0);
+  });
+
+  it('returns no anomaly for well-maintained plant', async () => {
+    const now = Date.now();
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7,
+      wateringLog: [
+        { date: new Date(now - 14 * 86400000).toISOString() },
+        { date: new Date(now - 7 * 86400000).toISOString() },
+        { date: new Date(now - 1 * 86400000).toISOString() },
+      ],
+    };
+    const res = await request(app).get('/plants/p1/anomaly').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.isAnomaly).toBe(false);
+  });
+});
+
 // ── gcsPath edge cases ───────────────────────────────────────────────────────
 
 describe('gcsPath — via DELETE /plants/:id', () => {

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -1312,6 +1312,103 @@ describe('GET /plants/:id/watering-recommendation', () => {
   });
 });
 
+// ── GET /plants/:id/health-prediction ────────────────────────────────────────
+
+describe('GET /plants/:id/health-prediction', () => {
+  it('returns 404 for non-existent plant', async () => {
+    const res = await request(app).get('/plants/missing/health-prediction').set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns heuristic prediction for healthy plant', async () => {
+    store[plantPath('p1')] = {
+      name: 'Monstera', species: 'Monstera', frequencyDays: 7, health: 'Good',
+      lastWatered: new Date().toISOString(),
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-08T00:00:00.000Z' },
+        { date: '2026-01-15T00:00:00.000Z' },
+      ],
+      healthLog: [
+        { date: '2026-01-01T00:00:00.000Z', health: 'Good' },
+        { date: '2026-01-15T00:00:00.000Z', health: 'Good' },
+      ],
+    };
+    const res = await request(app).get('/plants/p1/health-prediction').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.predictedHealth).toBeTruthy();
+    expect(res.body.horizon).toBe('14d');
+    expect(res.body.trend).toBeTruthy();
+    expect(res.body.keyRisks).toBeInstanceOf(Array);
+    expect(res.body.source).toBe('heuristic');
+  });
+
+  it('detects risk when plant is overdue for watering', async () => {
+    const oldDate = new Date(Date.now() - 30 * 86400000).toISOString(); // 30 days ago
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7, health: 'Good',
+      lastWatered: oldDate,
+      wateringLog: [{ date: oldDate }],
+      healthLog: [{ date: oldDate, health: 'Good' }],
+    };
+    const res = await request(app).get('/plants/p1/health-prediction').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.keyRisks.some(r => r.includes('Not watered'))).toBe(true);
+    expect(res.body.trend).toBe('declining');
+  });
+
+  it('uses Vertex AI when endpoint configured', async () => {
+    process.env.HEALTH_PREDICTION_ENDPOINT = 'health-ep-1';
+    vertexaiPredictFn = async () => [{
+      predictedHealth: 'Fair', probability: 0.82, trend: 'declining',
+      keyRisks: ['Low watering adherence', 'Season change approaching'],
+    }];
+    store[plantPath('p1')] = {
+      name: 'Fern', species: 'Nephrolepis', frequencyDays: 7, health: 'Good',
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-08T00:00:00.000Z' },
+        { date: '2026-01-15T00:00:00.000Z' },
+      ],
+      healthLog: [{ date: '2026-01-01T00:00:00.000Z', health: 'Good' }],
+    };
+    const res = await request(app).get('/plants/p1/health-prediction').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.predictedHealth).toBe('Fair');
+    expect(res.body.source).toBe('vertex_ai');
+    expect(res.body.keyRisks).toHaveLength(2);
+    delete process.env.HEALTH_PREDICTION_ENDPOINT;
+  });
+
+  it('returns cached prediction within TTL', async () => {
+    const cached = {
+      predictedHealth: 'Good', probability: 0.8, horizon: '14d',
+      trend: 'stable', keyRisks: ['Cached'], source: 'vertex_ai',
+    };
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7,
+      mlCache: { healthPrediction: { result: cached, cachedAt: new Date().toISOString() } },
+    };
+    const res = await request(app).get('/plants/p1/health-prediction').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.predictedHealth).toBe('Good');
+    expect(res.body.keyRisks).toEqual(['Cached']);
+  });
+
+  it('invalidates health prediction cache on health change', async () => {
+    store[plantPath('p1')] = {
+      name: 'Fern', health: 'Good',
+      mlCache: {
+        healthPrediction: { result: { predictedHealth: 'Good' }, cachedAt: new Date().toISOString() },
+      },
+    };
+    await request(app).put('/plants/p1').set('Authorization', authHeader())
+      .send({ health: 'Fair', healthReason: 'Wilting' });
+    const data = store[plantPath('p1')];
+    expect(data.mlCache.healthPrediction).toBeUndefined();
+  });
+});
+
 // ── gcsPath edge cases ───────────────────────────────────────────────────────
 
 describe('gcsPath — via DELETE /plants/:id', () => {

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -1409,6 +1409,69 @@ describe('GET /plants/:id/health-prediction', () => {
   });
 });
 
+// ── GET /plants/:id/seasonal-adjustment ──────────────────────────────────────
+
+describe('GET /plants/:id/seasonal-adjustment', () => {
+  it('returns 404 for non-existent plant', async () => {
+    const res = await request(app).get('/plants/missing/seasonal-adjustment').set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns seasonal adjustment with heuristic', async () => {
+    store[plantPath('p1')] = {
+      name: 'Monstera', species: 'Monstera Deliciosa', frequencyDays: 10,
+    };
+    const res = await request(app).get('/plants/p1/seasonal-adjustment').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.season).toBeTruthy();
+    expect(res.body.multiplier).toBeGreaterThan(0);
+    expect(res.body.adjustedFrequencyDays).toBeGreaterThan(0);
+    expect(res.body.note).toContain('Monstera Deliciosa');
+    expect(res.body.source).toBe('heuristic');
+  });
+
+  it('uses hemisphere from user config', async () => {
+    store[plantPath('p1')] = {
+      name: 'Fern', species: 'Nephrolepis', frequencyDays: 7,
+    };
+    store[`users/${USER_SUB}/config/preferences`] = { hemisphere: 'south' };
+    const res = await request(app).get('/plants/p1/seasonal-adjustment').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    // Season should be valid
+    expect(['spring', 'summer', 'autumn', 'winter']).toContain(res.body.season);
+  });
+
+  it('defaults to north hemisphere when no config', async () => {
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7,
+    };
+    const res = await request(app).get('/plants/p1/seasonal-adjustment').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.source).toBe('heuristic');
+  });
+
+  it('uses Vertex AI when endpoint configured', async () => {
+    process.env.SEASONAL_ADJUSTMENT_ENDPOINT = 'season-ep-1';
+    vertexaiPredictFn = async () => [{ multiplier: 0.65, note: 'Winter dormancy for Monstera' }];
+    store[plantPath('p1')] = {
+      name: 'Monstera', species: 'Monstera', frequencyDays: 10,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-08T00:00:00.000Z' },
+        { date: '2026-01-15T00:00:00.000Z' },
+        { date: '2026-01-22T00:00:00.000Z' },
+        { date: '2026-01-29T00:00:00.000Z' },
+        { date: '2026-02-05T00:00:00.000Z' },
+      ],
+    };
+    const res = await request(app).get('/plants/p1/seasonal-adjustment').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.multiplier).toBe(0.65);
+    expect(res.body.source).toBe('vertex_ai');
+    delete process.env.SEASONAL_ADJUSTMENT_ENDPOINT;
+  });
+});
+
 // ── POST /ml/anomaly-scan ────────────────────────────────────────────────────
 
 describe('POST /ml/anomaly-scan', () => {

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -68,6 +68,7 @@ let geminiGenerateFn;
 let storageSignedUrlFn;
 let storageDeleteFn;
 let storageDeletedPaths;
+let storageSavedFiles;
 let vertexaiCheckStatusFn;
 
 // ── Load the express app via proxyquire ───────────────────────────────────────
@@ -95,6 +96,7 @@ beforeAll(() => {
               return {
                 getSignedUrl: function() { return storageSignedUrlFn.apply(this, arguments); },
                 delete: function() { storageDeletedPaths.push(f); return storageDeleteFn(f); },
+                save: function(content, opts) { storageSavedFiles.push({ path: f, content, opts }); return Promise.resolve(); },
               };
             },
           };
@@ -120,6 +122,7 @@ beforeEach(() => {
   storageSignedUrlFn = async () => ['https://signed.example.com/img.jpg'];
   storageDeleteFn = async () => {};
   storageDeletedPaths = [];
+  storageSavedFiles = [];
   vertexaiCheckStatusFn = async () => ({ status: 'ok', project: 'test', location: 'us-central1', endpointCount: 0 });
 });
 
@@ -980,6 +983,113 @@ describe('GET /ml/export', () => {
     const res = await request(app).get('/ml/export').set('x-admin-token', 'test-token');
     expect(res.status).toBe(200);
     expect(res.text).toBe('');
+    delete process.env.ML_ADMIN_TOKEN;
+  });
+
+  it('returns CSV format when format=csv', async () => {
+    process.env.ML_ADMIN_TOKEN = 'test-token';
+    store['users/user-csv-1'] = { email: 'a@b.com' };
+    store['users/user-csv-1/plants/p1'] = {
+      name: 'Fern', species: 'Nephrolepis', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-08T00:00:00.000Z' },
+      ],
+      healthLog: [{ date: '2026-01-01T00:00:00.000Z', health: 'Good' }],
+    };
+    const res = await request(app).get('/ml/export?format=csv').set('x-admin-token', 'test-token');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/csv');
+    const lines = res.text.trim().split('\n');
+    expect(lines[0]).toBe('species,days_between_waterings,recommended_frequency,adherence_ratio,health_at_watering,health_7d_after,season,consecutive_overdue_days,pot_size,room');
+    expect(lines[1]).toContain('Nephrolepis');
+    delete process.env.ML_ADMIN_TOKEN;
+  });
+
+  it('rejects invalid format parameter', async () => {
+    process.env.ML_ADMIN_TOKEN = 'test-token';
+    const res = await request(app).get('/ml/export?format=xml').set('x-admin-token', 'test-token');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('format');
+    delete process.env.ML_ADMIN_TOKEN;
+  });
+
+  it('writes to GCS when dest=gcs', async () => {
+    process.env.ML_ADMIN_TOKEN = 'test-token';
+    process.env.ML_DATA_BUCKET = 'my-ml-bucket';
+    store['users/user-gcs-1'] = { email: 'a@b.com' };
+    store['users/user-gcs-1/plants/p1'] = {
+      name: 'Fern', species: 'Nephrolepis', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-03-01T00:00:00.000Z' },
+        { date: '2026-03-08T00:00:00.000Z' },
+      ],
+      healthLog: [],
+    };
+    const res = await request(app).get('/ml/export?dest=gcs&format=csv').set('x-admin-token', 'test-token');
+    expect(res.status).toBe(200);
+    expect(res.body.rows).toBe(1);
+    expect(res.body.format).toBe('csv');
+    expect(res.body.written).toContain('gs://my-ml-bucket/exports/');
+    expect(res.body.written).toContain('.csv');
+    expect(storageSavedFiles.length).toBe(1);
+    expect(storageSavedFiles[0].content).toContain('Nephrolepis');
+    delete process.env.ML_ADMIN_TOKEN;
+    delete process.env.ML_DATA_BUCKET;
+  });
+
+  it('computes correct feature derivation values', async () => {
+    process.env.ML_ADMIN_TOKEN = 'test-token';
+    store['users/user-feat-1'] = {};
+    store['users/user-feat-1/plants/p1'] = {
+      name: 'Aloe', species: 'Aloe Vera', frequencyDays: 14, potSize: 'medium', room: 'Living Room',
+      wateringLog: [
+        { date: '2026-06-01T00:00:00.000Z' },
+        { date: '2026-06-08T00:00:00.000Z' },  // 7 days gap (overdue: < 14)
+        { date: '2026-06-22T00:00:00.000Z' },  // 14 days gap (on time)
+      ],
+      healthLog: [
+        { date: '2026-06-01T00:00:00.000Z', health: 'Good' },
+        { date: '2026-06-10T00:00:00.000Z', health: 'Fair' },
+      ],
+    };
+    const res = await request(app).get('/ml/export').set('x-admin-token', 'test-token');
+    const rows = res.text.trim().split('\n').map(l => JSON.parse(l));
+    expect(rows).toHaveLength(2);
+
+    // First row: gap of 7 days, freq 14 → adherence 0.5
+    expect(rows[0].species).toBe('Aloe Vera');
+    expect(rows[0].days_between_waterings).toBe(7);
+    expect(rows[0].adherence_ratio).toBe(0.5);
+    expect(rows[0].season).toBe('summer');
+    expect(rows[0].pot_size).toBe('medium');
+    expect(rows[0].room).toBe('Living Room');
+
+    // Second row: gap of 14 days, freq 14 → adherence 1.0
+    expect(rows[1].days_between_waterings).toBe(14);
+    expect(rows[1].adherence_ratio).toBe(1);
+    expect(rows[1].consecutive_overdue_days).toBe(0);
+
+    delete process.env.ML_ADMIN_TOKEN;
+  });
+
+  it('derives correct season from watering dates', async () => {
+    process.env.ML_ADMIN_TOKEN = 'test-token';
+    store['users/user-season-1'] = {};
+    store['users/user-season-1/plants/p1'] = {
+      name: 'Plant', species: 'Test', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },  // winter
+        { date: '2026-03-15T00:00:00.000Z' },  // spring
+        { date: '2026-07-01T00:00:00.000Z' },  // summer
+        { date: '2026-10-15T00:00:00.000Z' },  // autumn
+        { date: '2026-12-25T00:00:00.000Z' },  // winter
+      ],
+      healthLog: [],
+    };
+    const res = await request(app).get('/ml/export').set('x-admin-token', 'test-token');
+    const rows = res.text.trim().split('\n').map(l => JSON.parse(l));
+    expect(rows.map(r => r.season)).toEqual(['spring', 'summer', 'autumn', 'winter']);
     delete process.env.ML_ADMIN_TOKEN;
   });
 });

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -1197,6 +1197,121 @@ describe('GET /ml/export', () => {
   });
 });
 
+// ── GET /plants/:id/watering-recommendation ─────────────────────────────────
+
+describe('GET /plants/:id/watering-recommendation', () => {
+  it('returns 404 for non-existent plant', async () => {
+    const res = await request(app).get('/plants/missing/watering-recommendation').set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/plants/p1/watering-recommendation');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns heuristic recommendation for plant with sufficient data', async () => {
+    store[plantPath('p1')] = {
+      name: 'Monstera', species: 'Monstera Deliciosa', frequencyDays: 10,
+      lastWatered: '2026-03-01T00:00:00.000Z',
+      wateringLog: [
+        { date: '2026-02-01T00:00:00.000Z' },
+        { date: '2026-02-11T00:00:00.000Z' },
+        { date: '2026-02-21T00:00:00.000Z' },
+        { date: '2026-03-01T00:00:00.000Z' },
+      ],
+      healthLog: [{ date: '2026-02-01T00:00:00.000Z', health: 'Good' }],
+    };
+    const res = await request(app).get('/plants/p1/watering-recommendation').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.recommendedFrequencyDays).toBe(10);
+    expect(res.body.confidenceInterval).toHaveLength(2);
+    expect(res.body.basis).toContain('10-day');
+    expect(res.body.nextWateringDate).toBeTruthy();
+    expect(res.body.source).toBe('heuristic');
+  });
+
+  it('adjusts recommendation when plant is over-watered and declining', async () => {
+    store[plantPath('p1')] = {
+      name: 'Fern', species: 'Nephrolepis', frequencyDays: 7,
+      lastWatered: '2026-03-10T00:00:00.000Z',
+      wateringLog: [
+        { date: '2026-03-01T00:00:00.000Z' },
+        { date: '2026-03-03T00:00:00.000Z' },
+        { date: '2026-03-05T00:00:00.000Z' },
+        { date: '2026-03-07T00:00:00.000Z' },
+        { date: '2026-03-10T00:00:00.000Z' },
+      ],
+      healthLog: [
+        { date: '2026-03-01T00:00:00.000Z', health: 'Good' },
+        { date: '2026-03-10T00:00:00.000Z', health: 'Poor' },
+      ],
+      health: 'Poor',
+    };
+    const res = await request(app).get('/plants/p1/watering-recommendation').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.recommendedFrequencyDays).toBeGreaterThan(7);
+    expect(res.body.basis).toContain('over-watered');
+  });
+
+  it('uses Vertex AI when endpoint is configured', async () => {
+    process.env.WATERING_RECOMMENDATION_ENDPOINT = 'rec-ep-1';
+    vertexaiPredictFn = async () => [{
+      recommendedFrequencyDays: 8,
+      confidenceInterval: [7, 10],
+      basis: 'Based on 20 waterings — Monstera in spring does best every 8-10 days',
+    }];
+    store[plantPath('p1')] = {
+      name: 'Monstera', species: 'Monstera Deliciosa', frequencyDays: 10,
+      lastWatered: '2026-03-15T00:00:00.000Z',
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-11T00:00:00.000Z' },
+        { date: '2026-01-21T00:00:00.000Z' },
+        { date: '2026-02-01T00:00:00.000Z' },
+        { date: '2026-02-11T00:00:00.000Z' },
+        { date: '2026-03-15T00:00:00.000Z' },
+      ],
+      healthLog: [{ date: '2026-01-01T00:00:00.000Z', health: 'Good' }],
+    };
+    const res = await request(app).get('/plants/p1/watering-recommendation').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.recommendedFrequencyDays).toBe(8);
+    expect(res.body.source).toBe('vertex_ai');
+    delete process.env.WATERING_RECOMMENDATION_ENDPOINT;
+  });
+
+  it('returns cached recommendation within TTL', async () => {
+    const cached = {
+      recommendedFrequencyDays: 9, confidenceInterval: [8, 10],
+      basis: 'Cached', nextWateringDate: '2026-04-01', source: 'vertex_ai',
+    };
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7,
+      mlCache: { wateringRecommendation: { result: cached, cachedAt: new Date().toISOString() } },
+    };
+    const res = await request(app).get('/plants/p1/watering-recommendation').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.recommendedFrequencyDays).toBe(9);
+    expect(res.body.source).toBe('vertex_ai');
+  });
+
+  it('invalidates recommendation cache on watering', async () => {
+    store[plantPath('p1')] = {
+      name: 'Fern', frequencyDays: 7,
+      wateringLog: [{ date: '2026-01-01T00:00:00.000Z' }],
+      mlCache: {
+        wateringRecommendation: { result: { recommendedFrequencyDays: 9 }, cachedAt: new Date().toISOString() },
+        wateringPattern: { result: { pattern: 'optimal' }, cachedAt: new Date().toISOString() },
+      },
+    };
+    await request(app).post('/plants/p1/water').set('Authorization', authHeader()).send({});
+    const data = store[plantPath('p1')];
+    expect(data.mlCache.wateringRecommendation).toBeUndefined();
+    expect(data.mlCache.wateringPattern).toBeUndefined();
+  });
+});
+
 // ── gcsPath edge cases ───────────────────────────────────────────────────────
 
 describe('gcsPath — via DELETE /plants/:id', () => {

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -1472,6 +1472,123 @@ describe('GET /plants/:id/seasonal-adjustment', () => {
   });
 });
 
+// ── GET /plants/:id/care-score ───────────────────────────────────────────────
+
+describe('GET /plants/:id/care-score', () => {
+  it('returns 404 for non-existent plant', async () => {
+    const res = await request(app).get('/plants/missing/care-score').set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns heuristic care score', async () => {
+    store[plantPath('p1')] = {
+      name: 'Monstera', species: 'Monstera', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-08T00:00:00.000Z' },
+        { date: '2026-01-15T00:00:00.000Z' },
+      ],
+      healthLog: [
+        { date: '2026-01-01T00:00:00.000Z', health: 'Good' },
+        { date: '2026-01-15T00:00:00.000Z', health: 'Good' },
+      ],
+    };
+    const res = await request(app).get('/plants/p1/care-score').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.score).toBeGreaterThanOrEqual(0);
+    expect(res.body.score).toBeLessThanOrEqual(100);
+    expect(['A', 'B', 'C', 'D', 'F']).toContain(res.body.grade);
+    expect(res.body.dimensions).toHaveProperty('consistency');
+    expect(res.body.dimensions).toHaveProperty('timing');
+    expect(res.body.dimensions).toHaveProperty('healthOutcome');
+    expect(res.body.dimensions).toHaveProperty('responsiveness');
+    expect(res.body.source).toBe('heuristic');
+  });
+
+  it('scores well-cared-for plant higher than neglected one', async () => {
+    // Well-cared plant
+    store[plantPath('p1')] = {
+      name: 'Good Fern', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-08T00:00:00.000Z' },
+        { date: '2026-01-15T00:00:00.000Z' },
+        { date: '2026-01-22T00:00:00.000Z' },
+      ],
+      healthLog: [{ date: '2026-01-01T00:00:00.000Z', health: 'Excellent' }],
+    };
+    // Neglected plant
+    store[plantPath('p2')] = {
+      name: 'Sad Fern', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-20T00:00:00.000Z' },
+        { date: '2026-02-15T00:00:00.000Z' },
+      ],
+      healthLog: [
+        { date: '2026-01-01T00:00:00.000Z', health: 'Good' },
+        { date: '2026-02-15T00:00:00.000Z', health: 'Poor' },
+      ],
+    };
+    const res1 = await request(app).get('/plants/p1/care-score').set('Authorization', authHeader());
+    const res2 = await request(app).get('/plants/p2/care-score').set('Authorization', authHeader());
+    expect(res1.body.score).toBeGreaterThan(res2.body.score);
+  });
+
+  it('returns cached care score', async () => {
+    const cached = { score: 85, grade: 'B', dimensions: {}, trend: 0, scoredAt: '2026-01-01', source: 'vertex_ai' };
+    store[plantPath('p1')] = {
+      name: 'Fern',
+      mlCache: { careScore: { result: cached, cachedAt: new Date().toISOString() } },
+    };
+    const res = await request(app).get('/plants/p1/care-score').set('Authorization', authHeader());
+    expect(res.body.score).toBe(85);
+    expect(res.body.source).toBe('vertex_ai');
+  });
+});
+
+// ── GET /ml/care-scores ─────────────────────────────────────────────────────
+
+describe('GET /ml/care-scores', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/ml/care-scores');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns scores for all plants sorted worst-first', async () => {
+    store[plantPath('p1')] = {
+      name: 'Good Plant', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-08T00:00:00.000Z' },
+        { date: '2026-01-15T00:00:00.000Z' },
+      ],
+      healthLog: [{ date: '2026-01-01T00:00:00.000Z', health: 'Excellent' }],
+    };
+    store[plantPath('p2')] = {
+      name: 'OK Plant', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-01-20T00:00:00.000Z' },
+        { date: '2026-02-10T00:00:00.000Z' },
+      ],
+      healthLog: [{ date: '2026-01-01T00:00:00.000Z', health: 'Fair' }],
+    };
+    const res = await request(app).get('/ml/care-scores').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0].score).toBeLessThanOrEqual(res.body[1].score);
+    expect(res.body[0]).toHaveProperty('plantId');
+    expect(res.body[0]).toHaveProperty('name');
+  });
+
+  it('returns empty array when no plants', async () => {
+    const res = await request(app).get('/ml/care-scores').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+});
+
 // ── GET /species/:name/cluster ───────────────────────────────────────────────
 
 describe('GET /species/:name/cluster', () => {

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -68,6 +68,7 @@ let geminiGenerateFn;
 let storageSignedUrlFn;
 let storageDeleteFn;
 let storageDeletedPaths;
+let vertexaiCheckStatusFn;
 
 // ── Load the express app via proxyquire ───────────────────────────────────────
 
@@ -105,6 +106,11 @@ beforeAll(() => {
         collection(name) { return makeCollRef(name); }
       },
     },
+    './vertexai': {
+      checkStatus: function() { return vertexaiCheckStatusFn(); },
+      predict: async () => [],
+      batchPredict: async () => ({}),
+    },
   });
 });
 
@@ -114,6 +120,7 @@ beforeEach(() => {
   storageSignedUrlFn = async () => ['https://signed.example.com/img.jpg'];
   storageDeleteFn = async () => {};
   storageDeletedPaths = [];
+  vertexaiCheckStatusFn = async () => ({ status: 'ok', project: 'test', location: 'us-central1', endpointCount: 0 });
 });
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
@@ -146,6 +153,39 @@ describe('GET /health', () => {
     expect(res.headers['x-xss-protection']).toBe('0');
     expect(res.headers['strict-transport-security']).toBe('max-age=31536000; includeSubDomains');
     expect(res.headers['permissions-policy']).toBe('camera=(), microphone=(), geolocation=()');
+  });
+});
+
+// ── GET /ml/status ───────────────────────────────────────────────────────────
+
+describe('GET /ml/status', () => {
+  it('returns 200 when Vertex AI is reachable', async () => {
+    vertexaiCheckStatusFn = async () => ({ status: 'ok', project: 'my-project', location: 'us-central1', endpointCount: 2 });
+    const res = await request(app).get('/ml/status');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.project).toBe('my-project');
+  });
+
+  it('returns 503 when Vertex AI is unconfigured', async () => {
+    vertexaiCheckStatusFn = async () => ({ status: 'unconfigured', project: null, location: 'us-central1', error: 'VERTEX_AI_PROJECT is not set' });
+    const res = await request(app).get('/ml/status');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('unconfigured');
+  });
+
+  it('returns 502 when Vertex AI returns error status', async () => {
+    vertexaiCheckStatusFn = async () => ({ status: 'error', project: 'p', location: 'us-central1', error: 'Network error' });
+    const res = await request(app).get('/ml/status');
+    expect(res.status).toBe(502);
+    expect(res.body.status).toBe('error');
+  });
+
+  it('returns 500 when checkStatus throws', async () => {
+    vertexaiCheckStatusFn = async () => { throw new Error('unexpected'); };
+    const res = await request(app).get('/ml/status');
+    expect(res.status).toBe(500);
+    expect(res.body.status).toBe('error');
   });
 });
 

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -1472,6 +1472,60 @@ describe('GET /plants/:id/seasonal-adjustment', () => {
   });
 });
 
+// ── GET /species/:name/cluster ───────────────────────────────────────────────
+
+describe('GET /species/:name/cluster', () => {
+  it('returns cluster for known tropical species', async () => {
+    const res = await request(app).get('/species/Calathea/cluster').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.clusterId).toBe('thirsty_tropicals');
+    expect(res.body.clusterLabel).toBe('Thirsty Tropicals');
+    expect(res.body.similarSpecies).toBeInstanceOf(Array);
+    expect(res.body.clusterCareProfile.droughtTolerance).toBe('low');
+  });
+
+  it('returns cluster for known drought-tolerant species', async () => {
+    const res = await request(app).get('/species/Snake%20Plant/cluster').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.clusterId).toBe('drought_tolerant');
+  });
+
+  it('returns cluster for known forgiving foliage', async () => {
+    const res = await request(app).get('/species/Monstera%20Deliciosa/cluster').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.clusterId).toBe('forgiving_foliage');
+  });
+
+  it('returns unknown for unrecognised species', async () => {
+    const res = await request(app).get('/species/Xyloplantia/cluster').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.clusterId).toBeNull();
+    expect(res.body.clusterLabel).toBe('Unknown');
+    expect(res.body.source).toBe('none');
+  });
+
+  it('uses Firestore cluster assignments when available', async () => {
+    store['config/clusters'] = {
+      assignments: {
+        'rare plant': { clusterId: 'forgiving_foliage', clusterLabel: 'Forgiving Foliage', similarSpecies: ['pothos'] },
+      },
+    };
+    const res = await request(app).get('/species/Rare%20Plant/cluster').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.clusterId).toBe('forgiving_foliage');
+    expect(res.body.source).toBe('trained');
+  });
+
+  it('uses Vertex AI when endpoint configured', async () => {
+    process.env.SPECIES_CLUSTER_ENDPOINT = 'cluster-ep-1';
+    vertexaiPredictFn = async () => [{ clusterId: 'seasonal_bloomers', clusterLabel: 'Seasonal Bloomers', similarSpecies: ['orchid'] }];
+    const res = await request(app).get('/species/Christmas%20Cactus/cluster').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.source).toBe('vertex_ai');
+    delete process.env.SPECIES_CLUSTER_ENDPOINT;
+  });
+});
+
 // ── POST /ml/anomaly-scan ────────────────────────────────────────────────────
 
 describe('POST /ml/anomaly-scan', () => {

--- a/api/plants/package-lock.json
+++ b/api/plants/package-lock.json
@@ -8,6 +8,7 @@
       "name": "plants-api",
       "version": "1.0.0",
       "dependencies": {
+        "@google-cloud/aiplatform": "^3.35.0",
         "@google-cloud/firestore": "^8.3.0",
         "@google-cloud/functions-framework": "^3.0.0",
         "@google-cloud/storage": "^7.0.0",
@@ -327,6 +328,85 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@google-cloud/aiplatform": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/aiplatform/-/aiplatform-3.35.0.tgz",
+      "integrity": "sha512-Eo+ckr1KbTxAOew9P+MeeR0aQXeW5PeOzrSM1JyGny/SGKejwX/RcGWSFpeapnlegTfI9N9xJeUeo3M+XBOeFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^4.0.3",
+        "protobuf.js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/aiplatform/node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@google-cloud/aiplatform/node_modules/google-gax": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/aiplatform/node_modules/proto3-json-serializer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/aiplatform/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@google-cloud/firestore": {
@@ -1220,6 +1300,12 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT"
     },
     "node_modules/@types/mime": {
@@ -4730,6 +4816,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/protobuf.js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/protobuf.js/-/protobuf.js-1.1.2.tgz",
+      "integrity": "sha512-USO7Xus/pzPw549M1TguiyoOrKEhm9VMXv+CkDufcjMC8Rd7EPbxeRQPEjCV8ua1tm0k7z9xHkogcxovZogWdA==",
+      "license": "MIT",
+      "dependencies": {
+        "long": "~1.1.2"
+      }
+    },
+    "node_modules/protobuf.js/node_modules/long": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/long/-/long-1.1.5.tgz",
+      "integrity": "sha512-TU6nAF5SdasnTr28c7e74P4Crbn9o3/zwo1pM22Wvg2i2vlZ4Eelxwu4QT7j21z0sDBlJDEnEZjXTZg2J8WJrg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
@@ -6420,6 +6524,60 @@
         "levn": "^0.4.1"
       }
     },
+    "@google-cloud/aiplatform": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/aiplatform/-/aiplatform-3.35.0.tgz",
+      "integrity": "sha512-Eo+ckr1KbTxAOew9P+MeeR0aQXeW5PeOzrSM1JyGny/SGKejwX/RcGWSFpeapnlegTfI9N9xJeUeo3M+XBOeFg==",
+      "requires": {
+        "google-gax": "^4.0.3",
+        "protobuf.js": "^1.1.2"
+      },
+      "dependencies": {
+        "@grpc/proto-loader": {
+          "version": "0.7.15",
+          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+          "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+          "requires": {
+            "lodash.camelcase": "^4.3.0",
+            "long": "^5.0.0",
+            "protobufjs": "^7.2.5",
+            "yargs": "^17.7.2"
+          }
+        },
+        "google-gax": {
+          "version": "4.6.1",
+          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+          "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+          "requires": {
+            "@grpc/grpc-js": "^1.10.9",
+            "@grpc/proto-loader": "^0.7.13",
+            "@types/long": "^4.0.0",
+            "abort-controller": "^3.0.0",
+            "duplexify": "^4.0.0",
+            "google-auth-library": "^9.3.0",
+            "node-fetch": "^2.7.0",
+            "object-hash": "^3.0.0",
+            "proto3-json-serializer": "^2.0.2",
+            "protobufjs": "^7.3.2",
+            "retry-request": "^7.0.0",
+            "uuid": "^9.0.1"
+          }
+        },
+        "proto3-json-serializer": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+          "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+          "requires": {
+            "protobufjs": "^7.2.5"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
+      }
+    },
     "@google-cloud/firestore": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-8.3.0.tgz",
@@ -7026,6 +7184,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/mime": {
       "version": "1.3.5",
@@ -9347,6 +9510,21 @@
       "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
       "requires": {
         "protobufjs": "^7.4.0"
+      }
+    },
+    "protobuf.js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/protobuf.js/-/protobuf.js-1.1.2.tgz",
+      "integrity": "sha512-USO7Xus/pzPw549M1TguiyoOrKEhm9VMXv+CkDufcjMC8Rd7EPbxeRQPEjCV8ua1tm0k7z9xHkogcxovZogWdA==",
+      "requires": {
+        "long": "~1.1.2"
+      },
+      "dependencies": {
+        "long": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/long/-/long-1.1.5.tgz",
+          "integrity": "sha512-TU6nAF5SdasnTr28c7e74P4Crbn9o3/zwo1pM22Wvg2i2vlZ4Eelxwu4QT7j21z0sDBlJDEnEZjXTZg2J8WJrg=="
+        }
       }
     },
     "protobufjs": {

--- a/api/plants/package.json
+++ b/api/plants/package.json
@@ -14,6 +14,7 @@
     "test:integration": "vitest run --config integration/vitest.config.mjs integration/api.test.js"
   },
   "dependencies": {
+    "@google-cloud/aiplatform": "^3.35.0",
     "@google-cloud/firestore": "^8.3.0",
     "@google-cloud/functions-framework": "^3.0.0",
     "@google-cloud/storage": "^7.0.0",

--- a/api/plants/vertexai.js
+++ b/api/plants/vertexai.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const { PredictionServiceClient, helpers } = require('@google-cloud/aiplatform');
+
+const PROJECT = process.env.VERTEX_AI_PROJECT;
+const LOCATION = process.env.VERTEX_AI_LOCATION || 'us-central1';
+
+let client;
+
+function getClient() {
+  if (!client) {
+    client = new PredictionServiceClient({
+      apiEndpoint: `${LOCATION}-aiplatform.googleapis.com`,
+    });
+  }
+  return client;
+}
+
+/**
+ * Send an online prediction request to a Vertex AI endpoint.
+ * @param {string} endpointId - The Vertex AI endpoint ID.
+ * @param {object[]} instances - Array of instance objects for prediction.
+ * @returns {Promise<object[]>} Array of prediction result objects.
+ */
+async function predict(endpointId, instances) {
+  if (!PROJECT) throw new Error('VERTEX_AI_PROJECT is not configured');
+  if (!endpointId) throw new Error('endpointId is required');
+  if (!Array.isArray(instances) || instances.length === 0) {
+    throw new Error('instances must be a non-empty array');
+  }
+
+  const endpoint = `projects/${PROJECT}/locations/${LOCATION}/endpoints/${endpointId}`;
+  const instanceValues = instances.map(i => helpers.toValue(i));
+
+  const maxRetries = 2;
+  let lastErr;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const [response] = await getClient().predict({ endpoint, instances: instanceValues });
+      return (response.predictions || []).map(p => helpers.fromValue(p));
+    } catch (err) {
+      lastErr = err;
+      const code = err.code || 0;
+      // Retry on UNAVAILABLE (14), RESOURCE_EXHAUSTED (8), DEADLINE_EXCEEDED (4)
+      const retryable = [4, 8, 14].includes(code);
+      if (!retryable || attempt === maxRetries) break;
+      await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+    }
+  }
+  const error = new Error(`Vertex AI prediction failed: ${lastErr.message}`);
+  error.code = lastErr.code;
+  throw error;
+}
+
+/**
+ * Submit a batch prediction job.
+ * @param {object} jobConfig - Batch prediction job configuration.
+ * @param {string} jobConfig.modelId - Model resource ID.
+ * @param {string} jobConfig.inputUri - GCS URI for input data (e.g. gs://bucket/input.jsonl).
+ * @param {string} jobConfig.outputUri - GCS URI prefix for output (e.g. gs://bucket/output/).
+ * @param {string} [jobConfig.displayName] - Human-readable job name.
+ * @returns {Promise<object>} The created batch prediction job.
+ */
+async function batchPredict(jobConfig) {
+  if (!PROJECT) throw new Error('VERTEX_AI_PROJECT is not configured');
+  if (!jobConfig || !jobConfig.modelId) throw new Error('jobConfig.modelId is required');
+  if (!jobConfig.inputUri) throw new Error('jobConfig.inputUri is required');
+  if (!jobConfig.outputUri) throw new Error('jobConfig.outputUri is required');
+
+  const { JobServiceClient } = require('@google-cloud/aiplatform');
+  const jobClient = new JobServiceClient({
+    apiEndpoint: `${LOCATION}-aiplatform.googleapis.com`,
+  });
+
+  const parent = `projects/${PROJECT}/locations/${LOCATION}`;
+  const model = `projects/${PROJECT}/locations/${LOCATION}/models/${jobConfig.modelId}`;
+
+  const [job] = await jobClient.createBatchPredictionJob({
+    parent,
+    batchPredictionJob: {
+      displayName: jobConfig.displayName || `batch-predict-${Date.now()}`,
+      model,
+      inputConfig: {
+        instancesFormat: 'jsonl',
+        gcsSource: { uris: [jobConfig.inputUri] },
+      },
+      outputConfig: {
+        predictionsFormat: 'jsonl',
+        gcsDestination: { outputUriPrefix: jobConfig.outputUri },
+      },
+    },
+  });
+
+  return {
+    name: job.name,
+    displayName: job.displayName,
+    state: job.state,
+    createTime: job.createTime,
+  };
+}
+
+/**
+ * Check Vertex AI connectivity by listing endpoints.
+ * @returns {Promise<object>} Status object with project, location, and reachability info.
+ */
+async function checkStatus() {
+  if (!PROJECT) {
+    return { status: 'unconfigured', project: null, location: LOCATION, error: 'VERTEX_AI_PROJECT is not set' };
+  }
+
+  try {
+    const parent = `projects/${PROJECT}/locations/${LOCATION}`;
+    const [endpoints] = await getClient().listEndpoints({ parent, pageSize: 1 });
+    return {
+      status: 'ok',
+      project: PROJECT,
+      location: LOCATION,
+      endpointCount: Array.isArray(endpoints) ? endpoints.length : 0,
+    };
+  } catch (err) {
+    return {
+      status: 'error',
+      project: PROJECT,
+      location: LOCATION,
+      error: err.message,
+    };
+  }
+}
+
+// Allow replacing the client for testing
+function _setClient(mockClient) {
+  client = mockClient;
+}
+
+module.exports = { predict, batchPredict, checkStatus, _setClient };

--- a/api/plants/vertexai.test.js
+++ b/api/plants/vertexai.test.js
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+// Save and restore env vars
+const origEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.VERTEX_AI_PROJECT = 'test-project';
+  process.env.VERTEX_AI_LOCATION = 'us-central1';
+});
+
+afterEach(() => {
+  process.env = { ...origEnv };
+  vi.restoreAllMocks();
+});
+
+// We test via proxyquire to mock the @google-cloud/aiplatform SDK
+const proxyquire = require('proxyquire').noCallThru();
+
+function loadModule(mocks = {}) {
+  const defaultMocks = {
+    '@google-cloud/aiplatform': {
+      PredictionServiceClient: mocks.PredictionServiceClient || class {
+        predict() { throw new Error('predict not mocked'); }
+        listEndpoints() { throw new Error('listEndpoints not mocked'); }
+      },
+      JobServiceClient: mocks.JobServiceClient || class {
+        createBatchPredictionJob() { throw new Error('createBatchPredictionJob not mocked'); }
+      },
+      helpers: {
+        toValue: v => v,
+        fromValue: v => v,
+      },
+    },
+  };
+  // Clear module from require cache to get a fresh instance
+  delete require.cache[require.resolve('./vertexai')];
+  return proxyquire('./vertexai', defaultMocks);
+}
+
+// ── predict() ────────────────────────────────────────────────────────────────
+
+describe('predict()', () => {
+  it('returns predictions from Vertex AI endpoint', async () => {
+    const mod = loadModule({
+      PredictionServiceClient: class {
+        predict() {
+          return [{ predictions: [{ pattern: 'optimal', confidence: 0.9 }] }];
+        }
+        listEndpoints() { return [[]]; }
+      },
+    });
+
+    const result = await mod.predict('endpoint-123', [{ species: 'Monstera' }]);
+    expect(result).toEqual([{ pattern: 'optimal', confidence: 0.9 }]);
+  });
+
+  it('throws when VERTEX_AI_PROJECT is not set', async () => {
+    delete process.env.VERTEX_AI_PROJECT;
+    const mod = loadModule();
+    await expect(mod.predict('ep-1', [{}])).rejects.toThrow('VERTEX_AI_PROJECT is not configured');
+  });
+
+  it('throws when endpointId is empty', async () => {
+    const mod = loadModule();
+    await expect(mod.predict('', [{}])).rejects.toThrow('endpointId is required');
+  });
+
+  it('throws when instances is empty array', async () => {
+    const mod = loadModule();
+    await expect(mod.predict('ep-1', [])).rejects.toThrow('instances must be a non-empty array');
+  });
+
+  it('throws when instances is not an array', async () => {
+    const mod = loadModule();
+    await expect(mod.predict('ep-1', 'bad')).rejects.toThrow('instances must be a non-empty array');
+  });
+
+  it('retries on UNAVAILABLE (code 14) errors', async () => {
+    let callCount = 0;
+    const mod = loadModule({
+      PredictionServiceClient: class {
+        predict() {
+          callCount++;
+          if (callCount < 3) {
+            const err = new Error('Service unavailable');
+            err.code = 14;
+            throw err;
+          }
+          return [{ predictions: [{ result: 'ok' }] }];
+        }
+        listEndpoints() { return [[]]; }
+      },
+    });
+
+    const result = await mod.predict('ep-1', [{ x: 1 }]);
+    expect(result).toEqual([{ result: 'ok' }]);
+    expect(callCount).toBe(3);
+  });
+
+  it('retries on RESOURCE_EXHAUSTED (code 8) errors', async () => {
+    let callCount = 0;
+    const mod = loadModule({
+      PredictionServiceClient: class {
+        predict() {
+          callCount++;
+          if (callCount === 1) {
+            const err = new Error('Quota exceeded');
+            err.code = 8;
+            throw err;
+          }
+          return [{ predictions: [{ ok: true }] }];
+        }
+        listEndpoints() { return [[]]; }
+      },
+    });
+
+    const result = await mod.predict('ep-1', [{ x: 1 }]);
+    expect(result).toEqual([{ ok: true }]);
+    expect(callCount).toBe(2);
+  });
+
+  it('does not retry on non-retryable errors', async () => {
+    let callCount = 0;
+    const mod = loadModule({
+      PredictionServiceClient: class {
+        predict() {
+          callCount++;
+          const err = new Error('Permission denied');
+          err.code = 7;
+          throw err;
+        }
+        listEndpoints() { return [[]]; }
+      },
+    });
+
+    await expect(mod.predict('ep-1', [{ x: 1 }])).rejects.toThrow('Vertex AI prediction failed: Permission denied');
+    expect(callCount).toBe(1);
+  });
+
+  it('fails after max retries exhausted', async () => {
+    let callCount = 0;
+    const mod = loadModule({
+      PredictionServiceClient: class {
+        predict() {
+          callCount++;
+          const err = new Error('Service unavailable');
+          err.code = 14;
+          throw err;
+        }
+        listEndpoints() { return [[]]; }
+      },
+    });
+
+    await expect(mod.predict('ep-1', [{ x: 1 }])).rejects.toThrow('Vertex AI prediction failed');
+    expect(callCount).toBe(3); // initial + 2 retries
+  });
+
+  it('returns empty array when predictions is empty', async () => {
+    const mod = loadModule({
+      PredictionServiceClient: class {
+        predict() { return [{ predictions: [] }]; }
+        listEndpoints() { return [[]]; }
+      },
+    });
+
+    const result = await mod.predict('ep-1', [{ x: 1 }]);
+    expect(result).toEqual([]);
+  });
+});
+
+// ── batchPredict() ───────────────────────────────────────────────────────────
+
+describe('batchPredict()', () => {
+  it('creates a batch prediction job', async () => {
+    const mod = loadModule({
+      JobServiceClient: class {
+        createBatchPredictionJob() {
+          return [{ name: 'projects/test/jobs/123', displayName: 'test-job', state: 'RUNNING', createTime: '2026-01-01' }];
+        }
+      },
+    });
+
+    const result = await mod.batchPredict({
+      modelId: 'model-1',
+      inputUri: 'gs://bucket/input.jsonl',
+      outputUri: 'gs://bucket/output/',
+    });
+
+    expect(result.name).toBe('projects/test/jobs/123');
+    expect(result.state).toBe('RUNNING');
+  });
+
+  it('throws when VERTEX_AI_PROJECT is not set', async () => {
+    delete process.env.VERTEX_AI_PROJECT;
+    const mod = loadModule();
+    await expect(mod.batchPredict({ modelId: 'm', inputUri: 'gs://a', outputUri: 'gs://b' }))
+      .rejects.toThrow('VERTEX_AI_PROJECT is not configured');
+  });
+
+  it('throws when modelId is missing', async () => {
+    const mod = loadModule();
+    await expect(mod.batchPredict({ inputUri: 'gs://a', outputUri: 'gs://b' }))
+      .rejects.toThrow('jobConfig.modelId is required');
+  });
+
+  it('throws when inputUri is missing', async () => {
+    const mod = loadModule();
+    await expect(mod.batchPredict({ modelId: 'm', outputUri: 'gs://b' }))
+      .rejects.toThrow('jobConfig.inputUri is required');
+  });
+
+  it('throws when outputUri is missing', async () => {
+    const mod = loadModule();
+    await expect(mod.batchPredict({ modelId: 'm', inputUri: 'gs://a' }))
+      .rejects.toThrow('jobConfig.outputUri is required');
+  });
+});
+
+// ── checkStatus() ────────────────────────────────────────────────────────────
+
+describe('checkStatus()', () => {
+  it('returns ok status when Vertex AI is reachable', async () => {
+    const mod = loadModule({
+      PredictionServiceClient: class {
+        predict() { return [{}]; }
+        listEndpoints({ pageSize }) {
+          expect(pageSize).toBe(1);
+          return [[{ name: 'endpoint-1' }]];
+        }
+      },
+    });
+
+    const result = await mod.checkStatus();
+    expect(result).toEqual({
+      status: 'ok',
+      project: 'test-project',
+      location: 'us-central1',
+      endpointCount: 1,
+    });
+  });
+
+  it('returns unconfigured when VERTEX_AI_PROJECT is not set', async () => {
+    delete process.env.VERTEX_AI_PROJECT;
+    const mod = loadModule();
+
+    const result = await mod.checkStatus();
+    expect(result.status).toBe('unconfigured');
+    expect(result.error).toContain('VERTEX_AI_PROJECT');
+  });
+
+  it('returns error status when Vertex AI is unreachable', async () => {
+    const mod = loadModule({
+      PredictionServiceClient: class {
+        predict() { return [{}]; }
+        listEndpoints() { throw new Error('Network error'); }
+      },
+    });
+
+    const result = await mod.checkStatus();
+    expect(result.status).toBe('error');
+    expect(result.error).toBe('Network error');
+    expect(result.project).toBe('test-project');
+  });
+});

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -46,6 +46,8 @@ export const plantsApi = {
   anomaly: (id) => request(`/plants/${id}/anomaly`),
   seasonalAdjustment: (id) => request(`/plants/${id}/seasonal-adjustment`),
   speciesCluster: (name) => request(`/species/${encodeURIComponent(name)}/cluster`),
+  careScore: (id) => request(`/plants/${id}/care-score`),
+  careScores: () => request('/ml/care-scores'),
   getFloorplan: () => request('/config/floorplan'),
   saveFloorplan: (imageUrl) => request('/config/floorplan', { method: 'PUT', body: JSON.stringify({ imageUrl }) }),
 }

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -44,6 +44,7 @@ export const plantsApi = {
   wateringRecommendation: (id) => request(`/plants/${id}/watering-recommendation`),
   healthPrediction: (id) => request(`/plants/${id}/health-prediction`),
   anomaly: (id) => request(`/plants/${id}/anomaly`),
+  seasonalAdjustment: (id) => request(`/plants/${id}/seasonal-adjustment`),
   getFloorplan: () => request('/config/floorplan'),
   saveFloorplan: (imageUrl) => request('/config/floorplan', { method: 'PUT', body: JSON.stringify({ imageUrl }) }),
 }

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -43,6 +43,7 @@ export const plantsApi = {
   wateringPattern: (id) => request(`/plants/${id}/watering-pattern`),
   wateringRecommendation: (id) => request(`/plants/${id}/watering-recommendation`),
   healthPrediction: (id) => request(`/plants/${id}/health-prediction`),
+  anomaly: (id) => request(`/plants/${id}/anomaly`),
   getFloorplan: () => request('/config/floorplan'),
   saveFloorplan: (imageUrl) => request('/config/floorplan', { method: 'PUT', body: JSON.stringify({ imageUrl }) }),
 }

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -41,6 +41,7 @@ export const plantsApi = {
   delete: (id) => request(`/plants/${id}`, { method: 'DELETE' }),
   water: (id) => request(`/plants/${id}/water`, { method: 'POST' }),
   wateringPattern: (id) => request(`/plants/${id}/watering-pattern`),
+  wateringRecommendation: (id) => request(`/plants/${id}/watering-recommendation`),
   getFloorplan: () => request('/config/floorplan'),
   saveFloorplan: (imageUrl) => request('/config/floorplan', { method: 'PUT', body: JSON.stringify({ imageUrl }) }),
 }

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -45,6 +45,7 @@ export const plantsApi = {
   healthPrediction: (id) => request(`/plants/${id}/health-prediction`),
   anomaly: (id) => request(`/plants/${id}/anomaly`),
   seasonalAdjustment: (id) => request(`/plants/${id}/seasonal-adjustment`),
+  speciesCluster: (name) => request(`/species/${encodeURIComponent(name)}/cluster`),
   getFloorplan: () => request('/config/floorplan'),
   saveFloorplan: (imageUrl) => request('/config/floorplan', { method: 'PUT', body: JSON.stringify({ imageUrl }) }),
 }

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -42,6 +42,7 @@ export const plantsApi = {
   water: (id) => request(`/plants/${id}/water`, { method: 'POST' }),
   wateringPattern: (id) => request(`/plants/${id}/watering-pattern`),
   wateringRecommendation: (id) => request(`/plants/${id}/watering-recommendation`),
+  healthPrediction: (id) => request(`/plants/${id}/health-prediction`),
   getFloorplan: () => request('/config/floorplan'),
   saveFloorplan: (imageUrl) => request('/config/floorplan', { method: 'PUT', body: JSON.stringify({ imageUrl }) }),
 }

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -30,6 +30,12 @@ const SUN_EXPOSURE_OPTIONS = [
   { value: 'part-sun', label: 'Part Sun' },
   { value: 'shade', label: 'Shade' },
 ]
+const POT_SIZES = [
+  { value: 'small', label: 'Small (< 15cm)' },
+  { value: 'medium', label: 'Medium (15-25cm)' },
+  { value: 'large', label: 'Large (25-40cm)' },
+  { value: 'xl', label: 'Extra Large (> 40cm)' },
+]
 const DAYS_OF_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 function today() { return new Date().toISOString().split('T')[0] }
@@ -273,6 +279,15 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
             </Col>
           </Row>
           <Row className="mb-3">
+            <Col md={6}>
+              <Form.Group>
+                <Form.Label>Pot Size</Form.Label>
+                <Form.Select value={form.potSize || ''} onChange={(e) => update('potSize', e.target.value || null)}>
+                  <option value="">— Select —</option>
+                  {POT_SIZES.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
+                </Form.Select>
+              </Form.Group>
+            </Col>
             <Col md={6}>
               <Form.Group>
                 <Form.Label>Sun Exposure</Form.Label>

--- a/src/layouts/components/menuData.js
+++ b/src/layouts/components/menuData.js
@@ -1,8 +1,11 @@
+const mlInsightsEnabled = import.meta.env.VITE_ML_INSIGHTS_ENABLED === 'true'
+
 export const menuItems = [
   { key: 'overview', label: 'Overview', isTitle: true },
   { key: 'dashboard', label: 'Dashboard', icon: '/icons/sprite.svg#home', url: '/' },
   { key: 'analytics', label: 'Analytics', icon: '/icons/sprite.svg#bar-chart-2', url: '/analytics' },
   { key: 'calendar', label: 'Care Calendar', icon: '/icons/sprite.svg#calendar', url: '/calendar' },
+  ...(mlInsightsEnabled ? [{ key: 'insights', label: 'Insights', icon: '/icons/sprite.svg#zap', url: '/insights' }] : []),
   { key: 'manage', label: 'Manage', isTitle: true },
   { key: 'settings', label: 'Settings', icon: '/icons/sprite.svg#settings', url: '/settings' },
 ]

--- a/src/pages/InsightsPage.jsx
+++ b/src/pages/InsightsPage.jsx
@@ -1,0 +1,262 @@
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { Row, Col, Card, Badge, Spinner, Button, ProgressBar } from 'react-bootstrap'
+import Chart from 'react-apexcharts'
+import { usePlantContext } from '../context/PlantContext.jsx'
+import { plantsApi } from '../api/plants.js'
+
+const GRADE_COLORS = { A: '#10b981', B: '#22c55e', C: '#f59e0b', D: '#ef4444', F: '#991b1b' }
+const PATTERN_COLORS = { optimal: '#10b981', over_watered: '#3b82f6', under_watered: '#ef4444', inconsistent: '#f59e0b', insufficient_data: '#9ca3af' }
+const PATTERN_LABELS = { optimal: 'Optimal', over_watered: 'Over-watered', under_watered: 'Under-watered', inconsistent: 'Inconsistent', insufficient_data: 'No Data' }
+
+export default function InsightsPage() {
+  const { plants } = usePlantContext()
+  const [careScores, setCareScores] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [expandedPlant, setExpandedPlant] = useState(null)
+  const [plantDetails, setPlantDetails] = useState({})
+
+  // Fetch aggregate care scores
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const scores = await plantsApi.careScores()
+        if (!cancelled) setCareScores(scores)
+      } catch { /* ignore */ }
+      if (!cancelled) setLoading(false)
+    }
+    load()
+    return () => { cancelled = true }
+  }, [plants])
+
+  // Lazy-load individual plant ML details on expand
+  const loadPlantDetails = useCallback(async (plantId) => {
+    if (plantDetails[plantId]) return
+    try {
+      const [pattern, prediction, anomaly, recommendation] = await Promise.all([
+        plantsApi.wateringPattern(plantId).catch(() => null),
+        plantsApi.healthPrediction(plantId).catch(() => null),
+        plantsApi.anomaly(plantId).catch(() => null),
+        plantsApi.wateringRecommendation(plantId).catch(() => null),
+      ])
+      setPlantDetails(prev => ({ ...prev, [plantId]: { pattern, prediction, anomaly, recommendation } }))
+    } catch { /* ignore */ }
+  }, [plantDetails])
+
+  const handleExpand = useCallback((plantId) => {
+    setExpandedPlant(prev => prev === plantId ? null : plantId)
+    loadPlantDetails(plantId)
+  }, [loadPlantDetails])
+
+  // Collection overview stats
+  const overview = useMemo(() => {
+    if (!careScores || careScores.length === 0) return null
+    const avgScore = Math.round(careScores.reduce((s, c) => s + c.score, 0) / careScores.length)
+    const atRisk = careScores.filter(c => c.score < 60)
+    return { avgScore, atRisk, total: careScores.length }
+  }, [careScores])
+
+  // Watering pattern distribution for donut chart
+  const patternDistribution = useMemo(() => {
+    if (!careScores) return null
+    // Group by patterns from loaded details, or show placeholder
+    const counts = { optimal: 0, over_watered: 0, under_watered: 0, inconsistent: 0, insufficient_data: 0 }
+    // Use grades as proxy: A/B likely optimal, C inconsistent, D/F problematic
+    for (const score of careScores) {
+      if (score.grade === 'A' || score.grade === 'B') counts.optimal++
+      else if (score.grade === 'C') counts.inconsistent++
+      else counts.under_watered++
+    }
+    return counts
+  }, [careScores])
+
+  // Minimum data check
+  const insufficientData = plants.length < 3 || (plants.reduce((sum, p) => sum + (p.wateringLog || []).length, 0) < 10)
+
+  if (insufficientData) {
+    const totalWaterings = plants.reduce((sum, p) => sum + (p.wateringLog || []).length, 0)
+    const plantsNeeded = Math.max(0, 3 - plants.length)
+    const wateringsNeeded = Math.max(0, 10 - totalWaterings)
+    return (
+      <div className="p-4">
+        <h2 className="mb-4">ML Insights</h2>
+        <Card className="text-center p-5">
+          <Card.Body>
+            <svg className="sa-icon sa-icon-5x text-muted mb-3"><use href="/icons/sprite.svg#bar-chart-2"></use></svg>
+            <h4>Not enough data yet</h4>
+            <p className="text-muted mb-4">Insights will appear as you log more plant care history.</p>
+            {plantsNeeded > 0 && <p>Add {plantsNeeded} more plant{plantsNeeded > 1 ? 's' : ''} to get started</p>}
+            {wateringsNeeded > 0 && <p>Log {wateringsNeeded} more watering{wateringsNeeded > 1 ? 's' : ''} to unlock health predictions</p>}
+            <ProgressBar now={Math.min(100, (totalWaterings / 10) * 100)} label={`${totalWaterings}/10 waterings`} className="mt-3" style={{ maxWidth: 300, margin: '0 auto' }} />
+          </Card.Body>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4">
+      <h2 className="mb-4">ML Insights</h2>
+
+      {loading ? (
+        <div className="text-center p-5"><Spinner animation="border" /></div>
+      ) : (
+        <>
+          {/* Collection Overview */}
+          {overview && (
+            <Row className="mb-4">
+              <Col md={4}>
+                <Card className="h-100">
+                  <Card.Body className="text-center">
+                    <h6 className="text-muted mb-2">Collection Health</h6>
+                    <div className="display-4 fw-bold" style={{ color: overview.avgScore >= 75 ? '#10b981' : overview.avgScore >= 60 ? '#f59e0b' : '#ef4444' }}>
+                      {overview.avgScore}
+                    </div>
+                    <small className="text-muted">{overview.total} plant{overview.total !== 1 ? 's' : ''}</small>
+                  </Card.Body>
+                </Card>
+              </Col>
+
+              <Col md={4}>
+                <Card className="h-100">
+                  <Card.Body>
+                    <h6 className="text-muted mb-2">At Risk</h6>
+                    {overview.atRisk.length === 0 ? (
+                      <p className="text-success mb-0">All plants healthy</p>
+                    ) : (
+                      <ul className="list-unstyled mb-0">
+                        {overview.atRisk.slice(0, 5).map(p => (
+                          <li key={p.plantId}>
+                            <Badge bg="danger" className="me-2">{p.grade}</Badge>
+                            {p.name} <small className="text-muted">({p.score})</small>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </Card.Body>
+                </Card>
+              </Col>
+
+              <Col md={4}>
+                <Card className="h-100">
+                  <Card.Body>
+                    <h6 className="text-muted mb-2">Pattern Breakdown</h6>
+                    {patternDistribution && (
+                      <Chart
+                        type="donut"
+                        height={180}
+                        series={Object.values(patternDistribution).filter(v => v > 0)}
+                        options={{
+                          labels: Object.keys(patternDistribution).filter(k => patternDistribution[k] > 0).map(k => PATTERN_LABELS[k]),
+                          colors: Object.keys(patternDistribution).filter(k => patternDistribution[k] > 0).map(k => PATTERN_COLORS[k]),
+                          legend: { position: 'bottom', fontSize: '11px' },
+                          dataLabels: { enabled: false },
+                        }}
+                      />
+                    )}
+                  </Card.Body>
+                </Card>
+              </Col>
+            </Row>
+          )}
+
+          {/* Per-Plant Scores */}
+          <h5 className="mb-3">Plant Scores</h5>
+          {careScores && careScores.map(score => (
+            <Card key={score.plantId} className="mb-2">
+              <Card.Body
+                className="d-flex align-items-center justify-content-between"
+                style={{ cursor: 'pointer' }}
+                onClick={() => handleExpand(score.plantId)}
+                role="button"
+                aria-expanded={expandedPlant === score.plantId}
+                aria-label={`${score.name} care score details`}
+              >
+                <div className="d-flex align-items-center gap-3">
+                  <Badge
+                    style={{ backgroundColor: GRADE_COLORS[score.grade], fontSize: '1.1rem', width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                  >
+                    {score.grade}
+                  </Badge>
+                  <div>
+                    <strong>{score.name}</strong>
+                    {score.species && <small className="text-muted ms-2">{score.species}</small>}
+                  </div>
+                </div>
+                <div className="d-flex align-items-center gap-3">
+                  <span className="fw-bold">{score.score}</span>
+                  <svg className="sa-icon" style={{ transform: expandedPlant === score.plantId ? 'rotate(180deg)' : '' }}>
+                    <use href="/icons/sprite.svg#chevron-down"></use>
+                  </svg>
+                </div>
+              </Card.Body>
+
+              {expandedPlant === score.plantId && (
+                <Card.Footer>
+                  {!plantDetails[score.plantId] ? (
+                    <div className="text-center p-3"><Spinner size="sm" /></div>
+                  ) : (
+                    <Row>
+                      <Col md={3}>
+                        <h6>Dimensions</h6>
+                        {score.dimensions && (
+                          <ul className="list-unstyled small">
+                            <li>Consistency: {score.dimensions.consistency}</li>
+                            <li>Timing: {score.dimensions.timing}</li>
+                            <li>Health: {score.dimensions.healthOutcome}</li>
+                            <li>Responsiveness: {score.dimensions.responsiveness}</li>
+                          </ul>
+                        )}
+                      </Col>
+                      <Col md={3}>
+                        <h6>Watering Pattern</h6>
+                        {plantDetails[score.plantId].pattern ? (
+                          <>
+                            <Badge style={{ backgroundColor: PATTERN_COLORS[plantDetails[score.plantId].pattern.pattern] }}>
+                              {PATTERN_LABELS[plantDetails[score.plantId].pattern.pattern] || plantDetails[score.plantId].pattern.pattern}
+                            </Badge>
+                            <ul className="list-unstyled small mt-2">
+                              {(plantDetails[score.plantId].pattern.contributingFactors || []).map((f, i) => <li key={i}>{f}</li>)}
+                            </ul>
+                          </>
+                        ) : <small className="text-muted">Unavailable</small>}
+                      </Col>
+                      <Col md={3}>
+                        <h6>Health Prediction</h6>
+                        {plantDetails[score.plantId].prediction ? (
+                          <>
+                            <p className="mb-1">
+                              In 2 weeks: <strong>{plantDetails[score.plantId].prediction.predictedHealth}</strong>
+                              {' '}({plantDetails[score.plantId].prediction.trend})
+                            </p>
+                            <ul className="list-unstyled small">
+                              {(plantDetails[score.plantId].prediction.keyRisks || []).map((r, i) => <li key={i}>{r}</li>)}
+                            </ul>
+                          </>
+                        ) : <small className="text-muted">Unavailable</small>}
+                      </Col>
+                      <Col md={3}>
+                        <h6>Recommendation</h6>
+                        {plantDetails[score.plantId].recommendation ? (
+                          <>
+                            <p className="mb-1">
+                              Every <strong>{plantDetails[score.plantId].recommendation.recommendedFrequencyDays}</strong> days
+                              {plantDetails[score.plantId].recommendation.confidenceInterval &&
+                                ` (${plantDetails[score.plantId].recommendation.confidenceInterval[0]}-${plantDetails[score.plantId].recommendation.confidenceInterval[1]})`
+                              }
+                            </p>
+                            <small className="text-muted">{plantDetails[score.plantId].recommendation.basis}</small>
+                          </>
+                        ) : <small className="text-muted">Unavailable</small>}
+                      </Col>
+                    </Row>
+                  )}
+                </Card.Footer>
+              )}
+            </Card>
+          ))}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -7,6 +7,9 @@ const DashboardPage = lazy(() => import('../pages/DashboardPage.jsx'))
 const AnalyticsPage = lazy(() => import('../pages/AnalyticsPage.jsx'))
 const CalendarPage = lazy(() => import('../pages/CalendarPage.jsx'))
 const SettingsPage = lazy(() => import('../pages/SettingsPage.jsx'))
+const InsightsPage = lazy(() => import('../pages/InsightsPage.jsx'))
+
+const mlInsightsEnabled = import.meta.env.VITE_ML_INSIGHTS_ENABLED === 'true'
 
 export const routes = [
   {
@@ -21,6 +24,7 @@ export const routes = [
       { index: true, element: <DashboardPage /> },
       { path: 'analytics', element: <AnalyticsPage /> },
       { path: 'calendar', element: <CalendarPage /> },
+      ...(mlInsightsEnabled ? [{ path: 'insights', element: <InsightsPage /> }] : []),
       { path: 'settings', element: <SettingsPage /> },
     ],
   },


### PR DESCRIPTION
- Add @google-cloud/aiplatform SDK dependency
- Create vertexai.js with predict(), batchPredict(), checkStatus() helpers
- Add GET /ml/status health-check endpoint for Vertex AI connectivity
- Include retry logic for transient gRPC errors (UNAVAILABLE, RESOURCE_EXHAUSTED, DEADLINE_EXCEEDED)
- Add comprehensive unit tests for vertexai.js and /ml/status route

https://claude.ai/code/session_01EXhz919pQMpTG8JGWxf61w