### PR TITLE
Move watering rec button and fix photo on plant create

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -808,6 +808,10 @@ app.post('/plants', requireUser, async (req, res) => {
   try {
     const now = new Date().toISOString();
     const { imageBase64: _img, ...body } = req.body;
+    if (body.imageUrl) {
+      try { body.imageUrl = body.imageUrl.split('?')[0]; } catch {}
+      body.photoLog = [{ url: body.imageUrl, date: now, type: 'growth', analysis: null }];
+    }
     const data = { ...body, createdAt: now, updatedAt: now };
     const docRef = await userPlants(req.userId).add(data);
     res.status(201).json({ id: docRef.id, ...data });

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -538,23 +538,19 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
               </div>
             )
           })()}
-          {onWater && (
-            <div className="d-flex justify-content-center mb-3">
+          <div className="d-flex justify-content-center gap-2 mb-3">
+            {onWater && (
               <Button variant="outline-info" size="sm" onClick={() => onWater(plant.id)}>
                 <svg className="sa-icon me-1" style={{ width: 12, height: 12 }}><use href="/icons/sprite.svg#droplet"></use></svg>
                 Mark as Watered
               </Button>
-            </div>
-          )}
-          {/* AI Watering Recommendation */}
+            )}
+            <Button variant="outline-success" size="sm" onClick={handleGetWateringRec} disabled={wateringRecLoading}>
+              {wateringRecLoading ? <Spinner size="sm" className="me-1" /> : <svg className="sa-icon me-1" style={{ width: 12, height: 12 }}><use href="/icons/sprite.svg#zap"></use></svg>}
+              {wateringRecLoading ? 'Loading...' : wateringRec ? 'Refresh' : 'Get Watering Recommendation'}
+            </Button>
+          </div>
           <div className="mb-3">
-            <div className="d-flex align-items-center justify-content-between mb-2">
-              <h6 className="text-muted text-uppercase fs-xs fw-600 mb-0">AI Watering Advice</h6>
-              <Button variant="outline-success" size="sm" onClick={handleGetWateringRec} disabled={wateringRecLoading}>
-                {wateringRecLoading ? <Spinner size="sm" className="me-1" /> : <svg className="sa-icon me-1" style={{ width: 12, height: 12 }}><use href="/icons/sprite.svg#zap"></use></svg>}
-                {wateringRecLoading ? 'Loading...' : wateringRec ? 'Refresh' : 'Get Watering Recommendation'}
-              </Button>
-            </div>
             {wateringRecError && <p className="text-danger fs-sm">{wateringRecError}</p>}
             {wateringRec && (
               <div className="p-2 rounded border bg-body-tertiary fs-sm">


### PR DESCRIPTION
## Summary
- **Watering tab**: Removed "AI Watering Advice" label, moved "Get Watering Recommendation" button next to "Mark as Watered"
- **Backend**: Initialize `photoLog` with the plant's image on `POST /plants` so photos appear in the Care tab for newly created plants

## Test plan
- [ ] Open Watering tab — both buttons should be side by side, no "AI Watering Advice" heading
- [ ] Create a new plant with a photo — open Care tab and verify the photo appears in Photo History

🤖 Generated with [Claude Code](https://claude.com/claude-code)