### PR TITLE
Move recommendations to own tab and fix phantom photos

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -866,24 +866,26 @@ app.put('/plants/:id', requireUser, async (req, res) => {
       updates.mlCache = mlCache;
     }
 
-    // Add images to photoLog for growth history
+    // Add images to photoLog for growth history — only when image actually changed
     if (body.imageUrl) {
       const newImageNorm = body.imageUrl.split('?')[0];
       const existingImageNorm = existing.imageUrl ? existing.imageUrl.split('?')[0] : null;
-      const photoLog = [...(existing.photoLog || [])];
-      // Push old image if being replaced
-      if (existingImageNorm && newImageNorm !== existingImageNorm) {
-        const alreadyInLog = photoLog.some((e) => e.url?.split('?')[0] === existingImageNorm);
-        if (!alreadyInLog) {
-          photoLog.push({ url: existingImageNorm, date: existing.updatedAt || new Date().toISOString(), type: 'growth', analysis: null });
+      if (newImageNorm !== existingImageNorm) {
+        const photoLog = [...(existing.photoLog || [])];
+        // Push old image if being replaced
+        if (existingImageNorm) {
+          const alreadyInLog = photoLog.some((e) => e.url?.split('?')[0] === existingImageNorm);
+          if (!alreadyInLog) {
+            photoLog.push({ url: existingImageNorm, date: existing.updatedAt || new Date().toISOString(), type: 'growth', analysis: null });
+          }
         }
+        // Push new image
+        const newAlreadyInLog = photoLog.some((e) => e.url?.split('?')[0] === newImageNorm);
+        if (!newAlreadyInLog) {
+          photoLog.push({ url: newImageNorm, date: new Date().toISOString(), type: 'growth', analysis: null });
+        }
+        updates.photoLog = photoLog;
       }
-      // Always push new image to photoLog
-      const newAlreadyInLog = photoLog.some((e) => e.url?.split('?')[0] === newImageNorm);
-      if (!newAlreadyInLog) {
-        photoLog.push({ url: newImageNorm, date: new Date().toISOString(), type: 'growth', analysis: null });
-      }
-      updates.photoLog = photoLog;
     }
 
     await ref.set(updates, { merge: true });

--- a/src/__tests__/PlantModal.test.jsx
+++ b/src/__tests__/PlantModal.test.jsx
@@ -321,17 +321,19 @@ describe('PlantModal', () => {
 
   // ── Care tab ──────────────────────────────────────────────────────────────
 
-  it('shows Get Recommendations button on the Care tab', () => {
+  // ── Recommendations tab ──────────────────────────────────────────────────
+
+  it('shows Get Recommendations button on the Recommendations tab', () => {
     renderModal({ plant: existingPlant })
-    fireEvent.click(screen.getByText('Care'))
-    expect(screen.getByRole('button', { name: /get|refresh/i })).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Recommendations'))
+    expect(screen.getByRole('button', { name: /get recommendations|refresh/i })).toBeInTheDocument()
   })
 
   it('calls recommendApi.get and shows results when Get Recommendations is clicked', async () => {
     const { recommendApi } = await import('../api/plants.js')
     renderModal({ plant: existingPlant })
-    fireEvent.click(screen.getByText('Care'))
-    fireEvent.click(screen.getByRole('button', { name: /get|refresh/i }))
+    fireEvent.click(screen.getByText('Recommendations'))
+    fireEvent.click(screen.getByRole('button', { name: /get recommendations|refresh/i }))
     await waitFor(() => expect(recommendApi.get).toHaveBeenCalledWith('Fern', 'Nephrolepis', expect.anything()))
     expect(await screen.findByText('A lovely fern.')).toBeInTheDocument()
     expect(screen.getByText('Water weekly.')).toBeInTheDocument()
@@ -341,8 +343,8 @@ describe('PlantModal', () => {
     const { recommendApi } = await import('../api/plants.js')
     recommendApi.get.mockRejectedValueOnce(new Error('Network error'))
     renderModal({ plant: existingPlant })
-    fireEvent.click(screen.getByText('Care'))
-    fireEvent.click(screen.getByRole('button', { name: /get|refresh/i }))
+    fireEvent.click(screen.getByText('Recommendations'))
+    fireEvent.click(screen.getByRole('button', { name: /get recommendations|refresh/i }))
     expect(await screen.findByText(/network error/i)).toBeInTheDocument()
   })
 

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -341,7 +341,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       {/* Tab nav for editing */}
       {isEditing && (
         <Nav variant="tabs" className="px-3 pt-2">
-          {[{ id: 'edit', label: 'Plant' }, { id: 'watering', label: 'Watering' }, { id: 'care', label: 'Care' }].map((tab) => (
+          {[{ id: 'edit', label: 'Plant' }, { id: 'watering', label: 'Watering' }, { id: 'care', label: 'Care' }, { id: 'recommendations', label: 'Recommendations' }].map((tab) => (
             <Nav.Item key={tab.id}>
               <Nav.Link active={activeTab === tab.id} onClick={() => setActiveTab(tab.id)}>{tab.label}</Nav.Link>
             </Nav.Item>
@@ -676,14 +676,17 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
             )
           })()}
 
-          <hr />
+        </Modal.Body>
+      )}
 
-          {/* AI Recommendations */}
+      {/* Recommendations tab */}
+      {isEditing && activeTab === 'recommendations' && (
+        <Modal.Body>
           <div className="d-flex align-items-center justify-content-between mb-3">
-            <h6 className="text-muted text-uppercase fs-xs fw-600 mb-0">Recommendations</h6>
+            <h6 className="text-muted text-uppercase fs-xs fw-600 mb-0">AI Care Recommendations</h6>
             <Button variant="outline-success" size="sm" onClick={handleGetRecommendations} disabled={careLoading}>
               {careLoading ? <Spinner size="sm" className="me-1" /> : <svg className="sa-icon me-1" style={{ width: 12, height: 12 }}><use href="/icons/sprite.svg#zap"></use></svg>}
-              {careLoading ? 'Loading...' : careData ? 'Refresh' : 'Get'}
+              {careLoading ? 'Loading...' : careData ? 'Refresh' : 'Get Recommendations'}
             </Button>
           </div>
           {careError && <p className="text-danger text-center fs-sm">{careError}</p>}
@@ -705,16 +708,34 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
                   </Col>
                 ))}
               </Row>
+              {careData.commonIssues?.length > 0 && (
+                <>
+                  <h6 className="text-muted text-uppercase fs-xs fw-600 mt-2">Common Issues</h6>
+                  <ul className="list-unstyled">
+                    {careData.commonIssues.map((issue, i) => (
+                      <li key={i} className="d-flex gap-2 fs-xs text-muted mb-1">
+                        <span className="text-warning">•</span>{issue}
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
               {careData.tips?.length > 0 && (
-                <ul className="list-unstyled mt-1">
-                  {careData.tips.map((tip, i) => (
-                    <li key={i} className="d-flex gap-2 fs-xs text-muted mb-1">
-                      <span className="text-success">•</span>{tip}
-                    </li>
-                  ))}
-                </ul>
+                <>
+                  <h6 className="text-muted text-uppercase fs-xs fw-600">Tips</h6>
+                  <ul className="list-unstyled">
+                    {careData.tips.map((tip, i) => (
+                      <li key={i} className="d-flex gap-2 fs-xs text-muted mb-1">
+                        <span className="text-success">•</span>{tip}
+                      </li>
+                    ))}
+                  </ul>
+                </>
               )}
             </div>
+          )}
+          {!careData && !careLoading && !careError && (
+            <p className="text-muted text-center py-4">Click "Get Recommendations" for AI-powered care advice tailored to your plant.</p>
           )}
         </Modal.Body>
       )}


### PR DESCRIPTION
## Summary
- **Recommendations tab**: Moved AI care recommendations out of Care into a dedicated 4th tab, with common issues and tips sections
- **Phantom photos fix**: photoLog entries now only added when `imageUrl` actually changes (normalized URL comparison), preventing duplicates on every save
- Tests updated for new tab structure

## Test plan
- [ ] Verify 4 tabs show: Plant, Watering, Care, Recommendations
- [ ] Care tab shows health/maturity + photos only, no recommendations
- [ ] Recommendations tab shows Get Recommendations button and displays results
- [ ] Save a plant without changing its photo — verify no new phantom entry in Photo History

🤖 Generated with [Claude Code](https://claude.com/claude-code)