### PR TITLE
Add gnome watering animation, plant bounce, and season overlay

### DIFF
--- a/src/assets/sass/app/_leaflet-overrides.scss
+++ b/src/assets/sass/app/_leaflet-overrides.scss
@@ -78,6 +78,63 @@
   animation: pulse-ring 1.5s ease-in-out infinite;
 }
 
+@keyframes plant-bounce {
+  0%, 100% { transform: translateY(0); }
+  25% { transform: translateY(-6px); }
+  50% { transform: translateY(0); }
+  75% { transform: translateY(-3px); }
+}
+
+.plant-lf-attention {
+  animation: plant-bounce 1.8s ease-in-out infinite;
+}
+
+/* Gnome watering animation */
+@keyframes gnome-walk {
+  0%, 100% { transform: translateY(0) scaleX(var(--gnome-dir, 1)); }
+  25% { transform: translateY(-3px) scaleX(var(--gnome-dir, 1)); }
+  50% { transform: translateY(0) scaleX(var(--gnome-dir, 1)); }
+  75% { transform: translateY(-2px) scaleX(var(--gnome-dir, 1)); }
+}
+
+@keyframes gnome-water {
+  0%, 100% { transform: rotate(0deg); }
+  30% { transform: rotate(-25deg); }
+  60% { transform: rotate(-25deg); }
+}
+
+@keyframes water-splash {
+  0% { opacity: 0; transform: translateY(-4px); }
+  30% { opacity: 1; }
+  100% { opacity: 0; transform: translateY(8px); }
+}
+
+.gnome-marker {
+  transition: none;
+  z-index: 9999 !important;
+}
+
+.gnome-body {
+  font-size: 28px;
+  line-height: 1;
+  animation: gnome-walk 0.4s ease-in-out infinite;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
+}
+
+.gnome-body.watering {
+  animation: gnome-water 0.8s ease-in-out;
+}
+
+.gnome-splash {
+  position: absolute;
+  bottom: -4px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 14px;
+  animation: water-splash 0.6s ease-out forwards;
+  pointer-events: none;
+}
+
 .lf-room-label {
   background: transparent !important;
   border: none !important;

--- a/src/components/FloorplanPanel.jsx
+++ b/src/components/FloorplanPanel.jsx
@@ -8,7 +8,7 @@ import HouseWeatherFrame from './HouseWeatherFrame.jsx'
 
 const Floorplan3D = lazy(() => import('./Floorplan3D.jsx'))
 
-export default function FloorplanPanel({ onPlantClick, onFloorplanClick }) {
+export default function FloorplanPanel({ onPlantClick, onFloorplanClick, gnomeWaterRef }) {
   const {
     plants, floors, activeFloorId, setActiveFloorId,
     weather, location, handleFloorRoomsChange,
@@ -153,6 +153,7 @@ export default function FloorplanPanel({ onPlantClick, onFloorplanClick }) {
             onMarkerDrag={handleLocalDrag}
             editMode={false}
             onRoomsChange={handleFloorRoomsChange}
+            gnomeWaterRef={gnomeWaterRef}
           />
         )}
         {activeFloor && viewMode === '3d' && (

--- a/src/components/LeafletFloorplan.jsx
+++ b/src/components/LeafletFloorplan.jsx
@@ -28,11 +28,13 @@ function getPlantEmoji(plant) {
 function makePlantIcon(plant, weather, floors) {
   const { color, daysUntil } = getWateringStatus(plant, weather, floors)
   const overdue = daysUntil < 0
+  const attention = daysUntil >= 0 && daysUntil <= 2
   const emoji = getPlantEmoji(plant)
+  const cls = overdue ? ' plant-lf-overdue' : attention ? ' plant-lf-attention' : ''
 
   return L.divIcon({
     className: 'plant-lf-icon',
-    html: `<div class="plant-lf-inner${overdue ? ' plant-lf-overdue' : ''}"
+    html: `<div class="plant-lf-inner${cls}"
                 style="width:32px;height:32px;border-radius:50%;
                        border:2px solid ${color};
                        background:#fff;
@@ -90,6 +92,7 @@ export default function LeafletFloorplan({
   onMarkerDrag,
   editMode = false,
   onRoomsChange,
+  gnomeWaterRef,
 }) {
   const containerRef   = useRef(null)
   const mapRef         = useRef(null)
@@ -462,6 +465,109 @@ export default function LeafletFloorplan({
       }
     }
   }, [plants, weather, floors])
+
+  // ── Gnome watering animation ──────────────────────────────────────────────
+  useEffect(() => {
+    if (!gnomeWaterRef) return
+    gnomeWaterRef.current = async (targetPlants, onComplete) => {
+      const map = mapRef.current
+      if (!map || !targetPlants.length) { onComplete?.(); return }
+
+      // Sort plants left-to-right for a natural walking path
+      const sorted = [...targetPlants].sort((a, b) => a.x - b.x)
+
+      // Create gnome marker
+      const startX = Math.max(0, sorted[0].x - 10)
+      const startY = sorted[0].y
+      const gnomeIcon = L.divIcon({
+        className: 'gnome-marker',
+        html: `<div class="gnome-body">🧑‍🌾</div>`,
+        iconSize: [32, 32],
+        iconAnchor: [16, 28],
+      })
+      const gnome = L.marker(toLL(startX, startY), { icon: gnomeIcon, interactive: false, zIndexOffset: 9999 })
+      gnome.addTo(map)
+
+      const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+      // Walk to each plant and water it
+      for (let i = 0; i < sorted.length; i++) {
+        const plant = sorted[i]
+        const targetLL = toLL(plant.x, plant.y)
+
+        // Determine walking direction for flip
+        const gnomePos = fromLL(gnome.getLatLng())
+        const dir = plant.x >= gnomePos.x ? 1 : -1
+
+        // Update gnome direction
+        gnome.setIcon(L.divIcon({
+          className: 'gnome-marker',
+          html: `<div class="gnome-body" style="--gnome-dir:${dir}">🧑‍🌾</div>`,
+          iconSize: [32, 32],
+          iconAnchor: [16, 28],
+        }))
+
+        // Animate walk: move in steps
+        const startLL = gnome.getLatLng()
+        const steps = 20
+        const duration = 600
+        for (let s = 1; s <= steps; s++) {
+          const t = s / steps
+          const lat = startLL.lat + (targetLL.lat - startLL.lat) * t
+          const lng = startLL.lng + (targetLL.lng - startLL.lng) * t
+          gnome.setLatLng([lat, lng])
+          await sleep(duration / steps)
+        }
+
+        // Watering animation
+        gnome.setIcon(L.divIcon({
+          className: 'gnome-marker',
+          html: `<div class="gnome-body watering" style="--gnome-dir:${dir}">🧑‍🌾</div>
+                 <div class="gnome-splash">💧</div>`,
+          iconSize: [32, 32],
+          iconAnchor: [16, 28],
+        }))
+        await sleep(800)
+
+        // Brief flash on the plant marker
+        const plantMarker = plantMarkersRef.current[plant.id]
+        if (plantMarker) {
+          const el = plantMarker.getElement()
+          if (el) {
+            el.style.transition = 'transform 0.2s'
+            el.style.transform = 'scale(1.3)'
+            setTimeout(() => { el.style.transform = '' }, 300)
+          }
+        }
+
+        // Reset gnome to walking
+        gnome.setIcon(L.divIcon({
+          className: 'gnome-marker',
+          html: `<div class="gnome-body" style="--gnome-dir:${dir}">🧑‍🌾</div>`,
+          iconSize: [32, 32],
+          iconAnchor: [16, 28],
+        }))
+        await sleep(200)
+      }
+
+      // Walk gnome off screen to the right
+      const lastPos = fromLL(gnome.getLatLng())
+      const exitLL = toLL(Math.min(100, lastPos.x + 15), lastPos.y)
+      const startExit = gnome.getLatLng()
+      const exitSteps = 15
+      for (let s = 1; s <= exitSteps; s++) {
+        const t = s / exitSteps
+        gnome.setLatLng([
+          startExit.lat + (exitLL.lat - startExit.lat) * t,
+          startExit.lng + (exitLL.lng - startExit.lng) * t,
+        ])
+        await sleep(400 / exitSteps)
+      }
+
+      map.removeLayer(gnome)
+      onComplete?.()
+    }
+  }, [gnomeWaterRef])
 
   // ── Pending room name prompt ──────────────────────────────────────────────
   const handleConfirmRoom = () => {

--- a/src/components/PlantListPanel.jsx
+++ b/src/components/PlantListPanel.jsx
@@ -67,10 +67,24 @@ function PlantCard({ plant, onClick, onWater, weather, floors }) {
   )
 }
 
-export default function PlantListPanel({ onPlantClick, onAddPlant }) {
+export default function PlantListPanel({ onPlantClick, onAddPlant, gnomeWaterRef }) {
   const { plants, floors, activeFloorId, weather, handleWaterPlant, handleBatchWater, plantsLoading } = usePlantContext()
   const [searchTerm, setSearchTerm] = useState('')
   const [roomFilter, setRoomFilter] = useState(null)
+  const [gnomeActive, setGnomeActive] = useState(false)
+
+  const handleGnomeBatchWater = useCallback((targetPlants) => {
+    if (gnomeActive) return
+    if (gnomeWaterRef?.current) {
+      setGnomeActive(true)
+      gnomeWaterRef.current(targetPlants, () => {
+        handleBatchWater(targetPlants.map((p) => p.id))
+        setGnomeActive(false)
+      })
+    } else {
+      handleBatchWater(targetPlants.map((p) => p.id))
+    }
+  }, [gnomeActive, gnomeWaterRef, handleBatchWater])
 
   const floorPlants = useMemo(() => {
     if (!activeFloorId) return plants
@@ -146,10 +160,11 @@ export default function PlantListPanel({ onPlantClick, onAddPlant }) {
                 variant="outline-info"
                 size="sm"
                 className="w-100"
-                onClick={() => handleBatchWater(floorPlants.map((p) => p.id))}
+                disabled={gnomeActive}
+                onClick={() => handleGnomeBatchWater(floorPlants)}
               >
-                <svg className="sa-icon me-1" style={{ width: 12, height: 12 }}><use href="/icons/sprite.svg#droplet"></use></svg>
-                Water All on Floor ({floorPlants.length} plants)
+                {gnomeActive ? <span className="spinner-border spinner-border-sm me-1" /> : <svg className="sa-icon me-1" style={{ width: 12, height: 12 }}><use href="/icons/sprite.svg#droplet"></use></svg>}
+                {gnomeActive ? 'Watering...' : `Water All on Floor (${floorPlants.length} plants)`}
               </Button>
             </div>
           )}
@@ -219,7 +234,8 @@ export default function PlantListPanel({ onPlantClick, onAddPlant }) {
                             variant="outline-primary"
                             size="sm"
                             className="py-0 px-2 fs-xs"
-                            onClick={() => handleBatchWater(grouped[room].map((p) => p.id))}
+                            disabled={gnomeActive}
+                            onClick={() => handleGnomeBatchWater(grouped[room])}
                           >
                             <svg className="sa-icon me-1" style={{ width: 10, height: 10 }}><use href="/icons/sprite.svg#droplet"></use></svg>
                             Water all

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import { Row, Col, Alert } from 'react-bootstrap'
 import { usePlantContext } from '../context/PlantContext.jsx'
 import FloorplanPanel from '../components/FloorplanPanel.jsx'
@@ -6,7 +6,8 @@ import PlantListPanel from '../components/PlantListPanel.jsx'
 import PlantModal from '../components/PlantModal.jsx'
 
 export default function DashboardPage() {
-  const { floors, activeFloorId, weather, handleSavePlant, handleDeletePlant, handleWaterPlant, isGuest, plantsError, plants, plantsLoading } = usePlantContext()
+  const { floors, activeFloorId, weather, handleSavePlant, handleDeletePlant, handleWaterPlant, handleBatchWater, isGuest, plantsError, plants, plantsLoading } = usePlantContext()
+  const gnomeWaterRef = useRef(null)
 
   const hasFloors = floors.length > 0
 
@@ -86,11 +87,13 @@ export default function DashboardPage() {
             <FloorplanPanel
               onPlantClick={handlePlantClick}
               onFloorplanClick={handleFloorplanClick}
+              gnomeWaterRef={gnomeWaterRef}
             />
             <div className="mt-4">
               <PlantListPanel
                 onPlantClick={handlePlantClick}
                 onAddPlant={handleAddPlant}
+                gnomeWaterRef={gnomeWaterRef}
               />
             </div>
           </>

--- a/src/pages/ForecastPage.jsx
+++ b/src/pages/ForecastPage.jsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { Row, Col, Badge } from 'react-bootstrap'
 import { usePlantContext } from '../context/PlantContext.jsx'
 import { isOutdoor } from '../utils/watering.js'
+import SeasonBadge from '../components/SeasonBadge.jsx'
 
 function dayLabel(dateStr, index) {
   if (index === 0) return 'Today'
@@ -46,6 +47,9 @@ export default function ForecastPage() {
               <div>
                 <h2 className="mb-0">{weather.current.temp}°{weather.unit === 'fahrenheit' ? 'F' : 'C'}</h2>
                 <span className="text-muted">{weather.current.condition.label}</span>
+              </div>
+              <div className="ms-auto">
+                <SeasonBadge lat={weather.location?.lat} />
               </div>
             </div>
           </div></div>


### PR DESCRIPTION
## Summary
- **Gnome animation**: When "Water All on Floor" or room "Water all" is clicked, an animated gnome 🧑‍🌾 walks across the floorplan to each plant, does a watering animation with 💧 splash, then walks off. Actual watering happens after the animation completes.
- **Plant bounce**: Plants due today or within 2 days get a gentle bounce animation on the floorplan to draw attention (overdue plants keep their existing pulse-ring).
- **Season on forecast**: SeasonBadge with animated particles now shows in the Current Conditions panel on the Forecast page.

## Test plan
- [ ] Click "Water All on Floor" — gnome walks to each plant and waters them
- [ ] Plants due today/soon bounce on the floorplan
- [ ] Overdue plants still pulse red (unchanged)
- [ ] Forecast page shows season badge next to current conditions
- [ ] Button disabled during gnome animation, re-enabled after

🤖 Generated with [Claude Code](https://claude.com/claude-code)