### PR TITLE
Fix gnome water marker position and add season to dashboard weather

### DIFF
--- a/src/components/HouseWeatherFrame.jsx
+++ b/src/components/HouseWeatherFrame.jsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import SeasonBadge from './SeasonBadge.jsx'
 
 const WEATHER_CONFIGS = {
   sunny:  { sky: '#87CEEB', ground: '#90C695', sunVisible: true, clouds: 0, rainDrops: 0, snowFlakes: 0 },
@@ -182,6 +183,7 @@ export default function HouseWeatherFrame({ weather, location, onLocationClick, 
             <span style={{ fontSize: '1.2rem' }}>{weather.current.condition.emoji}</span>
             <strong>{temp}°{unit}</strong>
             <span style={{ opacity: 0.8 }}>{label}</span>
+            <SeasonBadge lat={weather.location?.lat} light />
             {location?.name && (
               <span
                 onClick={onLocationClick}

--- a/src/components/LeafletFloorplan.jsx
+++ b/src/components/LeafletFloorplan.jsx
@@ -529,14 +529,14 @@ export default function LeafletFloorplan({
         }))
         await sleep(800)
 
-        // Brief flash on the plant marker
+        // Brief flash on the plant marker inner div (not the Leaflet container which uses transform for positioning)
         const plantMarker = plantMarkersRef.current[plant.id]
         if (plantMarker) {
-          const el = plantMarker.getElement()
-          if (el) {
-            el.style.transition = 'transform 0.2s'
-            el.style.transform = 'scale(1.3)'
-            setTimeout(() => { el.style.transform = '' }, 300)
+          const inner = plantMarker.getElement()?.querySelector('.plant-lf-inner')
+          if (inner) {
+            inner.style.transition = 'transform 0.2s'
+            inner.style.transform = 'scale(1.3)'
+            setTimeout(() => { inner.style.transform = '' }, 300)
           }
         }
 

--- a/src/components/SeasonBadge.jsx
+++ b/src/components/SeasonBadge.jsx
@@ -45,7 +45,7 @@ const ANIMATIONS = `
 }
 `
 
-export default function SeasonBadge({ lat }) {
+export default function SeasonBadge({ lat, light = false }) {
   const season = useMemo(() => getSeason(lat), [lat])
 
   if (!season) return null
@@ -61,9 +61,9 @@ export default function SeasonBadge({ lat }) {
         gap: 4,
         padding: '2px 10px 2px 6px',
         borderRadius: 20,
-        background: cfg.bg,
-        border: `1px solid ${cfg.border}`,
-        color: cfg.color,
+        background: light ? 'rgba(255,255,255,0.15)' : cfg.bg,
+        border: `1px solid ${light ? 'rgba(255,255,255,0.25)' : cfg.border}`,
+        color: light ? '#fff' : cfg.color,
         fontSize: '0.75rem',
         fontWeight: 600,
         overflow: 'hidden',


### PR DESCRIPTION
## Summary
- **Fix**: Plant markers no longer fly to the corner during gnome watering — now targets the inner div instead of the Leaflet positioning container
- **Season badge**: Now shows in the dashboard weather bar (HouseWeatherFrame) with a light variant for dark backgrounds
- **SeasonBadge**: Added `light` prop for use on dark overlays

## Test plan
- [ ] Click Water All — plants stay in place during gnome animation
- [ ] Season badge visible in dashboard weather bar
- [ ] Season badge still visible in topbar and forecast page

🤖 Generated with [Claude Code](https://claude.com/claude-code)