### PR TITLE
Add AI-driven watering frequency with bulk recalculate

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -161,6 +161,8 @@ async function signPlantData(data) {
   return data;
 }
 
+const OUTDOOR_ROOMS = new Set(['Garden', 'Balcony', 'Outdoors', 'Patio', 'Terrace', 'Deck', 'Yard', 'Courtyard', 'Porch', 'Veranda']);
+
 const app = express();
 app.set('trust proxy', true); // Behind API Gateway — trust X-Forwarded-For
 app.use(express.json({ limit: '10mb' }));
@@ -382,30 +384,35 @@ Rules:
 const WATERING_RECOMMEND_SCHEMA = {
   type: SchemaType.OBJECT,
   properties: {
-    amount:       { type: SchemaType.STRING },
-    frequency:    { type: SchemaType.STRING },
-    method:       { type: SchemaType.STRING },
-    seasonalTips: { type: SchemaType.STRING },
-    signs:        { type: SchemaType.STRING },
-    summary:      { type: SchemaType.STRING },
+    amount:                  { type: SchemaType.STRING },
+    frequency:               { type: SchemaType.STRING },
+    recommendedFrequencyDays: { type: SchemaType.INTEGER },
+    method:                  { type: SchemaType.STRING },
+    seasonalTips:            { type: SchemaType.STRING },
+    signs:                   { type: SchemaType.STRING },
+    summary:                 { type: SchemaType.STRING },
   },
-  required: ['amount', 'frequency', 'method', 'seasonalTips', 'signs', 'summary'],
+  required: ['amount', 'frequency', 'recommendedFrequencyDays', 'method', 'seasonalTips', 'signs', 'summary'],
 };
 
-const WATERING_RECOMMEND_PROMPT = (name, species, { plantedIn, isOutdoor, potSize, soilType, sunExposure, health, season } = {}) => {
+const WATERING_RECOMMEND_PROMPT = (name, species, { plantedIn, isOutdoor, potSize, potMaterial, soilType, sunExposure, health, season, maturity, temperature } = {}) => {
   const details = [];
   if (plantedIn) details.push(`planted in: ${plantedIn === 'ground' ? 'the ground' : plantedIn === 'garden-bed' ? 'a garden bed' : 'a pot'}`);
   if (isOutdoor !== undefined) details.push(`location: ${isOutdoor ? 'outdoors' : 'indoors'}`);
   if (potSize) details.push(`pot size: ${potSize}`);
+  if (potMaterial) details.push(`pot material: ${potMaterial}`);
   if (soilType) details.push(`soil: ${soilType}`);
   if (sunExposure) details.push(`sun exposure: ${sunExposure}`);
   if (health) details.push(`current health: ${health}`);
+  if (maturity) details.push(`maturity: ${maturity}`);
   if (season) details.push(`current season: ${season}`);
+  if (temperature) details.push(`current temperature: ${temperature}°C`);
   const ctx = details.length ? `\nPlant details: ${details.join(', ')}.` : '';
   return `You are a plant watering expert. Provide specific watering guidance for: ${name}${species ? ` (${species})` : ''}.${ctx}
 Rules:
 - amount: specific volume (e.g. "200-300ml" for pots, "deep soak to 15cm" for ground)
 - frequency: specific schedule (e.g. "every 5-7 days in summer")
+- recommendedFrequencyDays: a single integer (1-30) for the ideal watering interval in days for the CURRENT season and conditions. Consider the species' water needs, container type (terracotta dries faster than plastic), soil drainage, sun exposure, indoor vs outdoor, temperature, and plant maturity
 - method: best watering method for this setup
 - seasonalTips: how to adjust watering across seasons
 - signs: how to tell if over/under-watered
@@ -670,13 +677,13 @@ app.post('/recommend', async (req, res) => {
 
 app.post('/recommend-watering', async (req, res) => {
   try {
-    const { name, species, plantedIn, isOutdoor, potSize, soilType, sunExposure, health, season } = req.body;
+    const { name, species, plantedIn, isOutdoor, potSize, potMaterial, soilType, sunExposure, health, season, maturity, temperature } = req.body;
     if (!name) return res.status(400).json({ error: 'name is required' });
 
     const result = await geminiWithRetry({
       contents: [{
         role: 'user',
-        parts: [{ text: WATERING_RECOMMEND_PROMPT(name, species, { plantedIn, isOutdoor, potSize, soilType, sunExposure, health, season }) }],
+        parts: [{ text: WATERING_RECOMMEND_PROMPT(name, species, { plantedIn, isOutdoor, potSize, potMaterial, soilType, sunExposure, health, season, maturity, temperature }) }],
       }],
       generationConfig: {
         maxOutputTokens: 1024,
@@ -688,6 +695,54 @@ app.post('/recommend-watering', async (req, res) => {
 
     const parsed = parseGeminiJson(result.response.text());
     res.status(200).json(parsed);
+  } catch (err) {
+    res.status(err.status || 500).json({ error: err.message });
+  }
+});
+
+app.post('/plants/recalculate-frequencies', requireUser, async (req, res) => {
+  try {
+    const { season, temperature } = req.body || {};
+    const snapshot = await userPlants(req.userId).get();
+    const plants = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+    if (plants.length === 0) return res.status(200).json({ updated: 0, results: [] });
+
+    const results = [];
+    for (const plant of plants) {
+      try {
+        const outdoor = OUTDOOR_ROOMS.has(plant.room);
+        const result = await geminiWithRetry({
+          contents: [{
+            role: 'user',
+            parts: [{ text: WATERING_RECOMMEND_PROMPT(plant.name, plant.species, {
+              plantedIn: plant.plantedIn, isOutdoor: outdoor,
+              potSize: plant.potSize, potMaterial: plant.potMaterial,
+              soilType: plant.soilType, sunExposure: plant.sunExposure,
+              health: plant.health, maturity: plant.maturity,
+              season, temperature,
+            }) }],
+          }],
+          generationConfig: {
+            maxOutputTokens: 1024, temperature: 0.3,
+            responseMimeType: 'application/json',
+            responseSchema: WATERING_RECOMMEND_SCHEMA,
+          },
+        });
+        const parsed = parseGeminiJson(result.response.text());
+        const freq = parsed.recommendedFrequencyDays;
+        if (freq && freq >= 1 && freq <= 30) {
+          await userPlants(req.userId).doc(plant.id).set(
+            { frequencyDays: freq, updatedAt: new Date().toISOString() },
+            { merge: true },
+          );
+          results.push({ id: plant.id, name: plant.name, oldFrequency: plant.frequencyDays, newFrequency: freq });
+        }
+      } catch (err) {
+        log.warn('recalculate frequency failed for plant', { plantId: plant.id, error: err.message });
+        results.push({ id: plant.id, name: plant.name, error: err.message });
+      }
+    }
+    res.status(200).json({ updated: results.filter((r) => r.newFrequency).length, results });
   } catch (err) {
     res.status(err.status || 500).json({ error: err.message });
   }

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -323,7 +323,7 @@ describe('POST /recommend', () => {
 // ── POST /recommend-watering ──────────────────────────────────────────────────
 
 describe('POST /recommend-watering', () => {
-  const wateringPayload = { amount: '500ml', frequency: 'Every 3-5 days', method: 'Deep soak', seasonalTips: 'Reduce in winter', signs: 'Yellow leaves = overwatering', summary: 'Water deeply but infrequently.' };
+  const wateringPayload = { amount: '500ml', frequency: 'Every 3-5 days', recommendedFrequencyDays: 4, method: 'Deep soak', seasonalTips: 'Reduce in winter', signs: 'Yellow leaves = overwatering', summary: 'Water deeply but infrequently.' };
 
   it('returns 400 when name is missing', async () => {
     const res = await request(app).post('/recommend-watering').send({ species: 'Ficus' });
@@ -349,6 +349,36 @@ describe('POST /recommend-watering', () => {
     const res = await request(app).post('/recommend-watering').send({ name: 'Cactus' });
     expect(res.status).toBe(200);
     expect(res.body.amount).toBeTruthy();
+  });
+
+  it('returns recommendedFrequencyDays', async () => {
+    geminiGenerateFn = async () => ({ response: { text: () => JSON.stringify(wateringPayload) } });
+    const res = await request(app).post('/recommend-watering').send({
+      name: 'Fern', plantedIn: 'pot', potMaterial: 'terracotta', temperature: 25,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.recommendedFrequencyDays).toBe(4);
+  });
+});
+
+// ── POST /plants/recalculate-frequencies ──────────────────────────────────────
+
+describe('POST /plants/recalculate-frequencies', () => {
+  const wateringPayload = { amount: '300ml', frequency: 'Every 5 days', recommendedFrequencyDays: 5, method: 'Top water', seasonalTips: 'Less in winter', signs: 'Wilting', summary: 'Water every 5 days.' };
+
+  it('returns 401 without auth header', async () => {
+    const res = await request(app).post('/plants/recalculate-frequencies').send({});
+    expect(res.status).toBe(401);
+  });
+
+  it('returns updated count for existing plants', async () => {
+    // Create a test plant first
+    await request(app).post('/plants').set('Authorization', 'Bearer test-token').send({ name: 'Test Fern', species: 'Nephrolepis', frequencyDays: 7 });
+    geminiGenerateFn = async () => ({ response: { text: () => JSON.stringify(wateringPayload) } });
+    const res = await request(app).post('/plants/recalculate-frequencies').set('Authorization', 'Bearer test-token').send({ season: 'autumn', temperature: 22 });
+    expect(res.status).toBe(200);
+    expect(res.body.updated).toBeGreaterThanOrEqual(1);
+    expect(res.body.results.some((r) => r.newFrequency === 5)).toBe(true);
   });
 });
 

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -373,9 +373,9 @@ describe('POST /plants/recalculate-frequencies', () => {
 
   it('returns updated count for existing plants', async () => {
     // Create a test plant first
-    await request(app).post('/plants').set('Authorization', 'Bearer test-token').send({ name: 'Test Fern', species: 'Nephrolepis', frequencyDays: 7 });
+    await request(app).post('/plants').set('Authorization', authHeader()).send({ name: 'Test Fern', species: 'Nephrolepis', frequencyDays: 7 });
     geminiGenerateFn = async () => ({ response: { text: () => JSON.stringify(wateringPayload) } });
-    const res = await request(app).post('/plants/recalculate-frequencies').set('Authorization', 'Bearer test-token').send({ season: 'autumn', temperature: 22 });
+    const res = await request(app).post('/plants/recalculate-frequencies').set('Authorization', authHeader()).send({ season: 'autumn', temperature: 22 });
     expect(res.status).toBe(200);
     expect(res.body.updated).toBeGreaterThanOrEqual(1);
     expect(res.body.results.some((r) => r.newFrequency === 5)).toBe(true);

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -56,6 +56,7 @@ export const plantsApi = {
   speciesCluster: (name) => request(`/species/${encodeURIComponent(name)}/cluster`),
   careScore: (id) => request(`/plants/${id}/care-score`),
   careScores: () => request('/ml/care-scores'),
+  recalculateFrequencies: (params) => request('/plants/recalculate-frequencies', { method: 'POST', body: JSON.stringify(params || {}) }),
   getFloorplan: () => request('/config/floorplan'),
   saveFloorplan: (imageUrl) => request('/config/floorplan', { method: 'PUT', body: JSON.stringify({ imageUrl }) }),
 }

--- a/src/components/PlantListPanel.jsx
+++ b/src/components/PlantListPanel.jsx
@@ -1,7 +1,8 @@
 import { useMemo, useState, useCallback } from 'react'
-import { Button, FormControl, InputGroup, Badge, ListGroup, Form } from 'react-bootstrap'
+import { Button, FormControl, InputGroup, Badge, ListGroup, Form, Spinner } from 'react-bootstrap'
 import { usePlantContext } from '../context/PlantContext.jsx'
-import { getWateringStatus, urgencyColor, OUTDOOR_ROOMS } from '../utils/watering.js'
+import { plantsApi } from '../api/plants.js'
+import { getWateringStatus, urgencyColor, OUTDOOR_ROOMS, getSeason } from '../utils/watering.js'
 import PlantIcon from './PlantIcon.jsx'
 
 function UrgencyIcon({ days, skippedRain }) {
@@ -72,6 +73,20 @@ export default function PlantListPanel({ onPlantClick, onAddPlant, gnomeWaterRef
   const [searchTerm, setSearchTerm] = useState('')
   const [roomFilter, setRoomFilter] = useState(null)
   const [gnomeActive, setGnomeActive] = useState(false)
+  const [recalculating, setRecalculating] = useState(false)
+  const [recalcResult, setRecalcResult] = useState(null)
+
+  const handleRecalculate = useCallback(async () => {
+    setRecalculating(true); setRecalcResult(null)
+    try {
+      const season = getSeason(weather?.location?.lat)
+      const data = await plantsApi.recalculateFrequencies({ season, temperature: weather?.current?.temp })
+      setRecalcResult(data)
+      // Reload plants to reflect new frequencies
+      window.location.reload()
+    } catch (err) { setRecalcResult({ error: err.message }) }
+    finally { setRecalculating(false) }
+  }, [weather])
 
   const handleGnomeBatchWater = useCallback((targetPlants) => {
     if (gnomeActive) return
@@ -165,6 +180,22 @@ export default function PlantListPanel({ onPlantClick, onAddPlant, gnomeWaterRef
               >
                 {gnomeActive ? <span className="spinner-border spinner-border-sm me-1" /> : <svg className="sa-icon me-1" style={{ width: 12, height: 12 }}><use href="/icons/sprite.svg#droplet"></use></svg>}
                 {gnomeActive ? 'Watering...' : `Water All on Floor (${floorPlants.length} plants)`}
+              </Button>
+            </div>
+          )}
+
+          {/* Recalculate all frequencies */}
+          {floorPlants.length > 0 && (
+            <div className="px-3 pb-2">
+              <Button
+                variant="outline-warning"
+                size="sm"
+                className="w-100"
+                disabled={recalculating}
+                onClick={handleRecalculate}
+              >
+                {recalculating ? <Spinner size="sm" className="me-1" /> : <svg className="sa-icon me-1" style={{ width: 12, height: 12 }}><use href="/icons/sprite.svg#zap"></use></svg>}
+                {recalculating ? 'Recalculating...' : 'Recalculate All Watering Frequencies'}
               </Button>
             </div>
           )}

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -60,6 +60,13 @@ const SOIL_TYPE_OPTIONS = [
   { value: 'succulent-mix', label: 'Succulent / cactus mix' },
   { value: 'orchid-mix', label: 'Orchid mix (bark)' },
 ]
+const POT_MATERIAL_OPTIONS = [
+  { value: 'terracotta', label: 'Terracotta / Clay' },
+  { value: 'plastic', label: 'Plastic' },
+  { value: 'ceramic', label: 'Ceramic / Glazed' },
+  { value: 'fabric', label: 'Fabric / Grow Bag' },
+  { value: 'metal', label: 'Metal' },
+]
 const PLANTED_IN_OPTIONS = [
   { value: 'ground', label: 'In the Ground' },
   { value: 'garden-bed', label: 'Garden Bed' },
@@ -170,7 +177,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
     waterAmount: null, waterMethod: null,
     irrigationDuration: null, irrigationSchedule: null,
     sunExposure: null, sunHoursPerDay: null,
-    potSize: null, soilType: null,
+    potSize: null, soilType: null, potMaterial: null,
     plantedIn: null,
   })
   const [isSaving, setIsSaving] = useState(false)
@@ -201,6 +208,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
         sunHoursPerDay: plant.sunHoursPerDay ?? null,
         potSize: plant.potSize || null,
         soilType: plant.soilType || null,
+        potMaterial: plant.potMaterial || null,
         plantedIn: plant.plantedIn || null,
       })
     }
@@ -254,6 +262,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       sunHoursPerDay: form.sunHoursPerDay ? Number(form.sunHoursPerDay) : null,
       potSize: form.plantedIn === 'pot' ? form.potSize : null,
       soilType: form.plantedIn === 'pot' ? form.soilType : null,
+      potMaterial: form.plantedIn === 'pot' ? form.potMaterial : null,
       plantedIn: form.plantedIn,
     })
     setIsSaving(false)
@@ -285,9 +294,12 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
         name: form.name, species: form.species,
         plantedIn: form.plantedIn, isOutdoor: outdoor,
         potSize: form.plantedIn === 'pot' ? form.potSize : null,
+        potMaterial: form.plantedIn === 'pot' ? form.potMaterial : null,
         soilType: form.plantedIn === 'pot' ? form.soilType : null,
         sunExposure: form.sunExposure, health: form.health,
+        maturity: form.maturity,
         season: wateringStatus?.season || null,
+        temperature: weather?.current?.temp || null,
       })
       setWateringRec(data)
     }
@@ -414,26 +426,35 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
             </Form.Select>
           </Form.Group>
           {form.plantedIn === 'pot' && (
-            <Row className="mb-3">
-              <Col md={6}>
-                <Form.Group>
-                  <Form.Label>Pot Size</Form.Label>
-                  <Form.Select value={form.potSize || ''} onChange={(e) => update('potSize', e.target.value || null)}>
-                    <option value="">— Select —</option>
-                    {POT_SIZE_OPTIONS.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
-                  </Form.Select>
-                </Form.Group>
-              </Col>
-              <Col md={6}>
-                <Form.Group>
-                  <Form.Label>Soil Type</Form.Label>
-                  <Form.Select value={form.soilType || ''} onChange={(e) => update('soilType', e.target.value || null)}>
-                    <option value="">— Select —</option>
-                    {SOIL_TYPE_OPTIONS.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
-                  </Form.Select>
-                </Form.Group>
-              </Col>
-            </Row>
+            <>
+              <Row className="mb-3">
+                <Col md={6}>
+                  <Form.Group>
+                    <Form.Label>Pot Size</Form.Label>
+                    <Form.Select value={form.potSize || ''} onChange={(e) => update('potSize', e.target.value || null)}>
+                      <option value="">— Select —</option>
+                      {POT_SIZE_OPTIONS.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
+                    </Form.Select>
+                  </Form.Group>
+                </Col>
+                <Col md={6}>
+                  <Form.Group>
+                    <Form.Label>Soil Type</Form.Label>
+                    <Form.Select value={form.soilType || ''} onChange={(e) => update('soilType', e.target.value || null)}>
+                      <option value="">— Select —</option>
+                      {SOIL_TYPE_OPTIONS.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+                    </Form.Select>
+                  </Form.Group>
+                </Col>
+              </Row>
+              <Form.Group className="mb-3">
+                <Form.Label>Pot Material</Form.Label>
+                <Form.Select value={form.potMaterial || ''} onChange={(e) => update('potMaterial', e.target.value || null)}>
+                  <option value="">— Select —</option>
+                  {POT_MATERIAL_OPTIONS.map((m) => <option key={m.value} value={m.value}>{m.label}</option>)}
+                </Form.Select>
+              </Form.Group>
+            </>
           )}
         </Modal.Body>
       )}
@@ -577,6 +598,17 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
                   <div className="mt-2 pt-2 border-top">
                     <strong className="text-uppercase fs-xs">Signs to Watch</strong>
                     <p className="text-muted mb-0 fs-xs">{wateringRec.signs}</p>
+                  </div>
+                )}
+                {wateringRec.recommendedFrequencyDays && wateringRec.recommendedFrequencyDays !== Number(form.frequencyDays) && (
+                  <div className="mt-2 pt-2 border-top d-flex align-items-center justify-content-between">
+                    <span className="fs-xs">
+                      AI recommends watering every <strong>{wateringRec.recommendedFrequencyDays}d</strong>
+                      {form.frequencyDays ? <span className="text-muted"> (currently {form.frequencyDays}d)</span> : null}
+                    </span>
+                    <Button variant="outline-primary" size="sm" className="ms-2" onClick={() => update('frequencyDays', wateringRec.recommendedFrequencyDays)}>
+                      Apply
+                    </Button>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- **AI frequency**: Watering recommendation now returns `recommendedFrequencyDays` (integer 1-30) based on species, container type, soil, sun, temperature, maturity, and season
- **Pot Material**: New field (terracotta, plastic, ceramic, fabric, metal) — terracotta dries faster, affects AI recommendation
- **Apply button**: One-click to set AI-recommended frequency from watering recommendation
- **Recalculate All**: Bulk button on plant list calls AI for every plant and updates frequencies
- **New endpoint**: `POST /plants/recalculate-frequencies` processes all plants sequentially via Gemini

## New field
- `potMaterial` — shown when plantedIn is "pot", improves AI watering prediction (terracotta breathes, plastic retains moisture)

## Test plan
- [ ] Get Watering Recommendation shows recommended frequency with Apply button
- [ ] Click Apply — frequency slider updates
- [ ] Pot Material dropdown visible when Pot is selected
- [ ] "Recalculate All Watering Frequencies" updates all plants
- [ ] New endpoint needs adding to API Gateway OpenAPI spec in platform-infra

🤖 Generated with [Claude Code](https://claude.com/claude-code)