### PR TITLE
Add photo deletion, faster AI analysis, and species correction

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -648,6 +648,38 @@ app.post('/analyse', async (req, res) => {
   }
 });
 
+// ── Re-analyse with species hint ─────────────────────────────────────────────
+
+app.post('/analyse-with-hint', async (req, res) => {
+  try {
+    const { imageBase64, mimeType, speciesHint } = req.body;
+    if (!imageBase64 || !mimeType) {
+      return res.status(400).json({ error: 'imageBase64 and mimeType are required' });
+    }
+    if (!speciesHint) {
+      return res.status(400).json({ error: 'speciesHint is required' });
+    }
+
+    const hintPrompt = ANALYSE_PROMPT + `\n\nIMPORTANT: The user believes this plant is "${speciesHint}". Use this as the species identification (look up the scientific name) and tailor all care recommendations, watering frequency, soil type, and other advice specifically for this species. If the hint seems plausible from the photo, trust it.`;
+
+    const result = await geminiWithRetry({
+      contents: [{
+        role: 'user',
+        parts: [
+          { inlineData: { mimeType, data: imageBase64 } },
+          { text: hintPrompt },
+        ],
+      }],
+      generationConfig: { temperature: 0.1, responseMimeType: 'application/json', responseSchema: ANALYSE_SCHEMA },
+    });
+
+    const parsed = parseGeminiJson(result.response.text());
+    res.status(200).json(parsed);
+  } catch (err) {
+    res.status(err.status || 500).json({ error: err.message });
+  }
+});
+
 // ── Care recommendations via Gemini ──────────────────────────────────────────
 
 app.post('/recommend', async (req, res) => {
@@ -1041,6 +1073,48 @@ app.post('/plants/:id/diagnostic', requireUser, async (req, res) => {
     await ref.set({ photoLog, updatedAt: new Date().toISOString() }, { merge: true });
 
     res.status(200).json(entry);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ── Delete a photo from photoLog ─────────────────────────────────────────────
+
+app.delete('/plants/:id/photos', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const { url } = req.body;
+    if (!url) return res.status(400).json({ error: 'url is required' });
+
+    const existing = doc.data();
+    const photoLog = [...(existing.photoLog || [])];
+    const normalised = url.split('?')[0];
+    const idx = photoLog.findIndex((e) => e.url?.split('?')[0] === normalised);
+    if (idx === -1) return res.status(404).json({ error: 'Photo not found in log' });
+
+    photoLog.splice(idx, 1);
+
+    // Delete the file from GCS (best-effort)
+    const path = gcsPath(normalised);
+    if (path) await storage.bucket(IMAGES_BUCKET).file(path).delete().catch(() => {});
+
+    // If the deleted photo was the current plant image, fall back to latest remaining photo
+    const updates = { photoLog, updatedAt: new Date().toISOString() };
+    const existingImageNorm = existing.imageUrl ? existing.imageUrl.split('?')[0] : null;
+    if (existingImageNorm === normalised) {
+      const latest = [...photoLog].filter((e) => e.type === 'growth').sort((a, b) => new Date(b.date) - new Date(a.date))[0];
+      updates.imageUrl = latest?.url || null;
+    }
+
+    await ref.set(updates, { merge: true });
+
+    const updated = await ref.get();
+    const data = { id: updated.id, ...updated.data() };
+    await signPlantData(data);
+    res.status(200).json(data);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/api/plants/package-lock.json
+++ b/api/plants/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plants-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "plants-api",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@google-cloud/aiplatform": "^3.35.0",
         "@google-cloud/firestore": "^8.3.0",

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -52,6 +52,7 @@ export const plantsApi = {
       body: JSON.stringify({ imageBase64: data, mimeType: file.type }),
     })
   },
+  deletePhoto: (id, url) => request(`/plants/${id}/photos`, { method: 'DELETE', body: JSON.stringify({ url }) }),
   seasonalAdjustment: (id) => request(`/plants/${id}/seasonal-adjustment`),
   speciesCluster: (name) => request(`/species/${encodeURIComponent(name)}/cluster`),
   careScore: (id) => request(`/plants/${id}/care-score`),
@@ -81,6 +82,14 @@ export const analyseApi = {
     return request('/analyse', {
       method: 'POST',
       body: JSON.stringify({ imageBase64: data, mimeType: file.type }),
+    })
+  },
+  async analyseWithHint(file, speciesHint) {
+    const base64 = await fileToBase64(file)
+    const [, data] = base64.split(',')
+    return request('/analyse-with-hint', {
+      method: 'POST',
+      body: JSON.stringify({ imageBase64: data, mimeType: file.type, speciesHint }),
     })
   },
   async analyseFloorplan(file) {

--- a/src/components/ImageAnalyser.jsx
+++ b/src/components/ImageAnalyser.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Button, Card, Spinner, Alert, Badge, Form } from 'react-bootstrap'
+import { Button, Card, Spinner, Alert, Badge, Form, InputGroup } from 'react-bootstrap'
 import { analyseApi } from '../api/plants.js'
 
 const ANALYSIS_STAGES = [
@@ -25,6 +25,8 @@ export default function ImageAnalyser({ initialImage, onAnalysisComplete, onImag
   const [stageIndex, setStageIndex] = useState(0)
   const [error, setError] = useState(null)
   const [isDragging, setIsDragging] = useState(false)
+  const [showSpeciesHint, setShowSpeciesHint] = useState(false)
+  const [speciesHint, setSpeciesHint] = useState('')
   const fileInputRef = useRef(null)
   const objectUrlRef = useRef(null)
 
@@ -45,16 +47,22 @@ export default function ImageAnalyser({ initialImage, onAnalysisComplete, onImag
     setImageFile(file)
     setError(null)
     setAnalysisResult(null)
+    setShowSpeciesHint(false)
+    setSpeciesHint('')
     onImageChange(file)
     runAnalysis(file)
   }, [onImageChange])
 
-  const runAnalysis = useCallback(async (file) => {
+  const runAnalysis = useCallback(async (file, hint) => {
     setIsAnalysing(true); setError(null)
     try {
-      const result = await analyseApi.analyse(file)
+      const result = hint
+        ? await analyseApi.analyseWithHint(file, hint)
+        : await analyseApi.analyse(file)
       setAnalysisResult(result)
       onAnalysisComplete(result)
+      setShowSpeciesHint(false)
+      setSpeciesHint('')
     } catch (err) { setError(err.message) }
     finally { setIsAnalysing(false) }
   }, [onAnalysisComplete])
@@ -63,10 +71,15 @@ export default function ImageAnalyser({ initialImage, onAnalysisComplete, onImag
     if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current)
     objectUrlRef.current = null
     setPreviewSrc(null); setImageFile(null); setAnalysisResult(null); setError(null)
+    setShowSpeciesHint(false); setSpeciesHint('')
     onImageChange(null)
   }
 
   const handleReanalyse = () => { if (imageFile) runAnalysis(imageFile) }
+
+  const handleSubmitHint = () => {
+    if (imageFile && speciesHint.trim()) runAnalysis(imageFile, speciesHint.trim())
+  }
 
   return (
     <div>
@@ -119,7 +132,30 @@ export default function ImageAnalyser({ initialImage, onAnalysisComplete, onImag
               </span>
               <Button variant="link" size="sm" className="p-0 fs-xs text-muted" onClick={handleReanalyse}>Re-analyse</Button>
             </div>
-            {analysisResult.species && <p className="fw-500 fs-sm mb-2">{analysisResult.species}</p>}
+            {analysisResult.species && (
+              <div className="mb-2">
+                <p className="fw-500 fs-sm mb-1">{analysisResult.species}</p>
+                {!showSpeciesHint && !isAnalysing && (
+                  <Button variant="link" size="sm" className="p-0 fs-xs text-muted" onClick={() => setShowSpeciesHint(true)}>
+                    Not right? Suggest species
+                  </Button>
+                )}
+              </div>
+            )}
+            {showSpeciesHint && (
+              <InputGroup size="sm" className="mb-2">
+                <Form.Control
+                  placeholder="e.g. Monstera, Peace Lily..."
+                  value={speciesHint}
+                  onChange={(e) => setSpeciesHint(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleSubmitHint() }}
+                  disabled={isAnalysing}
+                />
+                <Button variant="primary" onClick={handleSubmitHint} disabled={!speciesHint.trim() || isAnalysing}>
+                  {isAnalysing ? <Spinner size="sm" /> : 'Re-analyse'}
+                </Button>
+              </InputGroup>
+            )}
             <div className="d-flex flex-wrap gap-2">
               {analysisResult.health && <Badge bg={HEALTH_COLORS[analysisResult.health] || 'secondary'}>Health: {analysisResult.health}</Badge>}
               {analysisResult.maturity && <Badge bg={MATURITY_COLORS[analysisResult.maturity] || 'secondary'}>Maturity: {analysisResult.maturity}</Badge>}

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { Modal, Button, Form, Nav, Tab, Badge, Spinner, Row, Col } from 'react-bootstrap'
 import ImageAnalyser from './ImageAnalyser.jsx'
-import { imagesApi, recommendApi, plantsApi } from '../api/plants.js'
+import { imagesApi, recommendApi, plantsApi, analyseApi } from '../api/plants.js'
 import { getWateringStatus, getAdjustedWaterAmount, getSuggestedFrequency, isOutdoor } from '../utils/watering.js'
 import { analyseWateringPattern, getPatternMeta } from '../utils/wateringPattern.js'
 
@@ -85,12 +85,12 @@ function GrowthUpload({ plantId, onComplete }) {
     if (!file?.type.startsWith('image/')) return
     setUploading(true)
     try {
-      const imageUrl = await imagesApi.upload(file, 'plants')
+      // Run upload and AI analysis in parallel for speed
+      const uploadPromise = imagesApi.upload(file, 'plants')
+      const analysisPromise = analyseApi.analyse(file).catch(() => null)
+      const [imageUrl, analysis] = await Promise.all([uploadPromise, analysisPromise])
       await plantsApi.update(plantId, { imageUrl })
-      try {
-        const analysis = await (await import('../api/plants.js')).analyseApi.analyse(file)
-        onComplete?.(analysis)
-      } catch { /* analysis optional */ }
+      if (analysis) onComplete?.(analysis)
     } catch (err) { console.error('Growth upload failed:', err) }
     finally { setUploading(false) }
   }
@@ -189,6 +189,9 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   const [wateringRec, setWateringRec] = useState(null)
   const [wateringRecLoading, setWateringRecLoading] = useState(false)
   const [wateringRecError, setWateringRecError] = useState(null)
+  const [deletedPhotoUrls, setDeletedPhotoUrls] = useState([])
+  const [confirmDeletePhoto, setConfirmDeletePhoto] = useState(null)
+  const [deletingPhoto, setDeletingPhoto] = useState(false)
 
   useEffect(() => {
     if (plant) {
@@ -272,6 +275,15 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
     if (confirmDelete) { onDelete(plant.id); setConfirmDelete(false) }
     else setConfirmDelete(true)
   }, [confirmDelete, plant, onDelete])
+
+  const handleDeletePhoto = useCallback(async (url) => {
+    setDeletingPhoto(true)
+    try {
+      await plantsApi.deletePhoto(plant.id, url)
+      setDeletedPhotoUrls((prev) => [...prev, url.split('?')[0]])
+    } catch (err) { console.error('Photo delete failed:', err) }
+    finally { setDeletingPhoto(false); setConfirmDeletePhoto(null) }
+  }, [plant])
 
   const wateringStatus = useMemo(() => plant ? getWateringStatus(plant, weather, floors) : null, [plant, weather, floors])
 
@@ -671,7 +683,9 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
 
           {/* Photo timeline */}
           {(() => {
-            const photos = [...(plant.photoLog || [])].sort((a, b) => new Date(b.date) - new Date(a.date))
+            const photos = [...(plant.photoLog || [])]
+              .filter((p) => !deletedPhotoUrls.includes(p.url?.split('?')[0]))
+              .sort((a, b) => new Date(b.date) - new Date(a.date))
 
             if (photos.length === 0) return null
 
@@ -680,11 +694,19 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
                 <h6 className="text-muted text-uppercase fs-xs fw-600 mb-2">Photo History ({photos.length})</h6>
                 <Row className="g-2 mb-3">
                   {photos.map((photo, i) => (
-                    <Col xs={6} md={4} key={i}>
+                    <Col xs={6} md={4} key={photo.url || i}>
                       <div className="border rounded overflow-hidden position-relative" style={{ minHeight: 120 }}>
                         <img src={photo.url} alt={`Photo ${i + 1}`} className="w-100"
                           style={{ height: 120, objectFit: 'cover', display: 'block' }}
                           onError={(e) => { e.target.style.display = 'none' }} />
+                        <Button variant="dark" size="sm"
+                          className="position-absolute top-0 end-0 m-1 rounded-circle p-0"
+                          style={{ width: 22, height: 22, opacity: 0.8 }}
+                          disabled={deletingPhoto}
+                          onClick={() => setConfirmDeletePhoto(photo.url)}
+                          title="Delete photo">
+                          <svg className="sa-icon" style={{ width: 10, height: 10 }}><use href="/icons/sprite.svg#trash-2"></use></svg>
+                        </Button>
                         <div className="position-absolute bottom-0 start-0 end-0 px-2 py-1" style={{ background: 'rgba(0,0,0,0.6)' }}>
                           <div className="d-flex align-items-center justify-content-between">
                             <small className="text-white" style={{ fontSize: '0.6rem' }}>
@@ -704,6 +726,19 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
                     </Col>
                   ))}
                 </Row>
+
+                {/* Photo delete confirmation */}
+                {confirmDeletePhoto && (
+                  <div className="alert alert-warning py-2 d-flex align-items-center justify-content-between">
+                    <small>Delete this photo? This cannot be undone.</small>
+                    <div className="d-flex gap-1">
+                      <Button variant="light" size="sm" onClick={() => setConfirmDeletePhoto(null)} disabled={deletingPhoto}>Cancel</Button>
+                      <Button variant="danger" size="sm" onClick={() => handleDeletePhoto(confirmDeletePhoto)} disabled={deletingPhoto}>
+                        {deletingPhoto ? <Spinner size="sm" /> : 'Delete'}
+                      </Button>
+                    </div>
+                  </div>
+                )}
               </>
             )
           })()}


### PR DESCRIPTION
- Add DELETE /plants/:id/photos endpoint to remove individual photos
  from photoLog with GCS cleanup and imageUrl fallback
- Add POST /analyse-with-hint endpoint for re-analysis with user-
  provided species hint when AI identification is wrong
- Add delete buttons on photo cards in Care tab with confirmation
- Run GCS upload and Gemini analysis in parallel during growth photo
  recording for faster completion
- Add "Not right? Suggest species" UI in ImageAnalyser to correct
  misidentified plants and re-run analysis with the hint

https://claude.ai/code/session_01AYCzWHYrxYJg1UMWs5bFMh