### PR TITLE
Fix bulk upload room default and add Reorganise button

### DIFF
--- a/src/__tests__/BulkPlantCard.test.jsx
+++ b/src/__tests__/BulkPlantCard.test.jsx
@@ -162,4 +162,50 @@ describe('BulkPlantCard', () => {
     const removeBtn = document.querySelector('use[href*="#x"]')
     expect(removeBtn).not.toBeInTheDocument()
   })
+
+  it('auto-updates room when floor changes to a floor without the current room', () => {
+    renderCard()
+    // Change floor from 'ground' (Kitchen, Living Room) to 'first' (Bedroom)
+    const selects = screen.getAllByRole('combobox')
+    const floorSelect = selects.find((s) =>
+      Array.from(s.options).some((o) => o.textContent === 'First Floor'),
+    )
+    fireEvent.change(floorSelect, { target: { value: 'first' } })
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        form: expect.objectContaining({ floor: 'first', room: 'Bedroom' }),
+      }),
+    )
+  })
+
+  it('keeps room when switching to a floor that has the same room', () => {
+    // Entry has room 'Kitchen' on floor 'ground'
+    // Switching to a floor that also has 'Kitchen' should keep it
+    const floorsWithShared = [
+      { id: 'ground', name: 'Ground Floor', rooms: [{ name: 'Kitchen' }, { name: 'Living Room' }] },
+      { id: 'first', name: 'First Floor', rooms: [{ name: 'Kitchen' }, { name: 'Bedroom' }] },
+    ]
+    const entry = makeEntry()
+    render(
+      <BulkPlantCard
+        entry={entry}
+        floors={floorsWithShared}
+        rooms={rooms}
+        onChange={onChange}
+        onRemove={onRemove}
+        onRetry={onRetry}
+      />,
+    )
+    const selects = screen.getAllByRole('combobox')
+    const floorSelect = selects.find((s) =>
+      Array.from(s.options).some((o) => o.textContent === 'First Floor'),
+    )
+    fireEvent.change(floorSelect, { target: { value: 'first' } })
+    // Room should stay as 'Kitchen' since 'first' floor also has it
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        form: expect.objectContaining({ floor: 'first', room: 'Kitchen' }),
+      }),
+    )
+  })
 })

--- a/src/__tests__/reorganise.test.js
+++ b/src/__tests__/reorganise.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { calculateReorganisedPositions } from '../utils/reorganise.js'
+
+const ROOMS = [
+  { name: 'Kitchen', x: 0, y: 0, width: 50, height: 50 },
+  { name: 'Bedroom', x: 50, y: 0, width: 50, height: 50 },
+]
+
+function makePlant(id, room, x = 50, y = 50) {
+  return { id, name: `Plant ${id}`, room, x, y }
+}
+
+describe('calculateReorganisedPositions', () => {
+  it('returns empty object for no plants', () => {
+    expect(calculateReorganisedPositions([], ROOMS)).toEqual({})
+  })
+
+  it('returns empty object for no rooms', () => {
+    const plants = [makePlant('p1', 'Kitchen')]
+    expect(calculateReorganisedPositions(plants, [])).toEqual({})
+  })
+
+  it('returns empty object for null inputs', () => {
+    expect(calculateReorganisedPositions(null, null)).toEqual({})
+  })
+
+  it('places a single plant in the center of its room', () => {
+    const plants = [makePlant('p1', 'Kitchen')]
+    const result = calculateReorganisedPositions(plants, ROOMS)
+
+    expect(result.p1).toBeDefined()
+    expect(result.p1.room).toBe('Kitchen')
+    // Single plant: cols=1, rows=1, spacingX=0, spacingY=0
+    // offsetX = 0 + pad + 0 = pad, offsetY = 0 + pad + 0 = pad
+    // So plant is at (pad, pad) — center of the room for 1 item
+    expect(result.p1.x).toBeGreaterThanOrEqual(0)
+    expect(result.p1.x).toBeLessThanOrEqual(50)
+    expect(result.p1.y).toBeGreaterThanOrEqual(0)
+    expect(result.p1.y).toBeLessThanOrEqual(50)
+  })
+
+  it('distributes multiple plants in a grid within their room', () => {
+    const plants = [
+      makePlant('p1', 'Kitchen', 50, 50),
+      makePlant('p2', 'Kitchen', 50, 50),
+      makePlant('p3', 'Kitchen', 50, 50),
+      makePlant('p4', 'Kitchen', 50, 50),
+    ]
+    const result = calculateReorganisedPositions(plants, ROOMS)
+
+    // 4 plants = 2x2 grid
+    expect(Object.keys(result)).toHaveLength(4)
+
+    // All should be within Kitchen bounds (0-50, 0-50)
+    for (const id of ['p1', 'p2', 'p3', 'p4']) {
+      expect(result[id].room).toBe('Kitchen')
+      expect(result[id].x).toBeGreaterThanOrEqual(0)
+      expect(result[id].x).toBeLessThanOrEqual(50)
+      expect(result[id].y).toBeGreaterThanOrEqual(0)
+      expect(result[id].y).toBeLessThanOrEqual(50)
+    }
+
+    // All positions should be unique (no overlaps)
+    const positions = Object.values(result).map((p) => `${p.x},${p.y}`)
+    expect(new Set(positions).size).toBe(4)
+  })
+
+  it('places plants from different rooms within their respective room bounds', () => {
+    const plants = [
+      makePlant('p1', 'Kitchen'),
+      makePlant('p2', 'Kitchen'),
+      makePlant('p3', 'Bedroom'),
+    ]
+    const result = calculateReorganisedPositions(plants, ROOMS)
+
+    expect(result.p1.room).toBe('Kitchen')
+    expect(result.p1.x).toBeLessThan(50)
+    expect(result.p2.room).toBe('Kitchen')
+    expect(result.p2.x).toBeLessThan(50)
+
+    expect(result.p3.room).toBe('Bedroom')
+    expect(result.p3.x).toBeGreaterThanOrEqual(50)
+  })
+
+  it('assigns unassigned plants to the first visible room', () => {
+    const plants = [makePlant('p1', 'Nonexistent Room')]
+    const result = calculateReorganisedPositions(plants, ROOMS)
+
+    expect(result.p1).toBeDefined()
+    expect(result.p1.room).toBe('Kitchen') // first visible room
+  })
+
+  it('skips hidden rooms and does not place plants there', () => {
+    const rooms = [
+      { name: 'Kitchen', x: 0, y: 0, width: 50, height: 50, hidden: true },
+      { name: 'Bedroom', x: 50, y: 0, width: 50, height: 50 },
+    ]
+    const plants = [makePlant('p1', 'Kitchen')]
+    const result = calculateReorganisedPositions(plants, rooms)
+
+    // Kitchen is hidden, so p1 is "unassigned" → placed in Bedroom (first visible)
+    expect(result.p1.room).toBe('Bedroom')
+  })
+
+  it('handles a single plant in a small room', () => {
+    const rooms = [{ name: 'Closet', x: 10, y: 10, width: 5, height: 5 }]
+    const plants = [makePlant('p1', 'Closet')]
+    const result = calculateReorganisedPositions(plants, rooms)
+
+    expect(result.p1.room).toBe('Closet')
+    expect(result.p1.x).toBeGreaterThanOrEqual(10)
+    expect(result.p1.x).toBeLessThanOrEqual(15)
+    expect(result.p1.y).toBeGreaterThanOrEqual(10)
+    expect(result.p1.y).toBeLessThanOrEqual(15)
+  })
+
+  it('evenly spaces 3 plants in a 2x2 grid', () => {
+    const rooms = [{ name: 'Room', x: 0, y: 0, width: 100, height: 100 }]
+    const plants = [
+      makePlant('p1', 'Room'),
+      makePlant('p2', 'Room'),
+      makePlant('p3', 'Room'),
+    ]
+    const result = calculateReorganisedPositions(plants, rooms)
+
+    // 3 plants → ceil(sqrt(3))=2 cols, ceil(3/2)=2 rows
+    // p1 at (col 0, row 0), p2 at (col 1, row 0), p3 at (col 0, row 1)
+    expect(result.p1.x).toBeLessThan(result.p2.x)
+    expect(result.p1.y).toBeLessThan(result.p3.y)
+    expect(result.p3.x).toBeLessThan(result.p2.x)
+  })
+})

--- a/src/components/BulkPlantCard.jsx
+++ b/src/components/BulkPlantCard.jsx
@@ -45,7 +45,15 @@ export default function BulkPlantCard({ entry, floors, rooms, onChange, onRemove
   const { previewUrl, status, form, error } = entry
 
   const update = (field, value) => {
-    onChange({ ...entry, form: { ...form, [field]: value } })
+    const updatedForm = { ...form, [field]: value }
+    // When floor changes, auto-select the first room on the new floor
+    if (field === 'floor') {
+      const newFloorRooms = (floors.find((f) => f.id === value)?.rooms || []).map((r) => r.name).filter(Boolean)
+      if (newFloorRooms.length > 0 && !newFloorRooms.includes(form.room)) {
+        updatedForm.room = newFloorRooms[0]
+      }
+    }
+    onChange({ ...entry, form: updatedForm })
   }
 
   const floorRooms = form.floor

--- a/src/components/FloorplanPanel.jsx
+++ b/src/components/FloorplanPanel.jsx
@@ -5,6 +5,7 @@ import { usePlantContext } from '../context/PlantContext.jsx'
 import { plantsApi } from '../api/plants.js'
 import LeafletFloorplan from './LeafletFloorplan.jsx'
 import HouseWeatherFrame from './HouseWeatherFrame.jsx'
+import { calculateReorganisedPositions } from '../utils/reorganise.js'
 
 const Floorplan3D = lazy(() => import('./Floorplan3D.jsx'))
 
@@ -38,6 +39,21 @@ export default function FloorplanPanel({ onPlantClick, onFloorplanClick, gnomeWa
   )
 
   const [hasDirty, setHasDirty] = useState(false)
+
+  // Reorganise plants — evenly distribute within their assigned room bounds
+  const handleReorganise = useCallback(() => {
+    if (!activeFloor?.rooms?.length || plantsOnFloor.length === 0) return
+
+    const updates = calculateReorganisedPositions(plantsOnFloor, activeFloor.rooms)
+
+    if (Object.keys(updates).length > 0) {
+      for (const [id, move] of Object.entries(updates)) {
+        dirtyMovesRef.current[id] = move
+      }
+      updatePlantsLocally(updates)
+      setHasDirty(true)
+    }
+  }, [activeFloor, plantsOnFloor, updatePlantsLocally])
 
   // Drag handler — update context immediately (no API call)
   const handleLocalDrag = useCallback((plant, x, y) => {
@@ -117,16 +133,24 @@ export default function FloorplanPanel({ onPlantClick, onFloorplanClick, gnomeWa
             </Nav.Item>
           ))}
         </Nav>
-        <ButtonGroup size="sm" className="flex-shrink-0">
-          <Button variant={viewMode === '2d' ? 'primary' : 'outline-secondary'} onClick={() => setViewMode('2d')} title="2D View">
-            <svg className="sa-icon me-1" style={{ width: 14, height: 14 }}><use href="/icons/sprite.svg#grid"></use></svg>
-            2D
-          </Button>
-          <Button variant={viewMode === '3d' ? 'primary' : 'outline-secondary'} onClick={() => setViewMode('3d')} title="3D View">
-            <svg className="sa-icon me-1" style={{ width: 14, height: 14 }}><use href="/icons/sprite.svg#box"></use></svg>
-            3D
-          </Button>
-        </ButtonGroup>
+        <div className="d-flex gap-2 flex-shrink-0">
+          {plantsOnFloor.length > 0 && activeFloor?.rooms?.length > 0 && (
+            <Button variant="outline-secondary" size="sm" onClick={handleReorganise} title="Evenly space plants within their rooms">
+              <svg className="sa-icon me-1" style={{ width: 14, height: 14 }}><use href="/icons/sprite.svg#grid"></use></svg>
+              Reorganise
+            </Button>
+          )}
+          <ButtonGroup size="sm">
+            <Button variant={viewMode === '2d' ? 'primary' : 'outline-secondary'} onClick={() => setViewMode('2d')} title="2D View">
+              <svg className="sa-icon me-1" style={{ width: 14, height: 14 }}><use href="/icons/sprite.svg#grid"></use></svg>
+              2D
+            </Button>
+            <Button variant={viewMode === '3d' ? 'primary' : 'outline-secondary'} onClick={() => setViewMode('3d')} title="3D View">
+              <svg className="sa-icon me-1" style={{ width: 14, height: 14 }}><use href="/icons/sprite.svg#box"></use></svg>
+              3D
+            </Button>
+          </ButtonGroup>
+        </div>
       </div>
 
       {/* Map view */}

--- a/src/pages/BulkUploadPage.jsx
+++ b/src/pages/BulkUploadPage.jsx
@@ -41,7 +41,11 @@ export default function BulkUploadPage() {
 
   const rooms = getRoomsFromFloors(floors)
   const defaultFloor = activeFloorId || floors?.[0]?.id || ''
-  const defaultRoom = rooms[0] || ''
+  // Use rooms from active floor so bulk uploads default to a room on the current floor
+  const activeFloorRooms = defaultFloor
+    ? (floors.find((f) => f.id === defaultFloor)?.rooms || []).map((r) => r.name).filter(Boolean)
+    : rooms
+  const defaultRoom = activeFloorRooms[0] || rooms[0] || ''
 
   // Rotate analysis stage text for entries being analysed
   useEffect(() => {
@@ -88,9 +92,12 @@ export default function BulkUploadPage() {
         const result = await analyseApi.analyse(entry.file)
         const species = result.species || ''
         const shortSpecies = species ? species.split('(')[0].split(',')[0].trim() : ''
-        const autoName = shortSpecies ? `${shortSpecies} - ${defaultRoom}` : ''
 
-        setEntries((prev) => prev.map((e) => e.id === entry.id ? {
+        setEntries((prev) => prev.map((e) => {
+          if (e.id !== entry.id) return e
+          const roomLabel = e.form.room || defaultRoom
+          const autoName = shortSpecies ? `${shortSpecies} - ${roomLabel}` : ''
+          return {
           ...e,
           status: 'ready',
           form: {
@@ -106,7 +113,8 @@ export default function BulkUploadPage() {
             ...(result.potSize ? { potSize: result.potSize } : {}),
             ...(result.soilType ? { soilType: result.soilType } : {}),
           },
-        } : e))
+        }
+        }))
       } catch (err) {
         setEntries((prev) => prev.map((e) => e.id === entry.id ? {
           ...e,

--- a/src/utils/reorganise.js
+++ b/src/utils/reorganise.js
@@ -1,0 +1,73 @@
+/**
+ * Calculate new positions for plants to distribute them evenly within their assigned rooms.
+ *
+ * @param {Array} plants - Plants on the current floor
+ * @param {Array} rooms - Room definitions with { name, x, y, width, height, hidden }
+ * @returns {Object} Map of plantId -> { x, y, room }
+ */
+export function calculateReorganisedPositions(plants, rooms) {
+  if (!rooms?.length || !plants?.length) return {}
+
+  // Build a lookup of room bounds (visible rooms only)
+  const roomBounds = {}
+  for (const room of rooms) {
+    if (room.hidden) continue
+    roomBounds[room.name] = room
+  }
+
+  // Group plants by room
+  const groups = {}
+  const unassigned = []
+  for (const plant of plants) {
+    const room = plant.room
+    if (room && roomBounds[room]) {
+      if (!groups[room]) groups[room] = []
+      groups[room].push(plant)
+    } else {
+      unassigned.push(plant)
+    }
+  }
+
+  const updates = {}
+
+  // For each room, lay plants out in a grid with padding
+  for (const [roomName, roomPlants] of Object.entries(groups)) {
+    layoutInBounds(roomPlants, roomBounds[roomName], roomName, updates)
+  }
+
+  // For unassigned plants, place in the first visible room
+  if (unassigned.length > 0) {
+    const firstRoom = rooms.find((r) => !r.hidden)
+    if (firstRoom) {
+      layoutInBounds(unassigned, firstRoom, firstRoom.name, updates)
+    }
+  }
+
+  return updates
+}
+
+function layoutInBounds(plants, bounds, roomName, updates) {
+  const count = plants.length
+  if (count === 0) return
+
+  const pad = Math.min(2, bounds.width * 0.08, bounds.height * 0.08)
+  const innerW = bounds.width - pad * 2
+  const innerH = bounds.height - pad * 2
+
+  // Calculate grid dimensions — prefer wider grids
+  const cols = Math.ceil(Math.sqrt(count))
+  const rows = Math.ceil(count / cols)
+
+  const spacingX = cols > 1 ? innerW / cols : 0
+  const spacingY = rows > 1 ? innerH / rows : 0
+  const offsetX = bounds.x + pad + spacingX / 2
+  const offsetY = bounds.y + pad + spacingY / 2
+
+  plants.forEach((plant, i) => {
+    const col = i % cols
+    const row = Math.floor(i / cols)
+    const x = Math.round((offsetX + col * spacingX) * 10) / 10
+    const y = Math.round((offsetY + row * spacingY) * 10) / 10
+    updates[plant.id] = { x, y, room: roomName }
+  })
+}


### PR DESCRIPTION
Bulk upload was defaulting all plants to the first room across all floors
(typically "Living") instead of the active floor's rooms. Fixed by deriving
the default room from the active floor. Also auto-updates the room when
changing floors in BulkPlantCard so it doesn't keep a stale room name.

Added a Reorganise button to the floorplan panel that distributes plants
evenly within their assigned room bounds using a grid layout. Unassigned
plants are placed in the first visible room. Positions are marked dirty
so the user can review and save/discard.

https://claude.ai/code/session_01SurXUFX7jWWssXYkaqBvBv