### PR TITLE
Fix bulk upload plants not saving when image signing fails

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -902,7 +902,9 @@ app.post('/plants', requireUser, async (req, res) => {
     const data = { ...body, createdAt: now, updatedAt: now };
     const docRef = await userPlants(req.userId).add(data);
     const response = { id: docRef.id, ...data };
-    await signPlantData(response);
+    try { await signPlantData(response); } catch (signErr) {
+      log.warn('sign-after-create failed', { plantId: docRef.id, error: signErr.message });
+    }
     res.status(201).json(response);
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -545,6 +545,18 @@ describe('POST /plants', () => {
     expect(store[plantPath(res.body.id)].imageBase64).toBeUndefined();
   });
 
+  it('returns 201 even when image signing fails after save', async () => {
+    storageSignedUrlFn = async () => { throw new Error('signing unavailable'); };
+    const res = await request(app)
+      .post('/plants').set('Authorization', authHeader())
+      .send({ name: 'Bulk Plant', imageUrl: 'https://storage.googleapis.com/bucket/plants/abc.jpg', floor: 'ground', x: 50, y: 50 });
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBeTruthy();
+    expect(res.body.name).toBe('Bulk Plant');
+    // Plant should be stored in Firestore despite signing failure
+    expect(store[plantPath(res.body.id)].name).toBe('Bulk Plant');
+  });
+
   it('stores sunExposure and sunHoursPerDay fields', async () => {
     const res = await request(app)
       .post('/plants').set('Authorization', authHeader())

--- a/src/__tests__/BulkUploadPage.test.jsx
+++ b/src/__tests__/BulkUploadPage.test.jsx
@@ -189,4 +189,70 @@ describe('BulkUploadPage', () => {
 
     await waitFor(() => expect(screen.getByRole('button', { name: /add more/i })).toBeInTheDocument())
   })
+
+  it('passes analysis recommendations and imageUrl in save data', async () => {
+    renderPage()
+
+    const input = document.querySelector('input[type="file"]')
+    const file = createImageFile()
+
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } })
+    })
+    await waitFor(() => expect(screen.getByText(/1 ready/)).toBeInTheDocument())
+
+    const saveBtn = screen.getByRole('button', { name: /save 1 plant$/i })
+    await act(async () => {
+      fireEvent.click(saveBtn)
+    })
+
+    await waitFor(() => expect(mockHandleBulkCreatePlants).toHaveBeenCalledTimes(1))
+    const [plants] = mockHandleBulkCreatePlants.mock.calls[0]
+    expect(plants).toHaveLength(1)
+    expect(plants[0]).toMatchObject({
+      name: expect.stringContaining('Monstera'),
+      species: 'Monstera deliciosa',
+      imageUrl: 'https://storage.example.com/plants/img.jpg',
+      floor: 'ground',
+      room: 'Kitchen',
+      recommendations: expect.any(Array),
+    })
+  })
+
+  it('shows saved badge after successful save', async () => {
+    renderPage()
+
+    const input = document.querySelector('input[type="file"]')
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [createImageFile()] } })
+    })
+    await waitFor(() => expect(screen.getByText(/1 ready/)).toBeInTheDocument())
+
+    const saveBtn = screen.getByRole('button', { name: /save 1 plant$/i })
+    await act(async () => {
+      fireEvent.click(saveBtn)
+    })
+
+    await waitFor(() => expect(screen.getByText(/1 saved/)).toBeInTheDocument())
+  })
+
+  it('saves multiple plants and all reach saved status', async () => {
+    renderPage()
+
+    const input = document.querySelector('input[type="file"]')
+    const files = [createImageFile('a.jpg'), createImageFile('b.jpg'), createImageFile('c.jpg')]
+
+    await act(async () => {
+      fireEvent.change(input, { target: { files } })
+    })
+    await waitFor(() => expect(screen.getByText(/3 ready/)).toBeInTheDocument())
+
+    const saveBtn = screen.getByRole('button', { name: /save 3 plants/i })
+    await act(async () => {
+      fireEvent.click(saveBtn)
+    })
+
+    await waitFor(() => expect(screen.getByText(/3 saved/)).toBeInTheDocument())
+    expect(mockHandleBulkCreatePlants).toHaveBeenCalledTimes(3)
+  })
 })

--- a/src/pages/BulkUploadPage.jsx
+++ b/src/pages/BulkUploadPage.jsx
@@ -100,6 +100,7 @@ export default function BulkUploadPage() {
           return {
           ...e,
           status: 'ready',
+          analysisRecommendations: result.recommendations || [],
           form: {
             ...e.form,
             name: autoName,
@@ -158,10 +159,8 @@ export default function BulkUploadPage() {
         const plantData = {
           ...entry.form,
           imageUrl,
-          recommendations: [],
+          recommendations: entry.analysisRecommendations || [],
         }
-        // Remove the imageFile field if present
-        delete plantData.imageFile
         // Create via context
         const results = await handleBulkCreatePlants([plantData])
         const result = results[0]


### PR DESCRIPTION
The POST /plants endpoint saved the plant to Firestore, then called
signPlantData() to sign the imageUrl for the response. If signing
threw (e.g. GCS permission issue, transient error), the entire
handler returned 500 even though the plant was already persisted.
This uniquely affected bulk upload because every bulk-uploaded plant
has an imageUrl (the user always drops a photo), while single plant
creation via PlantModal can work without a photo.

Fix: wrap signPlantData in a try-catch so the 201 response is always
returned after a successful Firestore write. Signing failures are
logged as warnings instead of surfaced as errors.

Also fix bulk upload discarding AI analysis recommendations — they
were hardcoded to [] instead of being passed through from the
analysis result.

https://claude.ai/code/session_017NpvnnrBvNNTbPiZcV4SRz