### PR TITLE
Add navigation tabs bar for quick page navigation

### DIFF
--- a/src/assets/sass/app/_plant-tracker.scss
+++ b/src/assets/sass/app/_plant-tracker.scss
@@ -104,6 +104,23 @@
   }
 }
 
+/* Navigation tabs */
+.nav-tab {
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 0.375rem 0.75rem;
+  white-space: nowrap;
+
+  &.active {
+    font-weight: 600;
+  }
+}
+
+.nav-tabs-bar {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 /* Watering ripple */
 @keyframes water-ripple {
   0% { transform: scale(0.8); opacity: 0.6; }

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext.jsx'
 import { PlantProvider } from '../context/PlantContext.jsx'
 import Sidebar from './components/Sidebar.jsx'
 import Topbar from './components/Topbar.jsx'
+import NavigationTabs from './components/NavigationTabs.jsx'
 import Onboarding from '../components/Onboarding.jsx'
 
 function Loader() {
@@ -28,6 +29,7 @@ export default function MainLayout() {
         <Topbar />
         <Sidebar />
         <main className="app-body">
+          <NavigationTabs />
           <div className="app-content">
             <Suspense fallback={<Loader />}>
               <Outlet />

--- a/src/layouts/components/NavigationTabs.jsx
+++ b/src/layouts/components/NavigationTabs.jsx
@@ -1,0 +1,34 @@
+import { NavLink } from 'react-router'
+import Nav from 'react-bootstrap/Nav'
+import { menuItems } from './menuData.js'
+
+const navItems = menuItems.filter((item) => !item.isTitle && item.url)
+
+export default function NavigationTabs() {
+  return (
+    <div className="nav-tabs-bar d-flex align-items-center px-3 py-2 border-bottom bg-body">
+      <Nav variant="pills" className="gap-1 flex-nowrap overflow-auto">
+        {navItems.map((item) => (
+          <Nav.Item key={item.key}>
+            <NavLink
+              to={item.url}
+              end={item.url === '/'}
+              className={({ isActive }) =>
+                `nav-link nav-tab py-1 px-2${isActive ? ' active' : ''}`
+              }
+            >
+              <span className="d-inline-flex align-items-center gap-1">
+                {item.icon && (
+                  <svg className="sa-icon" style={{ width: 14, height: 14 }}>
+                    <use href={item.icon}></use>
+                  </svg>
+                )}
+                {item.label}
+              </span>
+            </NavLink>
+          </Nav.Item>
+        ))}
+      </Nav>
+    </div>
+  )
+}


### PR DESCRIPTION
Adds pill-style navigation tabs above the main content area, matching
the floor tab styling. Tabs link to all app pages (Dashboard, Analytics,
Care Calendar, Forecast, Bulk Upload, Settings) with active state
highlighting and icons from the SVG sprite.

https://claude.ai/code/session_01PuytUDdnc6Rv6hwK7AcFnL