### PR TITLE
Remove outdoor zone panels from Dashboard, unify into single floorplan

### DIFF
--- a/src/__tests__/FloorplanPanel.test.jsx
+++ b/src/__tests__/FloorplanPanel.test.jsx
@@ -35,10 +35,9 @@ vi.mock('../components/LeafletFloorplan.jsx', () => ({
 
 // Render the house frame's children directly so assertions are simple
 vi.mock('../components/HouseWeatherFrame.jsx', () => ({
-  default: ({ children, yardAreas }) => (
+  default: ({ children }) => (
     <div data-testid="house-frame">
       {children}
-      <div data-testid="yard-areas" data-area-keys={yardAreas ? Object.keys(yardAreas).join(',') : ''} />
     </div>
   ),
 }))
@@ -105,11 +104,6 @@ function setupContexts(overrides = {}) {
   }
   layoutContextValue = {
     houseHeight: 500,
-    frontyardHeight: 200,
-    backyardHeight: 200,
-    sideLeftWidth: 140,
-    sideRightWidth: 140,
-    hiddenYardAreas: overrides.hiddenYardAreas ?? [],
   }
 }
 
@@ -146,60 +140,25 @@ describe('FloorplanPanel', () => {
     expect(screen.queryByText('Secret')).not.toBeInTheDocument()
   })
 
-  it('renders yard area tabs for outdoor areas that have rooms', () => {
+  it('renders the full floor — indoor and outdoor rooms — in a single map', () => {
     render(<FloorplanPanel onPlantClick={vi.fn()} onFloorplanClick={vi.fn()} />)
 
-    expect(screen.getByText('Front Yard')).toBeInTheDocument()
-    expect(screen.getByText('Backyard')).toBeInTheDocument()
-    expect(screen.queryByText('Side Left')).not.toBeInTheDocument()
-    expect(screen.queryByText('Side Right')).not.toBeInTheDocument()
+    const stub = screen.getByTestId('leaflet-stub')
+    expect(stub.dataset.floorId).toBe('ground')
+    // All 3 plants (indoor + outdoor) are rendered together
+    expect(stub.dataset.plantCount).toBe('3')
   })
 
-  it('omits yard tabs for areas hidden via layout settings', () => {
-    setupContexts({ hiddenYardAreas: ['backyard'] })
-
-    render(<FloorplanPanel onPlantClick={vi.fn()} onFloorplanClick={vi.fn()} />)
-
-    expect(screen.getByText('Front Yard')).toBeInTheDocument()
-    expect(screen.queryByText('Backyard')).not.toBeInTheDocument()
-  })
-
-  it('switches to a yard area when its tab is clicked and renders only that area\u2019s plants', () => {
-    render(<FloorplanPanel onPlantClick={vi.fn()} onFloorplanClick={vi.fn()} />)
-
-    // Initially the indoor floor view is active
-    const [initialStub] = screen.getAllByTestId('leaflet-stub')
-    expect(initialStub.dataset.floorId).toBe('ground')
-
-    fireEvent.click(screen.getByText('Front Yard'))
-
-    const stubs = screen.getAllByTestId('leaflet-stub')
-    const yardStub = stubs.find((s) => s.dataset.floorId === 'ground-frontyard')
-    expect(yardStub).toBeDefined()
-    expect(yardStub.dataset.floorType).toBe('outdoor')
-    // Only the Rose plant lives in the frontyard area
-    expect(yardStub.dataset.plantCount).toBe('1')
-  })
-
-  it('clicking a floor tab clears the active yard area and switches floors', () => {
+  it('clicking a floor tab switches floors', () => {
     const otherFloor = makeFloor({ id: 'first', name: 'First', order: 1, rooms: [] })
     const floors = [makeFloor(), otherFloor]
     setupContexts({ floors, floor: floors[0] })
 
     render(<FloorplanPanel onPlantClick={vi.fn()} onFloorplanClick={vi.fn()} />)
 
-    fireEvent.click(screen.getByText('Front Yard'))
     fireEvent.click(screen.getByText('First'))
 
     expect(setActiveFloorIdMock).toHaveBeenCalledWith('first')
-  })
-
-  it('passes yard area tiles to HouseWeatherFrame', () => {
-    render(<FloorplanPanel onPlantClick={vi.fn()} onFloorplanClick={vi.fn()} />)
-
-    const yardAreas = screen.getByTestId('yard-areas')
-    const keys = yardAreas.dataset.areaKeys.split(',').filter(Boolean)
-    expect(keys.sort()).toEqual(['backyard', 'frontyard'])
   })
 
   it('toggles between 2D and 3D views', () => {
@@ -227,15 +186,11 @@ describe('FloorplanPanel', () => {
     expect(screen.getByRole('button', { name: /Reorganise/i })).toBeInTheDocument()
   })
 
-  it('shows the analysing overlay only when no yard tab is active', () => {
+  it('shows the analysing overlay while the floorplan is being analysed', () => {
     setupContexts({ isAnalysingFloorplan: true })
 
-    const { rerender } = render(<FloorplanPanel onPlantClick={vi.fn()} onFloorplanClick={vi.fn()} />)
+    render(<FloorplanPanel onPlantClick={vi.fn()} onFloorplanClick={vi.fn()} />)
     expect(screen.getByText(/Analysing floorplan/i)).toBeInTheDocument()
-
-    fireEvent.click(screen.getByText('Front Yard'))
-
-    expect(screen.queryByText(/Analysing floorplan/i)).not.toBeInTheDocument()
   })
 
   it('renders only a legend but no map when activeFloorId does not match any floor', () => {
@@ -263,7 +218,7 @@ describe('FloorplanPanel', () => {
     expect(screen.queryByText('Overdue')).not.toBeInTheDocument()
   })
 
-  it('treats outdoor-type floors as a single outdoor map', () => {
+  it('renders outdoor-type floors as a single map', () => {
     const floor = makeFloor({
       id: 'yard',
       name: 'Yard',
@@ -284,9 +239,10 @@ describe('FloorplanPanel', () => {
 
     render(<FloorplanPanel onPlantClick={vi.fn()} onFloorplanClick={vi.fn()} />)
 
-    // Both yard areas should still appear as tabs when floor itself is outdoor
-    expect(screen.getByText('Backyard')).toBeInTheDocument()
-    expect(screen.getByText('Front Yard')).toBeInTheDocument()
+    const stub = screen.getByTestId('leaflet-stub')
+    expect(stub.dataset.floorId).toBe('yard')
+    expect(stub.dataset.floorType).toBe('outdoor')
+    expect(stub.dataset.plantCount).toBe('1')
   })
 
   it('persists dragged positions locally and updates the ref for saving', () => {

--- a/src/__tests__/HouseWeatherFrame.test.jsx
+++ b/src/__tests__/HouseWeatherFrame.test.jsx
@@ -106,36 +106,25 @@ describe('HouseWeatherFrame', () => {
     expect(onLocationClick).toHaveBeenCalled()
   })
 
-  it('renders the front yard tile when provided', () => {
-    render(
-      <HouseWeatherFrame
-        weather={baseWeather}
-        yardAreas={{ frontyard: <div data-testid="fy">fy</div> }}
-      >
-        <div />
+  it('uses a solid background for indoor floors by default', () => {
+    const { container } = render(
+      <HouseWeatherFrame weather={baseWeather}>
+        <div data-testid="child">c</div>
       </HouseWeatherFrame>,
     )
-    expect(screen.getByTestId('fy')).toBeInTheDocument()
-    expect(screen.getByText('Front Yard')).toBeInTheDocument()
+    const houseCol = container.querySelector('[data-testid="child"]').parentElement
+    expect(houseCol.style.background).not.toBe('transparent')
+    expect(houseCol.style.background).toBeTruthy()
   })
 
-  it('renders backyard, side-left, and side-right tiles when provided', () => {
-    render(
-      <HouseWeatherFrame
-        weather={baseWeather}
-        yardAreas={{
-          backyard: <div data-testid="by">by</div>,
-          'side-left': <div data-testid="sl">sl</div>,
-          'side-right': <div data-testid="sr">sr</div>,
-        }}
-      >
-        <div />
+  it('uses a transparent background when isOutdoor is true', () => {
+    const { container } = render(
+      <HouseWeatherFrame weather={baseWeather} isOutdoor>
+        <div data-testid="child">c</div>
       </HouseWeatherFrame>,
     )
-    expect(screen.getByTestId('by')).toBeInTheDocument()
-    expect(screen.getAllByTestId('sl').length).toBeGreaterThan(0)
-    expect(screen.getAllByTestId('sr').length).toBeGreaterThan(0)
-    expect(screen.getByText('Backyard')).toBeInTheDocument()
+    const houseCol = container.querySelector('[data-testid="child"]').parentElement
+    expect(houseCol.style.background).toBe('transparent')
   })
 
   it('applies the night configuration when isDay is false', () => {

--- a/src/components/FloorplanPanel.jsx
+++ b/src/components/FloorplanPanel.jsx
@@ -6,7 +6,6 @@ import { plantsApi } from '../api/plants.js'
 import LeafletFloorplan from './LeafletFloorplan.jsx'
 import HouseWeatherFrame from './HouseWeatherFrame.jsx'
 import { calculateReorganisedPositions } from '../utils/reorganise.js'
-import { isOutdoor, YARD_AREAS } from '../utils/watering.js'
 import { useLayoutContext } from '../context/LayoutContext.jsx'
 
 const Floorplan3D = lazy(() => import('./Floorplan3D.jsx'))
@@ -19,10 +18,9 @@ export default function FloorplanPanel({ onPlantClick, onFloorplanClick, gnomeWa
   } = usePlantContext()
 
   const navigate = useNavigate()
-  const { houseHeight, frontyardHeight, backyardHeight, sideLeftWidth, sideRightWidth, hiddenYardAreas } = useLayoutContext()
+  const { houseHeight } = useLayoutContext()
   const [viewMode, setViewMode] = useState('2d')
   const [saving, setSaving] = useState(false)
-  const [activeYardArea, setActiveYardArea] = useState(null)
 
   // Track dragged positions directly — { plantId: { x, y, room } }
   const dirtyMovesRef = useRef({})
@@ -41,98 +39,6 @@ export default function FloorplanPanel({ onPlantClick, onFloorplanClick, gnomeWa
     () => plants.filter((p) => (p.floor || 'ground') === activeFloorId),
     [plants, activeFloorId],
   )
-
-  // Split rooms and plants into indoor vs outdoor
-  const isOutdoorFloor = activeFloor?.type === 'outdoor'
-  const indoorRooms = useMemo(
-    () => (activeFloor?.rooms || []).filter((r) => {
-      if (r.hidden) return false
-      const t = r.type || activeFloor?.type || 'interior'
-      return t !== 'outdoor'
-    }),
-    [activeFloor],
-  )
-  const outdoorRooms = useMemo(
-    () => (activeFloor?.rooms || []).filter((r) => {
-      if (r.hidden) return false
-      const t = r.type || activeFloor?.type || 'interior'
-      return t === 'outdoor'
-    }),
-    [activeFloor],
-  )
-  const hasIndoorOutdoorSplit = !isOutdoorFloor && indoorRooms.length > 0 && outdoorRooms.length > 0
-
-  const indoorFloor = useMemo(() => {
-    if (!hasIndoorOutdoorSplit || !activeFloor) return activeFloor
-    return { ...activeFloor, rooms: indoorRooms }
-  }, [activeFloor, indoorRooms, hasIndoorOutdoorSplit])
-
-  // Group outdoor rooms by yard area
-  const outdoorByArea = useMemo(() => {
-    if (!activeFloor) return {}
-    const allOutdoor = isOutdoorFloor ? (activeFloor.rooms || []).filter((r) => !r.hidden) : outdoorRooms
-    if (allOutdoor.length === 0) return {}
-    const grouped = {}
-    for (const room of allOutdoor) {
-      const area = room.area || 'frontyard'
-      if (!grouped[area]) grouped[area] = []
-      grouped[area].push(room)
-    }
-    return grouped
-  }, [activeFloor, isOutdoorFloor, outdoorRooms])
-
-  const hasAnyOutdoorAreas = isOutdoorFloor || (hasIndoorOutdoorSplit && outdoorRooms.length > 0)
-
-  const indoorPlants = useMemo(() => {
-    if (isOutdoorFloor) return []
-    if (!hasIndoorOutdoorSplit) return plantsOnFloor
-    const outdoorRoomNames = new Set(outdoorRooms.map((r) => r.name))
-    return plantsOnFloor.filter((p) => !outdoorRoomNames.has(p.room))
-  }, [plantsOnFloor, outdoorRooms, hasIndoorOutdoorSplit, isOutdoorFloor])
-
-  // Group outdoor plants by their room's area
-  const outdoorPlantsByArea = useMemo(() => {
-    if (!hasAnyOutdoorAreas) return {}
-    const roomAreaMap = {}
-    const allOutdoor = isOutdoorFloor ? (activeFloor?.rooms || []) : outdoorRooms
-    for (const room of allOutdoor) {
-      roomAreaMap[room.name] = room.area || 'frontyard'
-    }
-    const outdoorRoomNames = new Set(allOutdoor.map((r) => r.name))
-    const relevantPlants = isOutdoorFloor ? plantsOnFloor : plantsOnFloor.filter((p) => outdoorRoomNames.has(p.room))
-    const grouped = {}
-    for (const plant of relevantPlants) {
-      const area = roomAreaMap[plant.room] || 'frontyard'
-      if (!grouped[area]) grouped[area] = []
-      grouped[area].push(plant)
-    }
-    return grouped
-  }, [plantsOnFloor, outdoorRooms, hasAnyOutdoorAreas, isOutdoorFloor, activeFloor])
-
-  // Yard area tabs — only areas that have rooms
-  const yardAreaTabs = useMemo(() => {
-    if (!hasAnyOutdoorAreas) return []
-    const hidden = hiddenYardAreas || []
-    return YARD_AREAS.filter((a) => !hidden.includes(a.id) && outdoorByArea[a.id]?.length > 0)
-  }, [hasAnyOutdoorAreas, outdoorByArea, hiddenYardAreas])
-
-  // Active yard area floor + plants for rendering in main map
-  const activeYardFloor = useMemo(() => {
-    if (!activeYardArea || !activeFloor) return null
-    const areaRooms = outdoorByArea[activeYardArea]
-    if (!areaRooms?.length) return null
-    return {
-      ...activeFloor,
-      id: `${activeFloor.id}-${activeYardArea}`,
-      type: 'outdoor',
-      rooms: areaRooms,
-    }
-  }, [activeYardArea, activeFloor, outdoorByArea])
-
-  const activeYardPlants = useMemo(() => {
-    if (!activeYardArea) return []
-    return outdoorPlantsByArea[activeYardArea] || []
-  }, [activeYardArea, outdoorPlantsByArea])
 
   const [hasDirty, setHasDirty] = useState(false)
 
@@ -209,72 +115,23 @@ export default function FloorplanPanel({ onPlantClick, onFloorplanClick, gnomeWa
     window.location.reload()
   }, [])
 
-  // Build yard area content for each area that has rooms
-  const yardAreaContent = useMemo(() => {
-    if (!hasAnyOutdoorAreas || viewMode !== '2d') return null
-    const hidden = hiddenYardAreas || []
-    const areas = {}
-    for (const areaId of YARD_AREAS.map((a) => a.id)) {
-      if (hidden.includes(areaId)) continue
-      const areaRooms = outdoorByArea[areaId]
-      if (!areaRooms?.length) continue
-      const areaFloor = {
-        ...activeFloor,
-        id: `${activeFloor.id}-${areaId}`,
-        type: 'outdoor',
-        rooms: areaRooms,
-      }
-      const areaPlants = outdoorPlantsByArea[areaId] || []
-      areas[areaId] = { floor: areaFloor, plants: areaPlants }
-    }
-    return Object.keys(areas).length > 0 ? areas : null
-  }, [hasAnyOutdoorAreas, viewMode, outdoorByArea, outdoorPlantsByArea, activeFloor, hiddenYardAreas])
-
-  const renderYardAreas = useMemo(() => {
-    if (!yardAreaContent) return null
-    const rendered = {}
-    for (const [areaId, { floor: areaFloor, plants: areaPlants }] of Object.entries(yardAreaContent)) {
-      const isSide = areaId === 'side-left' || areaId === 'side-right'
-      const areaHeight = areaId === 'frontyard' ? (frontyardHeight || 200)
-        : areaId === 'backyard' ? (backyardHeight || 200)
-        : undefined
-      rendered[areaId] = (
-        <div style={{ height: isSide ? '100%' : areaHeight, minHeight: isSide ? (houseHeight || 500) : undefined }}>
-          <LeafletFloorplan
-            key={areaFloor.id}
-            floor={areaFloor}
-            floors={floors}
-            plants={areaPlants}
-            weather={weather}
-            onFloorplanClick={onFloorplanClick}
-            onMarkerClick={onPlantClick}
-            onMarkerDrag={handleLocalDrag}
-            editMode={false}
-            onRoomsChange={handleFloorRoomsChange}
-          />
-        </div>
-      )
-    }
-    return rendered
-  }, [yardAreaContent, floors, weather, onFloorplanClick, onPlantClick, handleLocalDrag, handleFloorRoomsChange])
+  const isOutdoorFloor = activeFloor?.type === 'outdoor'
 
   return (
     <HouseWeatherFrame
       weather={weather}
       location={location}
       onLocationClick={() => navigate('/settings')}
-      yardAreas={renderYardAreas}
-      sideLeftWidth={sideLeftWidth}
-      sideRightWidth={sideRightWidth}
+      isOutdoor={isOutdoorFloor}
     >
-      {/* Floor + yard area tabs + view toggle */}
+      {/* Floor tabs + view toggle */}
       <div className="d-flex align-items-center justify-content-between px-3 py-2 border-bottom flex-wrap gap-2">
         <Nav variant="pills" className="gap-1 flex-nowrap overflow-auto flex-grow-1">
           {visibleFloors.map((f) => (
             <Nav.Item key={f.id}>
               <Nav.Link
-                active={!activeYardArea && f.id === activeFloorId}
-                onClick={() => { setActiveYardArea(null); setActiveFloorId(f.id) }}
+                active={f.id === activeFloorId}
+                onClick={() => setActiveFloorId(f.id)}
                 className="floor-tab py-1 px-2"
               >
                 <span className="d-inline-flex align-items-center gap-1">
@@ -284,22 +141,6 @@ export default function FloorplanPanel({ onPlantClick, onFloorplanClick, gnomeWa
                     </svg>
                   )}
                   {f.name}
-                </span>
-              </Nav.Link>
-            </Nav.Item>
-          ))}
-          {yardAreaTabs.map((area) => (
-            <Nav.Item key={area.id}>
-              <Nav.Link
-                active={activeYardArea === area.id}
-                onClick={() => setActiveYardArea(area.id)}
-                className="floor-tab py-1 px-2"
-              >
-                <span className="d-inline-flex align-items-center gap-1">
-                  <svg className="sa-icon sa-thin" style={{ width: 12, height: 12 }}>
-                    <use href="/icons/sprite.svg#sun"></use>
-                  </svg>
-                  {area.label}
                 </span>
               </Nav.Link>
             </Nav.Item>
@@ -326,8 +167,8 @@ export default function FloorplanPanel({ onPlantClick, onFloorplanClick, gnomeWa
       </div>
 
       {/* Map view */}
-      <div className="floorplan-wrapper" style={{ height: activeYardArea ? (houseHeight || 500) : (isOutdoorFloor ? 0 : (houseHeight || 500)) }}>
-        {isAnalysingFloorplan && !activeYardArea && (
+      <div className="floorplan-wrapper" style={{ height: houseHeight || 500 }}>
+        {isAnalysingFloorplan && (
           <div
             className="position-absolute d-flex flex-column align-items-center justify-content-center gap-2 w-100 h-100"
             style={{ background: 'rgba(0,0,0,0.7)', zIndex: 1000, top: 0, left: 0 }}
@@ -337,26 +178,12 @@ export default function FloorplanPanel({ onPlantClick, onFloorplanClick, gnomeWa
             <small className="text-muted">Identifying floors and rooms</small>
           </div>
         )}
-        {activeYardArea && activeYardFloor && viewMode === '2d' && (
+        {activeFloor && viewMode === '2d' && (
           <LeafletFloorplan
-            key={activeYardFloor.id}
-            floor={activeYardFloor}
+            key={activeFloor.id}
+            floor={activeFloor}
             floors={floors}
-            plants={activeYardPlants}
-            weather={weather}
-            onFloorplanClick={onFloorplanClick}
-            onMarkerClick={onPlantClick}
-            onMarkerDrag={handleLocalDrag}
-            editMode={false}
-            onRoomsChange={handleFloorRoomsChange}
-          />
-        )}
-        {!activeYardArea && activeFloor && viewMode === '2d' && !isOutdoorFloor && (
-          <LeafletFloorplan
-            key={indoorFloor?.id || activeFloor.id}
-            floor={hasIndoorOutdoorSplit ? indoorFloor : activeFloor}
-            floors={floors}
-            plants={hasIndoorOutdoorSplit ? indoorPlants : plantsOnFloor}
+            plants={plantsOnFloor}
             weather={weather}
             onFloorplanClick={onFloorplanClick}
             onMarkerClick={onPlantClick}

--- a/src/components/HouseWeatherFrame.jsx
+++ b/src/components/HouseWeatherFrame.jsx
@@ -20,39 +20,7 @@ const SEASON_PARTICLES = {
   winter: { emojis: ['❄️', '✨', '❄️'], count: 10 },
 }
 
-function YardAreaBox({ label, children, vertical }) {
-  return (
-    <div
-      style={{
-        borderRadius: 8,
-        overflow: 'visible',
-        border: '2px dashed rgba(255,255,255,0.4)',
-        background: 'rgba(255,255,255,0.1)',
-        backdropFilter: 'blur(2px)',
-        height: vertical ? '100%' : undefined,
-      }}
-    >
-      <div
-        style={{
-          padding: '3px 10px',
-          fontSize: '0.65rem',
-          fontWeight: 600,
-          color: 'rgba(255,255,255,0.7)',
-          textTransform: 'uppercase',
-          letterSpacing: '0.5px',
-          background: 'rgba(46,125,50,0.3)',
-          borderBottom: '1px solid rgba(255,255,255,0.15)',
-        }}
-      >
-        {label}
-      </div>
-      {children}
-    </div>
-  )
-}
-
-export default function HouseWeatherFrame({ weather, location, onLocationClick, children, yardAreas, sideLeftWidth = 140, sideRightWidth = 140 }) {
-  const hasSides = !!(yardAreas?.['side-left'] || yardAreas?.['side-right'])
+export default function HouseWeatherFrame({ weather, location, onLocationClick, children, isOutdoor = false }) {
   const condition = weather?.current?.condition?.sky || 'sunny'
   const isNight = weather?.current && !weather.current.isDay
   const config = isNight ? { ...WEATHER_CONFIGS.night } : (WEATHER_CONFIGS[condition] || WEATHER_CONFIGS.sunny)
@@ -290,74 +258,24 @@ export default function HouseWeatherFrame({ weather, location, onLocationClick, 
         </div>
       )}
 
-      {/* House shape with yard areas around it */}
+      {/* House shape — solid for indoor floors, transparent for outdoor zones */}
       <div className="position-relative" style={{ zIndex: 1, padding: '0 8px 15px' }}>
-        {/* Backyard — behind the house */}
-        {yardAreas?.backyard && (
-          <div className="mx-auto mb-2" style={{ width: '100%', maxWidth: hasSides ? 1100 : 920, position: 'relative', zIndex: 2 }}>
-            <YardAreaBox label="Backyard">{yardAreas.backyard}</YardAreaBox>
-          </div>
-        )}
-
-        {/* Main row: side-left + house + side-right */}
-        <div className="mx-auto d-flex gap-2" style={{ width: '100%', maxWidth: 1100, position: 'relative', zIndex: 2 }}>
-          {/* Side Left */}
-          {yardAreas?.['side-left'] && (
-            <div className="d-none d-lg-block flex-shrink-0" style={{ width: sideLeftWidth || 140 }}>
-              <YardAreaBox label="Side Left" vertical>{yardAreas['side-left']}</YardAreaBox>
-            </div>
-          )}
-
-          {/* House column */}
-          <div className="flex-grow-1 min-w-0">
-            <div
-              className="mx-auto"
-              style={{
-                width: '100%',
-                maxWidth: 920,
-                background: 'var(--bs-body-bg, #fff)',
-                borderRadius: 8,
-                boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
-                border: '1px solid rgba(0,0,0,0.06)',
-                overflow: 'hidden',
-                position: 'relative',
-                zIndex: 2,
-              }}
-            >
-              {children}
-            </div>
-          </div>
-
-          {/* Side Right */}
-          {yardAreas?.['side-right'] && (
-            <div className="d-none d-lg-block flex-shrink-0" style={{ width: sideRightWidth || 140 }}>
-              <YardAreaBox label="Side Right" vertical>{yardAreas['side-right']}</YardAreaBox>
-            </div>
-          )}
+        <div
+          className="mx-auto"
+          style={{
+            width: '100%',
+            maxWidth: 920,
+            background: isOutdoor ? 'transparent' : 'var(--bs-body-bg, #fff)',
+            borderRadius: 8,
+            boxShadow: isOutdoor ? 'none' : '0 4px 20px rgba(0,0,0,0.15)',
+            border: isOutdoor ? 'none' : '1px solid rgba(0,0,0,0.06)',
+            overflow: 'hidden',
+            position: 'relative',
+            zIndex: 2,
+          }}
+        >
+          {children}
         </div>
-
-        {/* Side areas on mobile — stacked below house */}
-        {(yardAreas?.['side-left'] || yardAreas?.['side-right']) && (
-          <div className="d-lg-none mx-auto mt-2 d-flex gap-2" style={{ width: '100%', maxWidth: 920 }}>
-            {yardAreas?.['side-left'] && (
-              <div className="flex-grow-1">
-                <YardAreaBox label="Side Left">{yardAreas['side-left']}</YardAreaBox>
-              </div>
-            )}
-            {yardAreas?.['side-right'] && (
-              <div className="flex-grow-1">
-                <YardAreaBox label="Side Right">{yardAreas['side-right']}</YardAreaBox>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Front Yard — in front of the house */}
-        {yardAreas?.frontyard && (
-          <div className="mx-auto mt-2" style={{ width: '100%', maxWidth: hasSides ? 1100 : 920, position: 'relative', zIndex: 2 }}>
-            <YardAreaBox label="Front Yard">{yardAreas.frontyard}</YardAreaBox>
-          </div>
-        )}
       </div>
 
       <style>{`


### PR DESCRIPTION
The separate Backyard, Side Left, Side Right, and Front Yard panels
surrounding the house are no longer needed — the main floorplan panel
now renders every room (indoor + outdoor) on the active floor in one
map. Also makes the floorplan background transparent when the active
floor is an outdoor zone so the weather scenery shows through, and
solid for indoor floors.