### PR TITLE
Track vertexai.js in coverage report

### DIFF
--- a/api/plants/vitest.config.mjs
+++ b/api/plants/vitest.config.mjs
@@ -6,7 +6,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      include: ['index.js'],
+      include: ['index.js', 'vertexai.js'],
       exclude: ['*.test.*', 'integration/**', 'node_modules/**'],
       thresholds: {
         statements: 80,


### PR DESCRIPTION
Adds vertexai.js to the vitest coverage include list so the Vertex AI
client module is measured alongside index.js in CI coverage checks.

https://claude.ai/code/session_01Gigiu5uWL7e7BRprchkvXw