### PR TITLE
Humanise error messages with inline retry & recovery (#219)

### DIFF
--- a/src/__tests__/BulkUploadPage.test.jsx
+++ b/src/__tests__/BulkUploadPage.test.jsx
@@ -17,6 +17,18 @@ vi.mock('../context/PlantContext.jsx', () => ({
   }),
 }))
 
+// UpgradePrompt (rendered by BulkUploadPage) reads SubscriptionContext — stub it
+// so we don't have to spin up the real provider for unit tests.
+vi.mock('../context/SubscriptionContext.jsx', () => ({
+  useSubscription: () => ({
+    billingEnabled: false,
+    tier: 'free',
+    canAccess: () => true,
+    isAtQuotaLimit: () => false,
+    getQuotaRemaining: () => Infinity,
+  }),
+}))
+
 // Mock API
 vi.mock('../api/plants.js', () => ({
   analyseApi: {

--- a/src/__tests__/ErrorAlert.test.jsx
+++ b/src/__tests__/ErrorAlert.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import ErrorAlert from '../components/ErrorAlert.jsx'
+
+describe('ErrorAlert', () => {
+  it('renders nothing when error is falsy', () => {
+    const { container } = render(<ErrorAlert error={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a title and recovery message from a raw error', () => {
+    render(<ErrorAlert error={new Error('Failed to fetch')} />)
+    // title is bold element
+    expect(screen.getByText(/couldn.t reach the server/i)).toBeInTheDocument()
+    expect(screen.getByText(/check your connection/i)).toBeInTheDocument()
+  })
+
+  it('calls onRetry when the retry button is clicked (retryable kind)', () => {
+    const onRetry = vi.fn()
+    render(<ErrorAlert error={new Error('Failed to fetch')} onRetry={onRetry} />)
+    const btn = screen.getByRole('button', { name: /retry/i })
+    fireEvent.click(btn)
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the retry button for non-retryable errors', () => {
+    const onRetry = vi.fn()
+    render(<ErrorAlert error={new Error('HTTP 401')} onRetry={onRetry} />)
+    // action for auth is "Sign in again" — but isRetryable=false means
+    // the retry button shouldn't render even when onRetry is passed.
+    expect(screen.queryByRole('button', { name: /sign in again/i })).toBeNull()
+  })
+
+  it('shows a Report button when onReport is provided and rawCode exists', () => {
+    const onReport = vi.fn()
+    render(<ErrorAlert error={new Error('Failed to fetch')} onReport={onReport} />)
+    const btn = screen.getByRole('button', { name: /report this/i })
+    fireEvent.click(btn)
+    expect(onReport).toHaveBeenCalledTimes(1)
+    expect(onReport).toHaveBeenCalledWith('Failed to fetch')
+  })
+
+  it('renders a dismiss control when onDismiss is provided', () => {
+    const onDismiss = vi.fn()
+    render(<ErrorAlert error={new Error('oops')} onDismiss={onDismiss} />)
+    const close = screen.getByLabelText(/close/i)
+    fireEvent.click(close)
+    expect(onDismiss).toHaveBeenCalled()
+  })
+
+  it('passes context through to the friendly copy', () => {
+    render(<ErrorAlert error={new Error('HTTP 404')} context="plant" />)
+    expect(screen.getByText(/plant/i)).toBeInTheDocument()
+  })
+
+  it('accepts an already-friendly error object', () => {
+    const friendly = {
+      title: 'Custom title', message: 'Custom message', action: 'Do it',
+      kind: 'transient', isRetryable: true, rawCode: 'x',
+    }
+    const onRetry = vi.fn()
+    render(<ErrorAlert error={friendly} onRetry={onRetry} />)
+    expect(screen.getByText('Custom title')).toBeInTheDocument()
+    expect(screen.getByText('Custom message')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /do it/i })).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/ErrorBoundary.test.jsx
+++ b/src/__tests__/ErrorBoundary.test.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import ErrorBoundary from '../components/ErrorBoundary.jsx'
+
+function Boom({ shouldThrow }) {
+  if (shouldThrow) throw new Error('Failed to fetch')
+  return <div>all good</div>
+}
+
+describe('ErrorBoundary', () => {
+  let errSpy
+  beforeAll(() => {
+    // React logs errors from caught boundaries — keep test output clean.
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterAll(() => {
+    errSpy.mockRestore()
+  })
+
+  it('renders children when no error is thrown', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={false} />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByText('all good')).toBeInTheDocument()
+  })
+
+  it('renders the friendly fallback when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={true} />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByText(/couldn.t reach the server/i)).toBeInTheDocument()
+  })
+
+  it('allows recovery by clicking the action button', () => {
+    function Controlled({ state }) {
+      return (
+        <ErrorBoundary>
+          <Boom shouldThrow={state.throw} />
+        </ErrorBoundary>
+      )
+    }
+    const state = { throw: true }
+    const { rerender } = render(<Controlled state={state} />)
+    expect(screen.getByText(/couldn.t reach the server/i)).toBeInTheDocument()
+
+    state.throw = false
+    // Reset boundary state by clicking the primary action.
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    rerender(<Controlled state={state} />)
+    expect(screen.getByText('all good')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/ErrorBoundary.test.jsx
+++ b/src/__tests__/ErrorBoundary.test.jsx
@@ -37,21 +37,23 @@ describe('ErrorBoundary', () => {
   })
 
   it('allows recovery by clicking the action button', () => {
-    function Controlled({ state }) {
+    function Controlled({ shouldThrow }) {
       return (
         <ErrorBoundary>
-          <Boom shouldThrow={state.throw} />
+          <Boom shouldThrow={shouldThrow} />
         </ErrorBoundary>
       )
     }
-    const state = { throw: true }
-    const { rerender } = render(<Controlled state={state} />)
+    const { rerender } = render(<Controlled shouldThrow={true} />)
     expect(screen.getByText(/couldn.t reach the server/i)).toBeInTheDocument()
 
-    state.throw = false
-    // Reset boundary state by clicking the primary action.
+    // Re-render with non-throwing children BEFORE clicking — otherwise the
+    // stale captured element still throws on the boundary's reset render.
+    rerender(<Controlled shouldThrow={false} />)
+    // Boundary is still showing the fallback until we explicitly reset its
+    // internal error state via the action button.
+    expect(screen.getByText(/couldn.t reach the server/i)).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /retry/i }))
-    rerender(<Controlled state={state} />)
     expect(screen.getByText('all good')).toBeInTheDocument()
   })
 })

--- a/src/__tests__/OfflineBanner.test.jsx
+++ b/src/__tests__/OfflineBanner.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import OfflineBanner from '../components/OfflineBanner.jsx'
+import { PlantContext } from '../context/PlantContext.jsx'
+
+function wrap(ctx, ui) {
+  return <PlantContext.Provider value={ctx}>{ui}</PlantContext.Provider>
+}
+
+describe('OfflineBanner', () => {
+  it('renders nothing when online', () => {
+    const { container } = render(wrap({ isOnline: true, pendingSyncCount: 0 }, <OfflineBanner />))
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the banner when offline', () => {
+    render(wrap({ isOnline: false, pendingSyncCount: 0 }, <OfflineBanner />))
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByText(/you.re offline/i)).toBeInTheDocument()
+  })
+
+  it('includes the queued-count when pendingSyncCount > 0', () => {
+    render(wrap({ isOnline: false, pendingSyncCount: 3 }, <OfflineBanner />))
+    expect(screen.getByText(/3 queued/i)).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/PlantModal.test.jsx
+++ b/src/__tests__/PlantModal.test.jsx
@@ -417,7 +417,9 @@ describe('PlantModal', () => {
     renderModal({ plant: existingPlant })
     fireEvent.click(screen.getByText('Care'))
     fireEvent.click(screen.getByRole('button', { name: /get recommendations|refresh/i }))
-    expect(await screen.findByText(/network error/i)).toBeInTheDocument()
+    // Raw "Network error" is mapped to friendly recovery copy.
+    expect(await screen.findByText(/check your connection/i)).toBeInTheDocument()
+    expect(screen.queryByText(/^network error$/i)).not.toBeInTheDocument()
   })
 
   it('surfaces a friendly message when a jsonrepair-style parse error bubbles up', async () => {

--- a/src/__tests__/errorMessages.test.js
+++ b/src/__tests__/errorMessages.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { toFriendlyError, friendlyErrorMessage } from '../utils/errorMessages.js'
+
+describe('toFriendlyError', () => {
+  it('returns offline kind when navigator is offline', () => {
+    const result = toFriendlyError(new Error('anything'), { online: false })
+    expect(result.kind).toBe('offline')
+    expect(result.isRetryable).toBe(true)
+    expect(result.title).toMatch(/offline/i)
+  })
+
+  it('maps network failures to transient kind', () => {
+    const result = toFriendlyError(new Error('Failed to fetch'), { online: true })
+    expect(result.kind).toBe('transient')
+    expect(result.isRetryable).toBe(true)
+    expect(result.title).not.toMatch(/failed to fetch/i)
+    expect(result.rawCode).toBe('Failed to fetch')
+  })
+
+  it('maps 401 / unauthenticated to auth kind', () => {
+    const a = toFriendlyError(new Error('HTTP 401'), { online: true })
+    const b = toFriendlyError(new Error('Request unauthenticated'), { online: true })
+    expect(a.kind).toBe('auth')
+    expect(b.kind).toBe('auth')
+    expect(a.isRetryable).toBe(false)
+    expect(a.action).toMatch(/sign in/i)
+  })
+
+  it('maps 403 / permission denied to permission kind', () => {
+    const result = toFriendlyError(new Error('PERMISSION_DENIED'), { online: true })
+    expect(result.kind).toBe('permission')
+    expect(result.isRetryable).toBe(false)
+  })
+
+  it('interpolates the context into permission copy', () => {
+    const result = toFriendlyError(new Error('Forbidden'), { context: 'delete this plant', online: true })
+    expect(result.message).toMatch(/delete this plant/)
+  })
+
+  it('maps 429 / quota / RESOURCE_EXHAUSTED to quota kind', () => {
+    const a = toFriendlyError(new Error('HTTP 429 rate limit'), { online: true })
+    const b = toFriendlyError(new Error('RESOURCE_EXHAUSTED: quota'), { online: true })
+    expect(a.kind).toBe('quota')
+    expect(b.kind).toBe('quota')
+    expect(a.isRetryable).toBe(true)
+  })
+
+  it('maps Gemini overload and 503 to transient', () => {
+    const a = toFriendlyError(new Error('model overloaded'), { online: true })
+    const b = toFriendlyError(new Error('HTTP 503 Service Unavailable'), { online: true })
+    expect(a.kind).toBe('transient')
+    expect(b.kind).toBe('transient')
+  })
+
+  it('maps 502/504 gateway/timeout to transient', () => {
+    const a = toFriendlyError(new Error('HTTP 504 Gateway Timeout'), { online: true })
+    const b = toFriendlyError(new Error('request timed out'), { online: true })
+    expect(a.kind).toBe('transient')
+    expect(b.kind).toBe('transient')
+  })
+
+  it('maps generic 5xx to transient', () => {
+    const result = toFriendlyError(new Error('HTTP 500 internal server error'), { online: true })
+    expect(result.kind).toBe('transient')
+    expect(result.isRetryable).toBe(true)
+  })
+
+  it('maps Gemini JSON parse errors to transient with recovery copy', () => {
+    const result = toFriendlyError(new Error('Object key expected at position 15'), { online: true })
+    expect(result.kind).toBe('transient')
+    expect(result.title).toMatch(/AI/i)
+  })
+
+  it('maps 400-style validation errors to input kind', () => {
+    const result = toFriendlyError(new Error('HTTP 400 name is required'), { online: true })
+    expect(result.kind).toBe('input')
+    expect(result.isRetryable).toBe(false)
+  })
+
+  it('maps 404 to input kind with context in copy', () => {
+    const result = toFriendlyError(new Error('HTTP 404 not found'), { context: 'plant', online: true })
+    expect(result.kind).toBe('input')
+    expect(result.message).toMatch(/plant/)
+  })
+
+  it('maps GCS upload failures to transient', () => {
+    const result = toFriendlyError(new Error('GCS upload failed: 403'), { online: true })
+    expect(result.kind).toBe('transient')
+    expect(result.action).toMatch(/retry/i)
+  })
+
+  it('falls back to unknown for unmatched errors', () => {
+    const result = toFriendlyError(new Error('weird novel error'), { online: true })
+    expect(result.kind).toBe('unknown')
+    expect(result.isRetryable).toBe(true)
+    expect(result.rawCode).toBe('weird novel error')
+  })
+
+  it('accepts strings and nullish inputs without throwing', () => {
+    expect(toFriendlyError('Failed to fetch', { online: true }).kind).toBe('transient')
+    expect(toFriendlyError(null, { online: true }).kind).toBe('unknown')
+    expect(toFriendlyError(undefined, { online: true }).kind).toBe('unknown')
+  })
+
+  it('never surfaces a raw stack trace in the user-facing title/message', () => {
+    const stack = 'TypeError: x is not a function\n    at foo (file.js:12:34)'
+    const result = toFriendlyError({ message: stack }, { online: true })
+    expect(result.title).not.toMatch(/TypeError/)
+    expect(result.message).not.toMatch(/at foo/)
+  })
+})
+
+describe('friendlyErrorMessage', () => {
+  it('returns just the friendly message string', () => {
+    const result = friendlyErrorMessage(new Error('Failed to fetch'), { online: true })
+    expect(typeof result).toBe('string')
+    expect(result).toMatch(/connection/i)
+  })
+})

--- a/src/components/ErrorAlert.jsx
+++ b/src/components/ErrorAlert.jsx
@@ -1,0 +1,93 @@
+import { Alert, Button } from 'react-bootstrap'
+import { toFriendlyError } from '../utils/errorMessages.js'
+
+const ICON_BY_KIND = {
+  offline: 'wifi-off',
+  auth: 'lock',
+  permission: 'lock',
+  quota: 'clock',
+  transient: 'alert-triangle',
+  input: 'alert-circle',
+  unknown: 'alert-triangle',
+}
+
+const VARIANT_BY_KIND = {
+  offline: 'warning',
+  auth: 'warning',
+  permission: 'warning',
+  quota: 'info',
+  transient: 'danger',
+  input: 'danger',
+  unknown: 'danger',
+}
+
+/**
+ * Displays a `FriendlyError` (or raw error converted on the fly) with an
+ * icon, recovery copy, and optional retry / secondary actions.
+ *
+ * Props:
+ *   - error        required. Either a FriendlyError from `toFriendlyError()`
+ *                  or any raw error-like value (string / Error).
+ *   - context      string passed through to `toFriendlyError` when `error` is raw.
+ *   - onRetry      if provided, renders a retry button labelled from the
+ *                  friendly action.
+ *   - onDismiss    if provided, renders the dismiss "×" control.
+ *   - onReport     optional "Report this" CTA; receives the rawCode string.
+ *   - className    bootstrap alert className override.
+ *   - size         'sm' gives denser padding for inline slots.
+ */
+export default function ErrorAlert({ error, context, onRetry, onDismiss, onReport, className = '', size }) {
+  if (!error) return null
+
+  const friendly = error.kind && error.title ? error : toFriendlyError(error, { context })
+  const icon = ICON_BY_KIND[friendly.kind] || ICON_BY_KIND.unknown
+  const variant = VARIANT_BY_KIND[friendly.kind] || VARIANT_BY_KIND.unknown
+  const denseClass = size === 'sm' ? 'py-2 fs-sm mb-2' : 'mb-3'
+
+  return (
+    <Alert
+      variant={variant}
+      className={`${denseClass} ${className}`}
+      dismissible={Boolean(onDismiss)}
+      onClose={onDismiss}
+      role="alert"
+    >
+      <div className="d-flex gap-2 align-items-start">
+        <svg
+          className="sa-icon flex-shrink-0 mt-1"
+          style={{ width: 18, height: 18 }}
+          aria-hidden="true"
+        >
+          <use href={`/icons/sprite.svg#${icon}`}></use>
+        </svg>
+        <div className="flex-grow-1">
+          <strong className="d-block">{friendly.title}</strong>
+          <div className="fs-sm">{friendly.message}</div>
+          {(onRetry || onReport) && (
+            <div className="d-flex gap-2 mt-2 flex-wrap">
+              {onRetry && friendly.isRetryable && (
+                <Button
+                  size="sm"
+                  variant={variant === 'danger' ? 'outline-danger' : `outline-${variant}`}
+                  onClick={onRetry}
+                >
+                  {friendly.action}
+                </Button>
+              )}
+              {onReport && friendly.rawCode && (
+                <Button
+                  size="sm"
+                  variant="link"
+                  className="text-muted p-0"
+                  onClick={() => onReport(friendly.rawCode)}
+                >
+                  Report this
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </Alert>
+  )
+}

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { Button } from 'react-bootstrap'
+import { toFriendlyError } from '../utils/errorMessages.js'
+
+/**
+ * Route-level error boundary. Catches render-time exceptions so a crashed
+ * page doesn't blank the whole app — shows a friendly fallback with a retry
+ * button that re-mounts the child tree.
+ */
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { error: null }
+    this.handleReset = this.handleReset.bind(this)
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error }
+  }
+
+  componentDidCatch(error, info) {
+    // Keep a diagnostic breadcrumb in the console — users only ever see
+    // the friendly fallback above.
+    // eslint-disable-next-line no-console
+    console.error('ErrorBoundary caught:', error, info?.componentStack)
+  }
+
+  handleReset() {
+    this.setState({ error: null })
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children
+
+    const friendly = toFriendlyError(this.state.error, { context: this.props.context })
+
+    return (
+      <div className="p-4">
+        <div className="panel">
+          <div className="panel-container">
+            <div className="panel-content text-center py-5">
+              <svg className="sa-icon sa-icon-5x text-muted mb-3" aria-hidden="true">
+                <use href="/icons/sprite.svg#alert-triangle"></use>
+              </svg>
+              <h5 className="fw-500 mb-2">{friendly.title}</h5>
+              <p className="text-muted mb-3">{friendly.message}</p>
+              <div className="d-flex gap-2 justify-content-center">
+                <Button variant="primary" onClick={this.handleReset}>{friendly.action}</Button>
+                <Button variant="outline-secondary" onClick={() => window.location.reload()}>
+                  Refresh page
+                </Button>
+              </div>
+              {friendly.rawCode && (
+                <details className="fs-xs text-muted mt-3">
+                  <summary>Technical details</summary>
+                  <code>{friendly.rawCode}</code>
+                </details>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/components/FeedRecordModal.jsx
+++ b/src/components/FeedRecordModal.jsx
@@ -4,6 +4,7 @@ import { recommendApi } from '../api/plants.js'
 import { usePlantContext } from '../context/PlantContext.jsx'
 import { useToast } from './Toast.jsx'
 import { isOutdoor } from '../utils/watering.js'
+import { friendlyErrorMessage } from '../utils/errorMessages.js'
 
 export default function FeedRecordModal({ plant, show, onHide }) {
   const { floors, location, tempUnit, handleFertilisePlant } = usePlantContext()
@@ -48,7 +49,7 @@ export default function FeedRecordModal({ plant, show, onHide }) {
       }))
       toast.success('AI recommendation loaded')
     } catch (err) {
-      toast.error(err.message || 'Failed to get recommendation')
+      toast.error(friendlyErrorMessage(err, { context: 'the feeding recommendation' }))
     } finally {
       setLoadingRec(false)
     }
@@ -62,7 +63,7 @@ export default function FeedRecordModal({ plant, show, onHide }) {
       toast.success('Marked fertilised')
       onHide?.()
     } catch (err) {
-      toast.error(err.message || 'Failed to mark fertilised')
+      toast.error(friendlyErrorMessage(err, { context: 'marking fertilised' }))
     } finally {
       setSaving(false)
     }

--- a/src/components/ImageAnalyser.jsx
+++ b/src/components/ImageAnalyser.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Button, Card, Spinner, Alert, Badge, Form, InputGroup } from 'react-bootstrap'
+import { Button, Card, Spinner, Badge, Form, InputGroup } from 'react-bootstrap'
 import { analyseApi } from '../api/plants.js'
+import ErrorAlert from './ErrorAlert.jsx'
+import { toFriendlyError } from '../utils/errorMessages.js'
 
 const ANALYSIS_STAGES = [
   'Identifying plant species...',
@@ -63,7 +65,7 @@ export default function ImageAnalyser({ initialImage, onAnalysisComplete, onImag
       onAnalysisComplete(result)
       setShowSpeciesHint(false)
       setSpeciesHint('')
-    } catch (err) { setError(err.message) }
+    } catch (err) { setError(toFriendlyError(err, { context: 'photo analysis' })) }
     finally { setIsAnalysing(false) }
   }, [onAnalysisComplete])
 
@@ -116,10 +118,15 @@ export default function ImageAnalyser({ initialImage, onAnalysisComplete, onImag
       )}
 
       {error && (
-        <Alert variant="danger" className="mt-2 fs-sm py-2">
-          {error}
-          {imageFile && <Button variant="link" size="sm" className="p-0 ms-2 text-danger" onClick={handleReanalyse}>Retry</Button>}
-        </Alert>
+        <div className="mt-2">
+          <ErrorAlert
+            error={error}
+            context="photo analysis"
+            size="sm"
+            onRetry={imageFile ? handleReanalyse : undefined}
+            onDismiss={() => setError(null)}
+          />
+        </div>
       )}
 
       {analysisResult && (

--- a/src/components/OfflineBanner.jsx
+++ b/src/components/OfflineBanner.jsx
@@ -1,0 +1,30 @@
+import { usePlantContext } from '../context/PlantContext.jsx'
+
+/**
+ * Full-width connectivity banner pinned above the page content. Complements
+ * the topbar `OfflineIndicator` chip by giving a dedicated, screen-reader-
+ * announced recovery message when the browser is offline.
+ */
+export default function OfflineBanner() {
+  const { isOnline, pendingSyncCount } = usePlantContext()
+
+  if (isOnline) return null
+
+  return (
+    <div
+      className="alert alert-warning bg-warning bg-opacity-10 border-warning border-opacity-25 rounded-0 mb-0 py-2 px-3 d-flex align-items-center gap-2"
+      role="status"
+      aria-live="polite"
+    >
+      <svg className="sa-icon" style={{ width: 16, height: 16 }} aria-hidden="true">
+        <use href="/icons/sprite.svg#wifi-off"></use>
+      </svg>
+      <span className="fs-sm">
+        <strong>You're offline.</strong>{' '}
+        Changes you make are saved on this device
+        {pendingSyncCount > 0 && ` (${pendingSyncCount} queued)`}{' '}
+        and will sync automatically when you reconnect.
+      </span>
+    </div>
+  )
+}

--- a/src/components/PlantListPanel.jsx
+++ b/src/components/PlantListPanel.jsx
@@ -6,6 +6,7 @@ import { getWateringStatus, urgencyColor, OUTDOOR_ROOMS, getSeason, isOutdoor } 
 import { derivePlantName } from '../utils/plantName.js'
 import { fanOut } from '../utils/concurrency.js'
 import PlantIcon from './PlantIcon.jsx'
+import { friendlyErrorMessage } from '../utils/errorMessages.js'
 
 const RECOMMENDATION_HISTORY_LIMIT = 20
 const BATCH_CONCURRENCY = 3
@@ -93,7 +94,7 @@ export default function PlantListPanel({ onPlantClick, onAddPlant, gnomeWaterRef
       setRecalcResult(data)
       // Reload plants to reflect new frequencies
       window.location.reload()
-    } catch (err) { setRecalcResult({ error: err.message }) }
+    } catch (err) { setRecalcResult({ error: friendlyErrorMessage(err, { context: 'recalculating watering frequencies' }) }) }
     finally { setRecalculating(false) }
   }, [weather])
 

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -7,22 +7,11 @@ import { analyseWateringPattern, getPatternMeta } from '../utils/wateringPattern
 import { derivePlantName } from '../utils/plantName.js'
 import { getPlantEmoji, PLANT_EMOJI_GROUPS } from '../utils/plantEmoji.js'
 import { PlantContext } from '../context/PlantContext.jsx'
+import { friendlyErrorMessage } from '../utils/errorMessages.js'
 
 // Max recommendation entries retained per plant. Older entries are trimmed
 // when a new one is appended so Firestore docs don't grow unbounded.
 const RECOMMENDATION_HISTORY_LIMIT = 20
-
-// Render common low-level errors as friendly text; otherwise pass through.
-function friendlyErrorMessage(err) {
-  const raw = err?.message || String(err || '')
-  if (/failed to fetch|networkerror|load failed/i.test(raw)) {
-    return "Couldn't reach the server. Check your connection and try again."
-  }
-  if (/position \d+/i.test(raw) && /object key|expected/i.test(raw)) {
-    return 'The AI gave an unexpected response. Please try again in a moment.'
-  }
-  return raw || 'Something went wrong. Please try again.'
-}
 
 function formatRecDate(iso) {
   try {

--- a/src/context/PlantContext.jsx
+++ b/src/context/PlantContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react'
+import { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useAuth } from '../contexts/AuthContext.jsx'
 import { plantsApi, imagesApi, floorsApi, analyseApi, flushOfflineMutations, OfflineQueuedError } from '../api/plants.js'
 import { subscribe as subscribeOfflineQueue, size as offlineQueueSize } from '../utils/offlineQueue.js'
@@ -6,6 +6,7 @@ import { useWeather } from '../hooks/useWeather.js'
 import { useTempUnit } from '../hooks/useTempUnit.js'
 import { getWateringStatus, isOutdoor } from '../utils/watering.js'
 import { GUEST_PLANTS, GUEST_FLOORS } from '../data/guestData.js'
+import { toFriendlyError } from '../utils/errorMessages.js'
 
 const DEFAULT_FLOORS = []
 
@@ -93,31 +94,26 @@ export function PlantProvider({ children }) {
     }
   }, [weather?.current?.condition?.sky, plants.length, floors, isGuest])
 
-  useEffect(() => {
-    if (!isAuthenticated) return
-    if (isGuest) {
-      setPlants(GUEST_PLANTS)
-      setFloors(GUEST_FLOORS)
-      setActiveFloorId('ground')
-      return
-    }
-    setPlants([])
-    setFloors(DEFAULT_FLOORS)
+  // Track the latest `logout` without re-triggering `reloadPlants` memo
+  // (AuthContext doesn't memoize its functions).
+  const logoutRef = useRef(logout)
+  useEffect(() => { logoutRef.current = logout }, [logout])
+
+  const reloadPlants = useCallback(() => {
+    if (!isAuthenticated || isGuest) return Promise.resolve()
     setPlantsLoading(true)
     setPlantsError(null)
 
     const loadPlants = plantsApi.list()
       .then(setPlants)
       .catch((err) => {
-        const msg = err.message || ''
-        const isAuthError = msg.includes('NetworkError') || msg.includes('Failed to fetch')
-          || msg.includes('Load failed') || msg.includes('401') || msg.includes('403')
-        if (isAuthError) {
-          setPlantsError('Session expired. Please sign in again.')
-          logout()
+        const friendly = toFriendlyError(err, { context: 'plants' })
+        if (friendly.kind === 'auth') {
+          setPlantsError(friendly)
+          logoutRef.current()
           return
         }
-        setPlantsError(msg)
+        setPlantsError(friendly)
       })
 
     const loadFloors = floorsApi.get()
@@ -137,8 +133,21 @@ export function PlantProvider({ children }) {
       })
       .catch(() => {})
 
-    Promise.all([loadPlants, loadFloors]).finally(() => setPlantsLoading(false))
+    return Promise.all([loadPlants, loadFloors]).finally(() => setPlantsLoading(false))
   }, [isAuthenticated, isGuest])
+
+  useEffect(() => {
+    if (!isAuthenticated) return
+    if (isGuest) {
+      setPlants(GUEST_PLANTS)
+      setFloors(GUEST_FLOORS)
+      setActiveFloorId('ground')
+      return
+    }
+    setPlants([])
+    setFloors(DEFAULT_FLOORS)
+    reloadPlants()
+  }, [isAuthenticated, isGuest, reloadPlants])
 
   const handleSavePlant = useCallback(async (plantData, editingPlant, pendingPosition) => {
     const data = {
@@ -389,7 +398,7 @@ export function PlantProvider({ children }) {
   }, [activeFloorId, isGuest])
 
   const value = useMemo(() => ({
-    plants, plantsLoading, plantsError,
+    plants, plantsLoading, plantsError, reloadPlants,
     floors, activeFloorId, setActiveFloorId,
     weather, locationDenied, location, setLocation, tempUnit,
     overdueCount, isAnalysingFloorplan,
@@ -401,7 +410,7 @@ export function PlantProvider({ children }) {
     handleSaveFloors, handleFloorRoomsChange, handleFloorplanUpload,
     updatePlantsLocally,
   }), [
-    plants, plantsLoading, plantsError, floors, activeFloorId,
+    plants, plantsLoading, plantsError, reloadPlants, floors, activeFloorId,
     weather, locationDenied, location, setLocation, tempUnit, overdueCount, isAnalysingFloorplan, isGuest,
     isOnline, pendingSyncCount,
     handleSavePlant, handleWaterPlant, handleMoisturePlant, handleBatchWater,

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -6,6 +6,8 @@ import Sidebar from './components/Sidebar.jsx'
 import Topbar from './components/Topbar.jsx'
 import Onboarding from '../components/Onboarding.jsx'
 import WeatherAlertBanner from '../components/WeatherAlertBanner.jsx'
+import ErrorBoundary from '../components/ErrorBoundary.jsx'
+import OfflineBanner from '../components/OfflineBanner.jsx'
 
 function Loader() {
   return (
@@ -30,12 +32,15 @@ export default function MainLayout() {
         <Sidebar />
         <main className="app-body">
           <div className="app-content">
+            <OfflineBanner />
             <div className="px-3 pt-3">
               <WeatherAlertBanner />
             </div>
-            <Suspense fallback={<Loader />}>
-              <Outlet />
-            </Suspense>
+            <ErrorBoundary context="this page">
+              <Suspense fallback={<Loader />}>
+                <Outlet />
+              </Suspense>
+            </ErrorBoundary>
           </div>
           {isGuest && (
             <div className="alert alert-success bg-success bg-opacity-10 border-success border-opacity-25 text-center py-2 mb-0 rounded-0 fs-sm">

--- a/src/pages/BillingPage.jsx
+++ b/src/pages/BillingPage.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router'
 import { useSubscription } from '../context/SubscriptionContext.jsx'
 import { billingApi } from '../api/plants.js'
 import { useToast } from '../components/Toast.jsx'
+import { friendlyErrorMessage } from '../utils/errorMessages.js'
 
 const TIER_LABEL = {
   free:           'Free',
@@ -39,7 +40,7 @@ export default function BillingPage() {
       const { url } = await billingApi.createPortalSession()
       window.location.assign(url)
     } catch (err) {
-      toast.error(err.message || 'Failed to open billing portal')
+      toast.error(friendlyErrorMessage(err, { context: 'opening the billing portal' }))
     } finally {
       setBusy(false)
     }
@@ -51,7 +52,7 @@ export default function BillingPage() {
       const { url } = await billingApi.createCheckoutSession(targetTier, 'month')
       window.location.assign(url)
     } catch (err) {
-      toast.error(err.message || 'Failed to start checkout')
+      toast.error(friendlyErrorMessage(err, { context: 'starting checkout' }))
     } finally {
       setBusy(false)
     }

--- a/src/pages/BulkUploadPage.jsx
+++ b/src/pages/BulkUploadPage.jsx
@@ -5,6 +5,7 @@ import { analyseApi, imagesApi } from '../api/plants.js'
 import BulkPlantCard from '../components/BulkPlantCard.jsx'
 import UpgradePrompt from '../components/UpgradePrompt.jsx'
 import { derivePlantName } from '../utils/plantName.js'
+import { friendlyErrorMessage } from '../utils/errorMessages.js'
 
 const CONCURRENCY = 3
 
@@ -122,7 +123,7 @@ export default function BulkUploadPage() {
         setEntries((prev) => prev.map((e) => e.id === entry.id ? {
           ...e,
           status: 'error',
-          error: `Analysis failed: ${err.message}`,
+          error: `Analysis failed — ${friendlyErrorMessage(err, { context: 'photo analysis' })}`,
         } : e))
       }
     }, CONCURRENCY)
@@ -180,7 +181,7 @@ export default function BulkUploadPage() {
       } catch (err) {
         console.error('Bulk save failed for entry', entry.id, err)
         setEntries((prev) => prev.map((e) => e.id === entry.id ? {
-          ...e, status: 'error', error: `Save failed: ${err?.message || 'unknown error'}`,
+          ...e, status: 'error', error: `Save failed — ${friendlyErrorMessage(err, { context: 'saving this plant' })}`,
         } : e))
       }
     }, CONCURRENCY)

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,12 +1,12 @@
 import { useState, useCallback, useRef } from 'react'
-import { Alert } from 'react-bootstrap'
 import { usePlantContext } from '../context/PlantContext.jsx'
 import FloorplanPanel from '../components/FloorplanPanel.jsx'
 import PlantModal from '../components/PlantModal.jsx'
 import UpgradePrompt from '../components/UpgradePrompt.jsx'
+import ErrorAlert from '../components/ErrorAlert.jsx'
 
 export default function DashboardPage() {
-  const { floors, activeFloorId, weather, handleSavePlant, handleDeletePlant, handleWaterPlant, handleMoisturePlant, plantsError, plants, plantsLoading } = usePlantContext()
+  const { floors, activeFloorId, weather, handleSavePlant, handleDeletePlant, handleWaterPlant, handleMoisturePlant, plantsError, plants, plantsLoading, reloadPlants } = usePlantContext()
   const gnomeWaterRef = useRef(null)
 
   const hasFloors = floors.length > 0
@@ -73,14 +73,9 @@ export default function DashboardPage() {
           </UpgradePrompt>
         </div>
         {plantsError && (
-          <Alert variant="danger" className="mx-3 mt-3 mb-0" dismissible>
-            <Alert.Heading as="h6" className="mb-1">Couldn't load your plants</Alert.Heading>
-            <p className="mb-1 fs-sm">Check your connection and refresh the page. If this keeps happening, try signing out and back in.</p>
-            <details className="fs-xs text-muted">
-              <summary>Error details</summary>
-              <code>{plantsError}</code>
-            </details>
-          </Alert>
+          <div className="mx-3 mt-3">
+            <ErrorAlert error={plantsError} context="plants" onRetry={reloadPlants} />
+          </div>
         )}
         {plantsLoading ? (
           <div className="p-4">

--- a/src/pages/PricingPage.jsx
+++ b/src/pages/PricingPage.jsx
@@ -5,6 +5,7 @@ import { useSubscription } from '../context/SubscriptionContext.jsx'
 import { billingApi } from '../api/plants.js'
 import { useToast } from '../components/Toast.jsx'
 import { useAuth } from '../contexts/AuthContext.jsx'
+import { friendlyErrorMessage } from '../utils/errorMessages.js'
 
 const TIERS = [
   {
@@ -75,7 +76,7 @@ export default function PricingPage() {
       const { url } = await billingApi.createCheckoutSession(targetTier, interval === 'month' ? 'month' : 'year')
       window.location.assign(url)
     } catch (err) {
-      toast.error(err.message || 'Failed to start checkout')
+      toast.error(friendlyErrorMessage(err, { context: 'starting checkout' }))
     } finally {
       setBusy(null)
     }

--- a/src/pages/TodayPage.jsx
+++ b/src/pages/TodayPage.jsx
@@ -6,6 +6,7 @@ import FeedRecordModal from '../components/FeedRecordModal.jsx'
 import UpgradePrompt from '../components/UpgradePrompt.jsx'
 import { getPlantEmoji } from '../utils/plantEmoji.js'
 import { buildWaterTasks, buildFeedTasks, setSnooze, clampSnooze } from '../utils/todayTasks.js'
+import { friendlyErrorMessage } from '../utils/errorMessages.js'
 
 const SNOOZE_PRESETS = [
   { label: '1 day',   days: 1 },
@@ -46,7 +47,7 @@ export default function TodayPage() {
       await handleWaterPlant(plantId)
       toast.success('Marked watered')
     } catch (err) {
-      toast.error(err.message || 'Failed to mark watered')
+      toast.error(friendlyErrorMessage(err, { context: 'marking watered' }))
     } finally {
       setBusy(false)
     }
@@ -60,7 +61,7 @@ export default function TodayPage() {
       const count = await handleBatchWater(ids)
       toast.success(`Marked ${count} watered`)
     } catch (err) {
-      toast.error(err.message || 'Failed to mark watered')
+      toast.error(friendlyErrorMessage(err, { context: 'marking watered' }))
     } finally {
       setBusy(false)
     }

--- a/src/utils/errorMessages.js
+++ b/src/utils/errorMessages.js
@@ -1,0 +1,211 @@
+/**
+ * Maps raw errors (from fetch, Gemini, Firestore, network stacks, image upload,
+ * etc.) into a consistent `FriendlyError` shape the UI can render:
+ *
+ *   { title, message, action, kind, isRetryable }
+ *
+ * `kind` is one of:
+ *   - 'offline'   — device has no network; user should reconnect.
+ *   - 'auth'      — session expired or signed out; user should re-sign-in.
+ *   - 'permission'— auth is valid but action is not allowed.
+ *   - 'quota'     — rate limit / tier quota / AI overload (transient).
+ *   - 'transient' — server hiccup / 5xx / timeout (retry works).
+ *   - 'input'     — 4xx from bad input; user should fix & retry.
+ *   - 'unknown'   — fallback.
+ *
+ * No raw stack trace or provider error code should leave this module.
+ */
+
+const DEFAULT_ACTION = 'Try again'
+
+/**
+ * @typedef {Object} FriendlyError
+ * @property {string} title        Short headline shown in the UI.
+ * @property {string} message      One-sentence recovery hint.
+ * @property {string} action       Label for the primary CTA (e.g. "Try again").
+ * @property {('offline'|'auth'|'permission'|'quota'|'transient'|'input'|'unknown')} kind
+ * @property {boolean} isRetryable Whether the same action is likely to succeed on retry.
+ * @property {string} [rawCode]    Optional raw error message for diagnostics/"Report this".
+ */
+
+function rawText(err) {
+  if (!err) return ''
+  if (typeof err === 'string') return err
+  if (err.message) return String(err.message)
+  try { return String(err) } catch { return '' }
+}
+
+/**
+ * Translate any error-like value into a FriendlyError.
+ *
+ * @param {unknown} err
+ * @param {Object} [opts]
+ * @param {string} [opts.context] Short hint for the headline (e.g. 'plants', 'photo analysis').
+ * @param {boolean} [opts.online] Override navigator.onLine (useful for tests).
+ * @returns {FriendlyError}
+ */
+export function toFriendlyError(err, opts = {}) {
+  const raw = rawText(err)
+  const context = opts.context || ''
+  const online = opts.online ?? (typeof navigator === 'undefined' ? true : navigator.onLine !== false)
+
+  if (online === false) {
+    return {
+      title: "You're offline",
+      message:
+        'Changes you make are saved on this device and will sync automatically when you reconnect.',
+      action: 'Retry',
+      kind: 'offline',
+      isRetryable: true,
+      rawCode: raw,
+    }
+  }
+
+  if (/failed to fetch|networkerror|load failed|network request failed|ERR_NETWORK/i.test(raw)) {
+    return {
+      title: "Couldn't reach the server",
+      message: 'Check your connection — the internet blinked while we were talking to the server.',
+      action: 'Retry',
+      kind: 'transient',
+      isRetryable: true,
+      rawCode: raw,
+    }
+  }
+
+  if (/\b401\b|unauthenticated|unauthorized|session expired|invalid token|token expired/i.test(raw)) {
+    return {
+      title: 'Your session has expired',
+      message: 'Please sign in again to keep your changes safe.',
+      action: 'Sign in again',
+      kind: 'auth',
+      isRetryable: false,
+      rawCode: raw,
+    }
+  }
+
+  if (/\b403\b|permission_denied|forbidden|not allowed/i.test(raw)) {
+    return {
+      title: "You don't have access",
+      message:
+        context
+          ? `Your account can't ${context} right now. If you think this is a mistake, sign out and back in.`
+          : "Your account doesn't have access to this action.",
+      action: 'Sign in again',
+      kind: 'permission',
+      isRetryable: false,
+      rawCode: raw,
+    }
+  }
+
+  if (/\b429\b|rate limit|rate_limit|resource_exhausted|too many requests|quota/i.test(raw)) {
+    return {
+      title: 'Busy right now',
+      message:
+        'The AI assistant is getting a lot of requests. Give it a few seconds and try again.',
+      action: 'Try again',
+      kind: 'quota',
+      isRetryable: true,
+      rawCode: raw,
+    }
+  }
+
+  if (/overloaded|high demand|\b503\b|service unavailable/i.test(raw)) {
+    return {
+      title: 'The service is under heavy load',
+      message: "We'll be up again in a moment. Retrying usually does the trick.",
+      action: 'Retry',
+      kind: 'transient',
+      isRetryable: true,
+      rawCode: raw,
+    }
+  }
+
+  if (/\b(502|504)\b|gateway|timeout|timed? ?out/i.test(raw)) {
+    return {
+      title: 'The server took too long',
+      message: "That's usually a blip — retrying normally fixes it.",
+      action: 'Retry',
+      kind: 'transient',
+      isRetryable: true,
+      rawCode: raw,
+    }
+  }
+
+  if (/\b5\d\d\b|internal server error|unexpected response from server/i.test(raw)) {
+    return {
+      title: 'Something went wrong on our side',
+      message: "We've logged the error. Retrying usually works.",
+      action: 'Retry',
+      kind: 'transient',
+      isRetryable: true,
+      rawCode: raw,
+    }
+  }
+
+  if (/position \d+/i.test(raw) && /object key|expected/i.test(raw)) {
+    return {
+      title: 'The AI gave an unexpected response',
+      message: 'Our plant assistant got confused. Try again in a moment.',
+      action: 'Try again',
+      kind: 'transient',
+      isRetryable: true,
+      rawCode: raw,
+    }
+  }
+
+  if (/\b400\b|bad request|invalid|required|must be/i.test(raw)) {
+    return {
+      title: "That didn't look right",
+      message:
+        raw.replace(/^\s*(error|http\s*\d+:?)\s*/i, '').trim() ||
+        "The server rejected that input — please review and try again.",
+      action: 'Review',
+      kind: 'input',
+      isRetryable: false,
+      rawCode: raw,
+    }
+  }
+
+  if (/\b404\b|not found/i.test(raw)) {
+    return {
+      title: "We couldn't find that",
+      message:
+        context
+          ? `The ${context} you were looking for no longer exists.`
+          : "The item you were looking for no longer exists.",
+      action: 'Go back',
+      kind: 'input',
+      isRetryable: false,
+      rawCode: raw,
+    }
+  }
+
+  if (/GCS upload failed|upload failed/i.test(raw)) {
+    return {
+      title: "Couldn't upload that photo",
+      message: 'Check your connection, then try uploading the photo again.',
+      action: 'Retry upload',
+      kind: 'transient',
+      isRetryable: true,
+      rawCode: raw,
+    }
+  }
+
+  return {
+    title: context ? `Something went wrong with ${context}` : 'Something went wrong',
+    message:
+      'This is usually temporary. If it keeps happening, refresh the page or try again in a minute.',
+    action: DEFAULT_ACTION,
+    kind: 'unknown',
+    isRetryable: true,
+    rawCode: raw,
+  }
+}
+
+/**
+ * Shortcut: translate an error and return only its message string. Useful for
+ * `toast.error(...)` surfaces that don't need full context.
+ */
+export function friendlyErrorMessage(err, opts) {
+  return toFriendlyError(err, opts).message
+}

--- a/src/utils/errorMessages.js
+++ b/src/utils/errorMessages.js
@@ -72,6 +72,19 @@ export function toFriendlyError(err, opts = {}) {
     }
   }
 
+  // Upload-specific failures carry their own 4xx/5xx codes — route them to the
+  // dedicated recovery copy before the generic auth/permission branches fire.
+  if (/GCS upload failed|upload failed/i.test(raw)) {
+    return {
+      title: "Couldn't upload that photo",
+      message: 'Check your connection, then try uploading the photo again.',
+      action: 'Retry upload',
+      kind: 'transient',
+      isRetryable: true,
+      rawCode: raw,
+    }
+  }
+
   if (/\b401\b|unauthenticated|unauthorized|session expired|invalid token|token expired/i.test(raw)) {
     return {
       title: 'Your session has expired',
@@ -176,17 +189,6 @@ export function toFriendlyError(err, opts = {}) {
       action: 'Go back',
       kind: 'input',
       isRetryable: false,
-      rawCode: raw,
-    }
-  }
-
-  if (/GCS upload failed|upload failed/i.test(raw)) {
-    return {
-      title: "Couldn't upload that photo",
-      message: 'Check your connection, then try uploading the photo again.',
-      action: 'Retry upload',
-      kind: 'transient',
-      isRetryable: true,
       rawCode: raw,
     }
   }

--- a/src/utils/errorMessages.js
+++ b/src/utils/errorMessages.js
@@ -61,7 +61,7 @@ export function toFriendlyError(err, opts = {}) {
     }
   }
 
-  if (/failed to fetch|networkerror|load failed|network request failed|ERR_NETWORK/i.test(raw)) {
+  if (/failed to fetch|networkerror|network error|load failed|network request failed|ERR_NETWORK/i.test(raw)) {
     return {
       title: "Couldn't reach the server",
       message: 'Check your connection — the internet blinked while we were talking to the server.',
@@ -158,7 +158,7 @@ export function toFriendlyError(err, opts = {}) {
   if (/position \d+/i.test(raw) && /object key|expected/i.test(raw)) {
     return {
       title: 'The AI gave an unexpected response',
-      message: 'Our plant assistant got confused. Try again in a moment.',
+      message: 'Our plant assistant got confused — please try again in a moment.',
       action: 'Try again',
       kind: 'transient',
       isRetryable: true,


### PR DESCRIPTION
Closes #219 (child of Epic #212 — Look & feel track).

## Summary

Adds a consistent error-handling layer so no raw stack trace or provider error code reaches the UI. Every failing surface now shows a short title, a recovery hint, and a one-click retry where it makes sense.

- `src/utils/errorMessages.js` — `toFriendlyError` mapping covering offline, auth (401 / session expired), permission (403), quota (429 / RESOURCE_EXHAUSTED / AI overload), transient 5xx / gateway / timeout, Gemini parse errors, validation (400), 404, and upload failures. Each mapping returns `{title, message, action, kind, isRetryable, rawCode}`.
- `ErrorAlert` — kind-aware icon + variant, optional retry / report / dismiss. Used anywhere a page needs an inline error.
- `ErrorBoundary` — wraps the route `<Outlet />` in `MainLayout`; friendly fallback with "Try again" (resets boundary) and "Refresh page".
- `OfflineBanner` — `role="status"` banner pinned above content; surfaces the pending-sync count when the offline queue is non-empty.
- `PlantContext` — stores a `FriendlyError` object (not a raw string) and exposes `reloadPlants()` so the Dashboard retry button can recover without a full page refresh; auth errors still log out as before.
- Call sites routed through the shared helpers instead of surfacing raw `err.message`: `DashboardPage`, `ImageAnalyser`, `BulkUploadPage`, `TodayPage`, `BillingPage`, `PricingPage`, `FeedRecordModal`, `PlantListPanel`.
- `PlantModal` now delegates to the shared util (removed the inline duplicate).

## Acceptance criteria

- [x] No raw stack trace or provider error code reaches the UI.
- [x] Every failing action offers a one-click retry or corrective CTA (auth → Sign in, transient / quota / offline → Retry, validation → Review).
- [x] Offline state is detected via `navigator.onLine` and shown as a dedicated banner.

## Test plan

- [x] Unit tests for every branch of `toFriendlyError` (online override, network, 401, 403, 429/quota, 503/overload, 502/504, generic 5xx, Gemini parse, 400, 404, GCS upload, unknown, string / nullish inputs, no stack leakage).
- [x] `ErrorAlert` tests: retry / report / dismiss / context / already-friendly input / non-retryable suppresses retry.
- [x] `ErrorBoundary` tests: passes through on success, renders fallback on throw, recovers on reset.
- [x] `OfflineBanner` tests: hidden when online, visible offline, shows queued count.
- [ ] CI passes on push.