### PR TITLE
PlantModal: validation, unsaved-change guard & ARIA tabs (#225)

### DIFF
--- a/src/__tests__/PlantModal.test.jsx
+++ b/src/__tests__/PlantModal.test.jsx
@@ -663,4 +663,180 @@ describe('PlantModal', () => {
     // assert at least one is visible.
     expect(screen.getAllByText('250ml').length).toBeGreaterThan(0)
   })
+
+  // ── Required-field indicators & inline validation ─────────────────────────
+
+  it('marks the species input as required for screen readers', () => {
+    renderModal()
+    selectMode('manual')
+    const speciesInput = screen.getByPlaceholderText(/nephrolepis/i)
+    expect(speciesInput).toHaveAttribute('aria-required', 'true')
+  })
+
+  it('includes a visually-hidden "(required)" label for the species field', () => {
+    renderModal()
+    selectMode('manual')
+    // The "*" is aria-hidden; the accessible label is the hidden text.
+    expect(screen.getByText(/\(required\)/i)).toBeInTheDocument()
+  })
+
+  it('shows an inline error when species is blurred empty', () => {
+    renderModal()
+    selectMode('manual')
+    const speciesInput = screen.getByPlaceholderText(/nephrolepis/i)
+    fireEvent.blur(speciesInput)
+    expect(screen.getByText(/species is required/i)).toBeInTheDocument()
+    expect(speciesInput).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('shows an inline error when species exceeds the 80-character limit', () => {
+    renderModal()
+    selectMode('manual')
+    const speciesInput = screen.getByPlaceholderText(/nephrolepis/i)
+    fireEvent.change(speciesInput, { target: { value: 'x'.repeat(81) } })
+    fireEvent.blur(speciesInput)
+    expect(screen.getByText(/at most 80 characters/i)).toBeInTheDocument()
+  })
+
+  it('clears the species error as soon as the user fixes the field', () => {
+    renderModal()
+    selectMode('manual')
+    const speciesInput = screen.getByPlaceholderText(/nephrolepis/i)
+    fireEvent.blur(speciesInput)
+    expect(screen.getByText(/species is required/i)).toBeInTheDocument()
+    fireEvent.change(speciesInput, { target: { value: 'Monstera' } })
+    expect(screen.queryByText(/species is required/i)).not.toBeInTheDocument()
+  })
+
+  it('shows a form-level error summary and does not call onSave when submitting with an invalid species', async () => {
+    const onSave = vi.fn()
+    renderModal({ plant: { ...existingPlant, species: '' }, onSave })
+    // Invalid species → submit should block. The Save button is disabled in
+    // that state, so we submit the form directly to exercise handleSubmit's
+    // validation path (e.g. user pressing Enter in a disabled-button scenario).
+    const speciesInput = screen.getByPlaceholderText(/nephrolepis/i)
+    expect(speciesInput).toHaveValue('')
+    fireEvent.submit(speciesInput.closest('form'))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/please fix the following/i)
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  // ── Unsaved-change guard ──────────────────────────────────────────────────
+
+  it('does not prompt to discard when closing a pristine modal', () => {
+    const onClose = vi.fn()
+    renderModal({ onClose })
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(screen.queryByText(/discard unsaved changes/i)).not.toBeInTheDocument()
+  })
+
+  it('prompts to discard unsaved changes when closing a dirty modal', () => {
+    const onClose = vi.fn()
+    renderModal({ onClose })
+    selectMode('manual')
+    fireEvent.change(screen.getByPlaceholderText(/nephrolepis/i), {
+      target: { value: 'Monstera' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.getByText(/discard unsaved changes/i)).toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('keeps the modal open when the user picks "Keep editing" in the guard', () => {
+    const onClose = vi.fn()
+    renderModal({ onClose })
+    selectMode('manual')
+    fireEvent.change(screen.getByPlaceholderText(/nephrolepis/i), {
+      target: { value: 'Monstera' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    fireEvent.click(screen.getByRole('button', { name: /keep editing/i }))
+    expect(screen.queryByText(/discard unsaved changes/i)).not.toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+    // Typed value is preserved.
+    expect(screen.getByPlaceholderText(/nephrolepis/i)).toHaveValue('Monstera')
+  })
+
+  it('closes the modal when the user confirms "Discard changes"', () => {
+    const onClose = vi.fn()
+    renderModal({ onClose })
+    selectMode('manual')
+    fireEvent.change(screen.getByPlaceholderText(/nephrolepis/i), {
+      target: { value: 'Monstera' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    fireEvent.click(screen.getByRole('button', { name: /discard changes/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('also guards the modal header close (X) button when dirty', () => {
+    const onClose = vi.fn()
+    renderModal({ plant: existingPlant, onClose })
+    fireEvent.change(screen.getByPlaceholderText(/nephrolepis/i), {
+      target: { value: 'Nephrolepis exaltata var.' },
+    })
+    fireEvent.click(screen.getByLabelText('Close'))
+    expect(screen.getByText(/discard unsaved changes/i)).toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  // ── ARIA tab semantics ────────────────────────────────────────────────────
+
+  it('exposes the tabs with role="tablist" and role="tab"', () => {
+    renderModal({ plant: existingPlant })
+    expect(screen.getByRole('tablist', { name: /plant sections/i })).toBeInTheDocument()
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs.map((t) => t.textContent)).toEqual(['Plant', 'Watering', 'Care'])
+  })
+
+  it('marks the active tab with aria-selected="true"', () => {
+    renderModal({ plant: existingPlant })
+    const [plantTab, wateringTab, careTab] = screen.getAllByRole('tab')
+    expect(plantTab).toHaveAttribute('aria-selected', 'true')
+    expect(wateringTab).toHaveAttribute('aria-selected', 'false')
+    expect(careTab).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('links each tab to its panel via aria-controls / aria-labelledby', () => {
+    renderModal({ plant: existingPlant })
+    const [plantTab] = screen.getAllByRole('tab')
+    expect(plantTab).toHaveAttribute('aria-controls', 'plant-tabpanel-edit')
+    const panel = screen.getByRole('tabpanel')
+    expect(panel).toHaveAttribute('id', 'plant-tabpanel-edit')
+    expect(panel).toHaveAttribute('aria-labelledby', 'plant-tab-edit')
+  })
+
+  it('moves focus to the next tab when ArrowRight is pressed', () => {
+    renderModal({ plant: existingPlant })
+    const [plantTab, wateringTab] = screen.getAllByRole('tab')
+    fireEvent.keyDown(plantTab, { key: 'ArrowRight' })
+    expect(wateringTab).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('wraps to the first tab when ArrowRight is pressed on the last tab', () => {
+    renderModal({ plant: existingPlant })
+    fireEvent.click(screen.getByText('Care'))
+    const careTab = screen.getAllByRole('tab')[2]
+    fireEvent.keyDown(careTab, { key: 'ArrowRight' })
+    expect(screen.getAllByRole('tab')[0]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('moves focus to the previous tab when ArrowLeft is pressed', () => {
+    renderModal({ plant: existingPlant })
+    fireEvent.click(screen.getByText('Watering'))
+    const wateringTab = screen.getAllByRole('tab')[1]
+    fireEvent.keyDown(wateringTab, { key: 'ArrowLeft' })
+    expect(screen.getAllByRole('tab')[0]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('jumps to the first tab on Home and the last on End', () => {
+    renderModal({ plant: existingPlant })
+    fireEvent.click(screen.getByText('Watering'))
+    const wateringTab = screen.getAllByRole('tab')[1]
+    fireEvent.keyDown(wateringTab, { key: 'End' })
+    expect(screen.getAllByRole('tab')[2]).toHaveAttribute('aria-selected', 'true')
+    fireEvent.keyDown(screen.getAllByRole('tab')[2], { key: 'Home' })
+    expect(screen.getAllByRole('tab')[0]).toHaveAttribute('aria-selected', 'true')
+  })
 })

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo, useContext } from 'react'
-import { Modal, Button, Form, Nav, Tab, Badge, Spinner, Row, Col, Pagination, Accordion } from 'react-bootstrap'
+import { Modal, Button, Form, Badge, Spinner, Row, Col, Pagination, Accordion } from 'react-bootstrap'
 import ImageAnalyser from './ImageAnalyser.jsx'
 import { imagesApi, recommendApi, plantsApi, analyseApi } from '../api/plants.js'
 import { getWateringStatus, getAdjustedWaterAmount, isOutdoor, getMoistureDisplay } from '../utils/watering.js'
@@ -109,6 +109,17 @@ const PLANTED_IN_OPTIONS = [
 const DAYS_OF_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 function today() { return new Date().toISOString().split('T')[0] }
+
+const SPECIES_MAX_LENGTH = 80
+
+function validateSpecies(value) {
+  const trimmed = (value || '').trim()
+  if (!trimmed) return 'Species is required.'
+  if (trimmed.length > SPECIES_MAX_LENGTH) {
+    return `Species must be at most ${SPECIES_MAX_LENGTH} characters (currently ${trimmed.length}).`
+  }
+  return null
+}
 
 function GrowthUpload({ plantId, onComplete }) {
   const [uploading, setUploading] = useState(false)
@@ -241,6 +252,15 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   const [moisturePage, setMoisturePage] = useState(1)
   const [wateringPage, setWateringPage] = useState(1)
 
+  // Validation + unsaved-change guard state. `isDirty` is set by user-initiated
+  // edits only (not programmatic resyncs like the wateringRec effect).
+  const [isDirty, setIsDirty] = useState(false)
+  const [showUnsavedGuard, setShowUnsavedGuard] = useState(false)
+  const [speciesError, setSpeciesError] = useState(null)
+  const [submitAttempted, setSubmitAttempted] = useState(false)
+  const speciesInputRef = useRef(null)
+  const errorSummaryRef = useRef(null)
+
   // Optional: when rendered inside the app PlantProvider we can update the
   // in-memory plants list so history persists across modal reopens without a
   // page refresh. Tests render PlantModal without a provider, so this is
@@ -299,7 +319,16 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
     }
   }, [plant, activeFloorId])
 
-  const update = useCallback((key, value) => setForm((prev) => ({ ...prev, [key]: value })), [])
+  const update = useCallback((key, value) => {
+    setForm((prev) => ({ ...prev, [key]: value }))
+    setIsDirty(true)
+  }, [])
+
+  // Mirror species validity whenever the field changes so the error clears as
+  // soon as the user fixes it (no blur needed).
+  useEffect(() => {
+    if (submitAttempted || speciesError) setSpeciesError(validateSpecies(form.species))
+  }, [form.species, submitAttempted, speciesError])
 
   // Frequency, watering method, and water amount are no longer user-editable —
   // they mirror whatever the latest AI watering recommendation produced, so
@@ -329,13 +358,28 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       ...(result.potSize ? { potSize: result.potSize } : {}),
       ...(result.soilType ? { soilType: result.soilType } : {}),
     }))
+    setIsDirty(true)
   }, [])
 
-  const handleImageChange = useCallback((file) => setForm((prev) => ({ ...prev, imageFile: file, imageUrl: null })), [])
+  const handleImageChange = useCallback((file) => {
+    setForm((prev) => ({ ...prev, imageFile: file, imageUrl: null }))
+    setIsDirty(true)
+  }, [])
 
   const handleSubmit = useCallback(async (e) => {
     e.preventDefault()
-    if (!form.species.trim()) return
+    setSubmitAttempted(true)
+    const err = validateSpecies(form.species)
+    setSpeciesError(err)
+    if (err) {
+      // Scroll the error summary into view and return focus to the invalid
+      // field so keyboard + screen-reader users can recover immediately.
+      requestAnimationFrame(() => {
+        errorSummaryRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'center' })
+        speciesInputRef.current?.focus?.()
+      })
+      return
+    }
     setIsSaving(true)
     let imageUrl = form.imageUrl
     if (form.imageFile) {
@@ -360,8 +404,49 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       plantedIn: form.plantedIn,
       emoji: form.emoji || null,
     })
+    setIsDirty(false)
     setIsSaving(false)
   }, [form, onSave])
+
+  // Unsaved-change guard. All close paths (X, Esc, backdrop, Cancel) route
+  // through this so dirty edits aren't silently discarded.
+  const handleClose = useCallback(() => {
+    if (isDirty) setShowUnsavedGuard(true)
+    else onClose()
+  }, [isDirty, onClose])
+
+  const handleDiscardChanges = useCallback(() => {
+    setShowUnsavedGuard(false)
+    setIsDirty(false)
+    onClose()
+  }, [onClose])
+
+  // Keyboard navigation between tabs (Left/Right, Home/End) per WAI-ARIA
+  // Tabs Pattern.
+  const TABS = useMemo(
+    () => [
+      { id: 'edit', label: 'Plant' },
+      { id: 'watering', label: 'Watering' },
+      { id: 'care', label: 'Care' },
+    ],
+    [],
+  )
+
+  const handleTabKeyDown = useCallback((e, index) => {
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      setActiveTab(TABS[(index + 1) % TABS.length].id)
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      setActiveTab(TABS[(index - 1 + TABS.length) % TABS.length].id)
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      setActiveTab(TABS[0].id)
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      setActiveTab(TABS[TABS.length - 1].id)
+    }
+  }, [TABS])
 
   const handleDelete = useCallback(() => {
     if (confirmDelete) { onDelete(plant.id); setConfirmDelete(false) }
@@ -428,7 +513,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   }, [form, plant, floors, wateringStatus, wateringHistory, persistHistory, ctxLocation, ctxTempUnit, weather])
 
   return (
-    <Modal show onHide={onClose} size="lg" centered scrollable>
+    <Modal show onHide={handleClose} size="lg" centered scrollable>
       <Modal.Header closeButton className="border-bottom">
         <Modal.Title className="d-flex align-items-center gap-2 fs-6">
           <svg className="sa-icon text-primary"><use href="/icons/sprite.svg#feather"></use></svg>
@@ -470,20 +555,66 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
         </Modal.Body>
       )}
 
-      {/* Tab nav for editing */}
+      {/* Tab nav for editing — WAI-ARIA Tabs Pattern. Using native buttons
+          (rather than Nav.Link) so aria-controls / aria-selected are preserved
+          exactly as set; React-Bootstrap's Nav.Link filters them when it's not
+          nested inside a Tab.Container. */}
       {isEditing && (
-        <Nav variant="tabs" className="px-3 pt-2">
-          {[{ id: 'edit', label: 'Plant' }, { id: 'watering', label: 'Watering' }, { id: 'care', label: 'Care' }].map((tab) => (
-            <Nav.Item key={tab.id}>
-              <Nav.Link active={activeTab === tab.id} onClick={() => setActiveTab(tab.id)}>{tab.label}</Nav.Link>
-            </Nav.Item>
-          ))}
-        </Nav>
+        <ul className="nav nav-tabs px-3 pt-2" role="tablist" aria-label="Plant sections">
+          {TABS.map((tab, i) => {
+            const selected = activeTab === tab.id
+            return (
+              <li key={tab.id} className="nav-item" role="presentation">
+                <button
+                  type="button"
+                  role="tab"
+                  id={`plant-tab-${tab.id}`}
+                  aria-selected={selected}
+                  aria-controls={`plant-tabpanel-${tab.id}`}
+                  tabIndex={selected ? 0 : -1}
+                  className={`nav-link${selected ? ' active' : ''}`}
+                  onClick={() => setActiveTab(tab.id)}
+                  onKeyDown={(e) => handleTabKeyDown(e, i)}
+                >
+                  {tab.label}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
       )}
 
       {/* Edit form */}
       {mode !== null && (!isEditing || activeTab === 'edit') && (
-        <Modal.Body as="form" onSubmit={handleSubmit}>
+        <Modal.Body
+          as="form"
+          onSubmit={handleSubmit}
+          noValidate
+          {...(isEditing
+            ? { role: 'tabpanel', id: 'plant-tabpanel-edit', 'aria-labelledby': 'plant-tab-edit' }
+            : {})}
+        >
+          {submitAttempted && speciesError && (
+            <div
+              ref={errorSummaryRef}
+              role="alert"
+              aria-live="assertive"
+              className="alert alert-danger py-2 mb-3"
+            >
+              <strong className="d-block mb-1">Please fix the following before saving:</strong>
+              <ul className="mb-0 ps-3">
+                <li>
+                  <a
+                    href="#plant-species-input"
+                    className="alert-link"
+                    onClick={(e) => { e.preventDefault(); speciesInputRef.current?.focus() }}
+                  >
+                    {speciesError}
+                  </a>
+                </li>
+              </ul>
+            </div>
+          )}
           {!isEditing && mode === 'photo' && (
             <>
               <ImageAnalyser initialImage={form.imageUrl} onAnalysisComplete={handleAnalysisComplete} onImageChange={handleImageChange} />
@@ -495,12 +626,33 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
               <Accordion.Header>Identity</Accordion.Header>
               <Accordion.Body>
                 <Form.Group className="mb-3">
-                  <Form.Label>Species *</Form.Label>
-                  <Form.Control type="text" placeholder="e.g. Nephrolepis exaltata" value={form.species}
-                    onChange={(e) => update('species', e.target.value)} required />
-                  <Form.Text className="text-muted">
-                    Display name will be {form.species ? <strong>{derivePlantName({ species: form.species, room: form.room })}</strong> : 'derived from species + room'}
-                  </Form.Text>
+                  <Form.Label htmlFor="plant-species-input">
+                    Species <span aria-hidden="true">*</span>
+                    <span className="visually-hidden"> (required)</span>
+                  </Form.Label>
+                  <Form.Control
+                    id="plant-species-input"
+                    ref={speciesInputRef}
+                    type="text"
+                    placeholder="e.g. Nephrolepis exaltata"
+                    value={form.species}
+                    onChange={(e) => update('species', e.target.value)}
+                    onBlur={() => setSpeciesError(validateSpecies(form.species))}
+                    aria-required="true"
+                    aria-invalid={speciesError ? 'true' : 'false'}
+                    aria-describedby={speciesError ? 'plant-species-error' : 'plant-species-help'}
+                    isInvalid={!!speciesError}
+                    maxLength={SPECIES_MAX_LENGTH + 20}
+                  />
+                  {speciesError ? (
+                    <Form.Control.Feedback type="invalid" id="plant-species-error">
+                      {speciesError}
+                    </Form.Control.Feedback>
+                  ) : (
+                    <Form.Text className="text-muted" id="plant-species-help">
+                      Display name will be {form.species ? <strong>{derivePlantName({ species: form.species, room: form.room })}</strong> : 'derived from species + room'}
+                    </Form.Text>
+                  )}
                 </Form.Group>
                 <Form.Group>
                   <div className="d-flex align-items-center justify-content-between mb-1">
@@ -757,7 +909,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
 
       {/* Watering tab */}
       {isEditing && activeTab === 'watering' && (
-        <Modal.Body>
+        <Modal.Body role="tabpanel" id="plant-tabpanel-watering" aria-labelledby="plant-tab-watering">
           {wateringStatus?.seasonNote && (
             <div className="mb-3 p-2 rounded border fs-sm d-flex align-items-center gap-2" style={{ borderColor: '#60a5fa', background: 'rgba(96,165,250,0.08)' }}>
               <svg className="sa-icon text-info" style={{ width: 14, height: 14 }}><use href="/icons/sprite.svg#sun"></use></svg>
@@ -1037,7 +1189,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
 
       {/* Care tab — consolidated: health, maturity, notes, photos, recommendations */}
       {isEditing && activeTab === 'care' && (
-        <Modal.Body>
+        <Modal.Body role="tabpanel" id="plant-tabpanel-care" aria-labelledby="plant-tab-care">
           {/* Health & Maturity (read-only, updated by AI) */}
           <Row className="mb-3">
             <Col md={4}>
@@ -1153,6 +1305,35 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
         </Modal.Body>
       )}
 
+      {/* Unsaved-change guard */}
+      {showUnsavedGuard && (
+        <div
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="unsaved-guard-title"
+          aria-describedby="unsaved-guard-body"
+          className="position-absolute top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center"
+          style={{ background: 'rgba(0,0,0,0.6)', zIndex: 10, borderRadius: 'inherit' }}
+        >
+          <div className="card shadow-lg mx-4" style={{ maxWidth: 360 }}>
+            <div className="card-body p-4">
+              <p id="unsaved-guard-title" className="fw-500 mb-1">Discard unsaved changes?</p>
+              <p id="unsaved-guard-body" className="text-muted fs-sm mb-3">
+                Your edits to this plant haven't been saved. Leaving now will lose them.
+              </p>
+              <div className="d-flex gap-2 justify-content-end">
+                <Button variant="light" onClick={() => setShowUnsavedGuard(false)} autoFocus>
+                  Keep editing
+                </Button>
+                <Button variant="danger" onClick={handleDiscardChanges}>
+                  Discard changes
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Delete confirmation */}
       {confirmDelete && (
         <div className="position-absolute top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style={{ background: 'rgba(0,0,0,0.6)', zIndex: 10, borderRadius: 'inherit' }}>
@@ -1180,7 +1361,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
             Delete
           </Button>
         )}
-        <Button variant="light" onClick={onClose}>Cancel</Button>
+        <Button variant="light" onClick={handleClose}>Cancel</Button>
         {mode !== null && (!isEditing || activeTab === 'edit') && (
           <Button variant="primary" onClick={handleSubmit} disabled={!form.species.trim() || isSaving}>
             {isSaving ? <Spinner size="sm" className="me-2" /> : <svg className="sa-icon me-1"><use href="/icons/sprite.svg#save"></use></svg>}


### PR DESCRIPTION
## Summary

Closes the UX gaps in PlantModal called out in #225 (child of Epic #212).

- **Required-field indicators & inline validation** — species now has `aria-required`, an inline error on blur (required, ≤ 80 chars), and a form-level error summary with a focus-restoring link when submit is attempted with an invalid value. Error clears in real time as the user fixes it.
- **Unsaved-change guard** — backdrop clicks, Esc, the header X and the footer Cancel all route through a custom "Discard unsaved changes?" dialog whenever the form is dirty. Dirty state is tracked on user-initiated edits only, so internal resyncs (e.g. AI watering recommendation auto-filling the watering fields) don't trigger false prompts.
- **ARIA tab semantics** — replaced `Nav.Link` with native buttons so `role`/`aria-selected`/`aria-controls` are preserved exactly as set. Added `role=tablist`/`tab`/`tabpanel`, visible-selection management, and WAI-ARIA-compliant keyboard nav (Left/Right/Home/End).

## Test plan

- [x] Added 18 new unit tests covering the validation, guard, and tab semantics.
- [x] Existing 61 PlantModal tests still pass.
- [x] Full frontend suite: 516/516 passing.
- [x] Coverage thresholds met (lines 42.78% / branches 40.18% / functions 36.51%).
- [x] `npm run build` succeeds.

https://claude.ai/code/session_016HyjUiVPuadwGgrerG9jmA