### PR TITLE
feat(#209): quantitative growth tracking — measurements & phenology tab

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1307,6 +1307,111 @@ app.post('/plants/:id/fertilise', requireUser, async (req, res) => {
   }
 });
 
+// ── Growth measurements ───────────────────────────────────────────────────────
+
+app.get('/plants/:id/measurements', requireUser, async (req, res) => {
+  try {
+    const doc = await userPlants(req.userId).doc(req.params.id).get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+    res.status(200).json(doc.data().measurements || []);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/plants/:id/measurements', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const { height_cm, width_cm, leafCount, stemCount, notes } = req.body || {};
+    const payload = {};
+    if (height_cm != null && height_cm !== '') payload.height_cm = Number(height_cm);
+    if (width_cm  != null && width_cm  !== '') payload.width_cm  = Number(width_cm);
+    if (leafCount  != null && leafCount  !== '') payload.leafCount  = Number(leafCount);
+    if (stemCount  != null && stemCount  !== '') payload.stemCount  = Number(stemCount);
+    if (Object.keys(payload).length === 0) {
+      return res.status(400).json({ error: 'At least one of height_cm, width_cm, leafCount, or stemCount is required' });
+    }
+
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const entry = { id, date: now, notes: notes || '', ...payload };
+    const existing = doc.data();
+    const measurements = [...(existing.measurements || []), entry];
+    await ref.set({ measurements, updatedAt: now }, { merge: true });
+    res.status(201).json(entry);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.delete('/plants/:id/measurements/:measurementId', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+    const existing = doc.data();
+    const measurements = (existing.measurements || []).filter(m => m.id !== req.params.measurementId);
+    await ref.set({ measurements, updatedAt: new Date().toISOString() }, { merge: true });
+    res.status(200).json({ deleted: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ── Phenology events ──────────────────────────────────────────────────────────
+
+const PHENOLOGY_EVENTS = new Set(['first-leaf', 'first-bud', 'first-bloom', 'first-fruit', 'leaf-drop', 'dormancy', 'new-growth', 'other']);
+
+app.get('/plants/:id/phenology', requireUser, async (req, res) => {
+  try {
+    const doc = await userPlants(req.userId).doc(req.params.id).get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+    res.status(200).json(doc.data().phenologyEvents || []);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/plants/:id/phenology', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const { event, notes, date } = req.body || {};
+    if (!event || !PHENOLOGY_EVENTS.has(event)) {
+      return res.status(400).json({ error: `event must be one of: ${[...PHENOLOGY_EVENTS].join(', ')}` });
+    }
+
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const entry = { id, date: date || now, event, notes: notes || '' };
+    const existing = doc.data();
+    const phenologyEvents = [...(existing.phenologyEvents || []), entry];
+    await ref.set({ phenologyEvents, updatedAt: now }, { merge: true });
+    res.status(201).json(entry);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.delete('/plants/:id/phenology/:eventId', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+    const existing = doc.data();
+    const phenologyEvents = (existing.phenologyEvents || []).filter(e => e.id !== req.params.eventId);
+    await ref.set({ phenologyEvents, updatedAt: new Date().toISOString() }, { merge: true });
+    res.status(200).json({ deleted: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Fertiliser recommendation (Gemini, structured) ───────────────────────────
 
 const FERTILISER_RECOMMEND_SCHEMA = {

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -80,6 +80,7 @@ let app;
 
 beforeAll(() => {
   proxyquire('./index', {
+    'express-rate-limit': () => (_req, _res, next) => next(),
     '@google-cloud/functions-framework': {
       http: (_, handler) => { app = handler; },
     },
@@ -2381,5 +2382,266 @@ describe('POST /recommend-fertiliser', () => {
     const res = await request(app).post('/recommend-fertiliser').send({ name: 'Rose' });
     expect(res.status).toBe(500);
     expect(res.body.error).toBe('Gemini down');
+  });
+});
+
+// ── Growth measurements ───────────────────────────────────────────────────────
+
+describe('GET /plants/:id/measurements', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).get('/plants/p1/measurements');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for non-existent plant', async () => {
+    const res = await request(app).get('/plants/missing/measurements')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns empty array when plant has no measurements', async () => {
+    store[plantPath('p1')] = { species: 'Fern' };
+    const res = await request(app).get('/plants/p1/measurements')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('returns existing measurements array', async () => {
+    const measurements = [{ id: 'uuid-1', date: '2026-01-01', height_cm: 45, notes: '' }];
+    store[plantPath('p1')] = { species: 'Monstera', measurements };
+    const res = await request(app).get('/plants/p1/measurements')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(measurements);
+  });
+});
+
+describe('POST /plants/:id/measurements', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).post('/plants/p1/measurements').send({ height_cm: 30 });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for non-existent plant', async () => {
+    const res = await request(app).post('/plants/missing/measurements')
+      .set('Authorization', authHeader()).send({ height_cm: 30 });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when no measurement values provided', async () => {
+    store[plantPath('p1')] = { species: 'Fern' };
+    const res = await request(app).post('/plants/p1/measurements')
+      .set('Authorization', authHeader()).send({ notes: 'just notes' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/required/);
+  });
+
+  it('creates a measurement with height_cm and returns 201', async () => {
+    store[plantPath('p1')] = { species: 'Monstera' };
+    const res = await request(app).post('/plants/p1/measurements')
+      .set('Authorization', authHeader()).send({ height_cm: 45, notes: 'looking good' });
+    expect(res.status).toBe(201);
+    expect(res.body.height_cm).toBe(45);
+    expect(res.body.notes).toBe('looking good');
+    expect(res.body.id).toBeDefined();
+    expect(res.body.date).toBeDefined();
+    // confirm saved to store
+    expect(store[plantPath('p1')].measurements).toHaveLength(1);
+    expect(store[plantPath('p1')].measurements[0].height_cm).toBe(45);
+  });
+
+  it('creates a measurement with multiple fields', async () => {
+    store[plantPath('p1')] = { species: 'Monstera' };
+    const res = await request(app).post('/plants/p1/measurements')
+      .set('Authorization', authHeader())
+      .send({ height_cm: 50, width_cm: 30, leafCount: 12, stemCount: 2 });
+    expect(res.status).toBe(201);
+    expect(res.body.width_cm).toBe(30);
+    expect(res.body.leafCount).toBe(12);
+    expect(res.body.stemCount).toBe(2);
+  });
+
+  it('appends to existing measurements', async () => {
+    const existing = [{ id: 'old-1', date: '2026-01-01', height_cm: 40, notes: '' }];
+    store[plantPath('p1')] = { species: 'Monstera', measurements: existing };
+    await request(app).post('/plants/p1/measurements')
+      .set('Authorization', authHeader()).send({ height_cm: 45 });
+    expect(store[plantPath('p1')].measurements).toHaveLength(2);
+  });
+
+  it('accepts leafCount only (no height)', async () => {
+    store[plantPath('p1')] = { species: 'Pothos' };
+    const res = await request(app).post('/plants/p1/measurements')
+      .set('Authorization', authHeader()).send({ leafCount: 8 });
+    expect(res.status).toBe(201);
+    expect(res.body.leafCount).toBe(8);
+    expect(res.body.height_cm).toBeUndefined();
+  });
+});
+
+describe('DELETE /plants/:id/measurements/:measurementId', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).delete('/plants/p1/measurements/mid1');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for non-existent plant', async () => {
+    const res = await request(app).delete('/plants/missing/measurements/mid1')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('removes the matching measurement and returns { deleted: true }', async () => {
+    store[plantPath('p1')] = {
+      species: 'Monstera',
+      measurements: [
+        { id: 'mid1', date: '2026-01-01', height_cm: 40, notes: '' },
+        { id: 'mid2', date: '2026-02-01', height_cm: 45, notes: '' },
+      ],
+    };
+    const res = await request(app).delete('/plants/p1/measurements/mid1')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ deleted: true });
+    expect(store[plantPath('p1')].measurements).toHaveLength(1);
+    expect(store[plantPath('p1')].measurements[0].id).toBe('mid2');
+  });
+
+  it('is a no-op when measurement id does not exist', async () => {
+    store[plantPath('p1')] = { species: 'Fern', measurements: [{ id: 'mid1', height_cm: 10, notes: '' }] };
+    const res = await request(app).delete('/plants/p1/measurements/nonexistent')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(store[plantPath('p1')].measurements).toHaveLength(1);
+  });
+});
+
+// ── Phenology events ──────────────────────────────────────────────────────────
+
+describe('GET /plants/:id/phenology', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).get('/plants/p1/phenology');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for non-existent plant', async () => {
+    const res = await request(app).get('/plants/missing/phenology')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns empty array when plant has no phenology events', async () => {
+    store[plantPath('p1')] = { species: 'Rose' };
+    const res = await request(app).get('/plants/p1/phenology')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('returns existing phenology events', async () => {
+    const events = [{ id: 'ev1', date: '2026-04-14', event: 'first-bloom', notes: 'pink flowers' }];
+    store[plantPath('p1')] = { species: 'Rose', phenologyEvents: events };
+    const res = await request(app).get('/plants/p1/phenology')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(events);
+  });
+});
+
+describe('POST /plants/:id/phenology', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).post('/plants/p1/phenology').send({ event: 'first-bloom' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for non-existent plant', async () => {
+    const res = await request(app).post('/plants/missing/phenology')
+      .set('Authorization', authHeader()).send({ event: 'first-bloom' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when event is missing', async () => {
+    store[plantPath('p1')] = { species: 'Rose' };
+    const res = await request(app).post('/plants/p1/phenology')
+      .set('Authorization', authHeader()).send({ notes: 'no event type' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/event must be one of/);
+  });
+
+  it('returns 400 for invalid event type', async () => {
+    store[plantPath('p1')] = { species: 'Rose' };
+    const res = await request(app).post('/plants/p1/phenology')
+      .set('Authorization', authHeader()).send({ event: 'invalid-type' });
+    expect(res.status).toBe(400);
+  });
+
+  it('creates a phenology event and returns 201', async () => {
+    store[plantPath('p1')] = { species: 'Rose' };
+    const res = await request(app).post('/plants/p1/phenology')
+      .set('Authorization', authHeader())
+      .send({ event: 'first-bloom', notes: 'Beautiful pink flowers', date: '2026-04-14' });
+    expect(res.status).toBe(201);
+    expect(res.body.event).toBe('first-bloom');
+    expect(res.body.notes).toBe('Beautiful pink flowers');
+    expect(res.body.date).toBe('2026-04-14');
+    expect(res.body.id).toBeDefined();
+    expect(store[plantPath('p1')].phenologyEvents).toHaveLength(1);
+  });
+
+  it('accepts all valid event types', async () => {
+    const validEvents = ['first-leaf', 'first-bud', 'first-bloom', 'first-fruit', 'leaf-drop', 'dormancy', 'new-growth', 'other'];
+    for (const event of validEvents) {
+      store[plantPath('plant-ev')] = { species: 'Test' };
+      const res = await request(app).post('/plants/plant-ev/phenology')
+        .set('Authorization', authHeader()).send({ event });
+      expect(res.status).toBe(201);
+    }
+  });
+
+  it('uses current timestamp when date is not provided', async () => {
+    store[plantPath('p1')] = { species: 'Rose' };
+    const before = new Date().toISOString();
+    const res = await request(app).post('/plants/p1/phenology')
+      .set('Authorization', authHeader()).send({ event: 'new-growth' });
+    expect(res.status).toBe(201);
+    expect(new Date(res.body.date) >= new Date(before)).toBe(true);
+  });
+
+  it('appends to existing phenology events', async () => {
+    const existing = [{ id: 'ev1', date: '2026-01-01', event: 'first-leaf', notes: '' }];
+    store[plantPath('p1')] = { species: 'Rose', phenologyEvents: existing };
+    await request(app).post('/plants/p1/phenology')
+      .set('Authorization', authHeader()).send({ event: 'first-bloom' });
+    expect(store[plantPath('p1')].phenologyEvents).toHaveLength(2);
+  });
+});
+
+describe('DELETE /plants/:id/phenology/:eventId', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).delete('/plants/p1/phenology/ev1');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for non-existent plant', async () => {
+    const res = await request(app).delete('/plants/missing/phenology/ev1')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('removes the matching phenology event', async () => {
+    store[plantPath('p1')] = {
+      species: 'Rose',
+      phenologyEvents: [
+        { id: 'ev1', date: '2026-01-01', event: 'first-leaf', notes: '' },
+        { id: 'ev2', date: '2026-04-14', event: 'first-bloom', notes: '' },
+      ],
+    };
+    const res = await request(app).delete('/plants/p1/phenology/ev1')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ deleted: true });
+    expect(store[plantPath('p1')].phenologyEvents).toHaveLength(1);
+    expect(store[plantPath('p1')].phenologyEvents[0].id).toBe('ev2');
   });
 });

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -58,6 +58,11 @@ vi.mock('../hooks/useTempUnit.js', () => ({
   useTempUnit: () => ({ unit: 'celsius', toggle: vi.fn() }),
 }))
 
+// react-apexcharts uses canvas APIs not available in jsdom
+vi.mock('react-apexcharts', () => ({
+  default: () => <div data-testid="apex-chart" />,
+}))
+
 // Leaflet is not available in jsdom
 vi.mock('../components/LeafletFloorplan.jsx', () => ({
   default: () => <div data-testid="leaflet-floorplan" />,

--- a/src/__tests__/PlantModal.test.jsx
+++ b/src/__tests__/PlantModal.test.jsx
@@ -2,15 +2,22 @@ import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import PlantModal from '../components/PlantModal.jsx'
+import { measurementsApi, phenologyApi } from '../api/plants.js'
 
 // Stub out ImageAnalyser to avoid triggering real API calls in unit tests.
 vi.mock('../components/ImageAnalyser.jsx', () => ({
   default: () => <div data-testid="image-analyser" />,
 }))
 
-// Stub imagesApi, recommendApi, plantsApi, and analyseApi so no real network
-// calls happen. plantsApi.update is needed because PlantModal persists
-// recommendation history via the plant doc on success.
+// Stub react-apexcharts so the Growth tab chart renders without canvas issues.
+vi.mock('react-apexcharts', () => ({
+  default: ({ series, type }) => (
+    <div data-testid="apex-chart" data-type={type} data-series={JSON.stringify(series)} />
+  ),
+}))
+
+// Stub imagesApi, recommendApi, plantsApi, analyseApi, measurementsApi, and
+// phenologyApi so no real network calls happen.
 vi.mock('../api/plants.js', () => ({
   imagesApi: { upload: vi.fn().mockResolvedValue('https://example.com/img.jpg') },
   plantsApi: {
@@ -39,6 +46,16 @@ vi.mock('../api/plants.js', () => ({
       signs: 'Yellow leaves = overwatering',
       summary: 'Water moderately.',
     }),
+  },
+  measurementsApi: {
+    list: vi.fn().mockResolvedValue([]),
+    add: vi.fn().mockResolvedValue({ id: 'new-m', date: '2026-04-21T00:00:00.000Z', height_cm: 45, notes: '' }),
+    delete: vi.fn().mockResolvedValue({ deleted: true }),
+  },
+  phenologyApi: {
+    list: vi.fn().mockResolvedValue([]),
+    add: vi.fn().mockResolvedValue({ id: 'new-ev', date: '2026-04-21', event: 'first-bloom', notes: '' }),
+    delete: vi.fn().mockResolvedValue({ deleted: true }),
   },
 }))
 
@@ -787,7 +804,7 @@ describe('PlantModal', () => {
     renderModal({ plant: existingPlant })
     expect(screen.getByRole('tablist', { name: /plant sections/i })).toBeInTheDocument()
     const tabs = screen.getAllByRole('tab')
-    expect(tabs.map((t) => t.textContent)).toEqual(['Plant', 'Watering', 'Care'])
+    expect(tabs.map((t) => t.textContent)).toEqual(['Plant', 'Watering', 'Care', 'Growth'])
   })
 
   it('marks the active tab with aria-selected="true"', () => {
@@ -816,9 +833,9 @@ describe('PlantModal', () => {
 
   it('wraps to the first tab when ArrowRight is pressed on the last tab', () => {
     renderModal({ plant: existingPlant })
-    fireEvent.click(screen.getByText('Care'))
-    const careTab = screen.getAllByRole('tab')[2]
-    fireEvent.keyDown(careTab, { key: 'ArrowRight' })
+    fireEvent.click(screen.getByText('Growth'))
+    const growthTab = screen.getAllByRole('tab')[3]
+    fireEvent.keyDown(growthTab, { key: 'ArrowRight' })
     expect(screen.getAllByRole('tab')[0]).toHaveAttribute('aria-selected', 'true')
   })
 
@@ -835,8 +852,125 @@ describe('PlantModal', () => {
     fireEvent.click(screen.getByText('Watering'))
     const wateringTab = screen.getAllByRole('tab')[1]
     fireEvent.keyDown(wateringTab, { key: 'End' })
-    expect(screen.getAllByRole('tab')[2]).toHaveAttribute('aria-selected', 'true')
-    fireEvent.keyDown(screen.getAllByRole('tab')[2], { key: 'Home' })
+    // Growth is now the last tab (index 3)
+    expect(screen.getAllByRole('tab')[3]).toHaveAttribute('aria-selected', 'true')
+    fireEvent.keyDown(screen.getAllByRole('tab')[3], { key: 'Home' })
     expect(screen.getAllByRole('tab')[0]).toHaveAttribute('aria-selected', 'true')
+  })
+})
+
+// ── Growth tab ────────────────────────────────────────────────────────────────
+
+describe('Growth tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    measurementsApi.add.mockResolvedValue({ id: 'new-m', date: '2026-04-21T00:00:00.000Z', height_cm: 45, notes: '' })
+    phenologyApi.add.mockResolvedValue({ id: 'new-ev', date: '2026-04-21', event: 'first-bloom', notes: '' })
+  })
+
+  it('renders the Growth tab button for existing plants', () => {
+    renderModal({ plant: existingPlant })
+    expect(screen.getByRole('tab', { name: 'Growth' })).toBeInTheDocument()
+  })
+
+  it('does not render the Growth tab for new plants', () => {
+    renderModal({ plant: null })
+    expect(screen.queryByRole('tab', { name: 'Growth' })).not.toBeInTheDocument()
+  })
+
+  it('shows measurement form when Growth tab is active', () => {
+    renderModal({ plant: existingPlant })
+    fireEvent.click(screen.getByRole('tab', { name: 'Growth' }))
+    expect(screen.getByLabelText(/height \(cm\)/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/leaf count/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /log measurement/i })).toBeInTheDocument()
+  })
+
+  it('shows validation error when Log Measurement clicked with no values', () => {
+    renderModal({ plant: existingPlant })
+    fireEvent.click(screen.getByRole('tab', { name: 'Growth' }))
+    fireEvent.click(screen.getByRole('button', { name: /log measurement/i }))
+    expect(screen.getByText(/at least one measurement/i)).toBeInTheDocument()
+  })
+
+  it('calls measurementsApi.add and adds entry on success', async () => {
+    renderModal({ plant: existingPlant })
+    fireEvent.click(screen.getByRole('tab', { name: 'Growth' }))
+    fireEvent.change(screen.getByLabelText(/height \(cm\)/i), { target: { value: '45' } })
+    fireEvent.click(screen.getByRole('button', { name: /log measurement/i }))
+    await waitFor(() => expect(measurementsApi.add).toHaveBeenCalledWith('plant-1', expect.objectContaining({ height_cm: 45 })))
+  })
+
+  it('shows measurement history when plant has existing measurements', () => {
+    const plantWithMeasurements = {
+      ...existingPlant,
+      measurements: [
+        { id: 'm1', date: '2026-01-01T00:00:00.000Z', height_cm: 40, notes: '' },
+      ],
+    }
+    renderModal({ plant: plantWithMeasurements })
+    fireEvent.click(screen.getByRole('tab', { name: 'Growth' }))
+    expect(screen.getByText('40 cm')).toBeInTheDocument()
+  })
+
+  it('renders chart when plant has 2+ height measurements', () => {
+    const plantWithMeasurements = {
+      ...existingPlant,
+      measurements: [
+        { id: 'm1', date: '2026-01-01T00:00:00.000Z', height_cm: 40, notes: '' },
+        { id: 'm2', date: '2026-02-01T00:00:00.000Z', height_cm: 45, notes: '' },
+      ],
+    }
+    renderModal({ plant: plantWithMeasurements })
+    fireEvent.click(screen.getByRole('tab', { name: 'Growth' }))
+    expect(screen.getByTestId('apex-chart')).toBeInTheDocument()
+  })
+
+  it('does not render chart for fewer than 2 height measurements', () => {
+    const plantWithOneMeasurement = {
+      ...existingPlant,
+      measurements: [{ id: 'm1', date: '2026-01-01T00:00:00.000Z', height_cm: 40, notes: '' }],
+    }
+    renderModal({ plant: plantWithOneMeasurement })
+    fireEvent.click(screen.getByRole('tab', { name: 'Growth' }))
+    expect(screen.queryByTestId('apex-chart')).not.toBeInTheDocument()
+  })
+
+  it('shows phenology form and empty state message', () => {
+    renderModal({ plant: existingPlant })
+    fireEvent.click(screen.getByRole('tab', { name: 'Growth' }))
+    expect(screen.getByRole('heading', { name: /phenology events/i })).toBeInTheDocument()
+    expect(screen.getByText(/no phenology events logged/i)).toBeInTheDocument()
+  })
+
+  it('calls phenologyApi.add when Log Event is clicked with a selected event', async () => {
+    renderModal({ plant: existingPlant })
+    fireEvent.click(screen.getByRole('tab', { name: 'Growth' }))
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'first-bloom' } })
+    fireEvent.click(screen.getByRole('button', { name: /log event/i }))
+    await waitFor(() => expect(phenologyApi.add).toHaveBeenCalledWith('plant-1', expect.objectContaining({ event: 'first-bloom' })))
+  })
+
+  it('shows existing phenology events', () => {
+    const plantWithEvents = {
+      ...existingPlant,
+      phenologyEvents: [{ id: 'ev1', date: '2026-04-14', event: 'first-bloom', notes: 'Pink flowers' }],
+    }
+    renderModal({ plant: plantWithEvents })
+    fireEvent.click(screen.getByRole('tab', { name: 'Growth' }))
+    expect(screen.getByText('first-bloom')).toBeInTheDocument()
+    expect(screen.getByText('Pink flowers')).toBeInTheDocument()
+  })
+
+  it('calls measurementsApi.delete when delete button is clicked', async () => {
+    measurementsApi.delete.mockResolvedValue({ deleted: true })
+    const plantWithMeasurements = {
+      ...existingPlant,
+      measurements: [{ id: 'm1', date: '2026-01-01T00:00:00.000Z', height_cm: 40, notes: '' }],
+    }
+    renderModal({ plant: plantWithMeasurements })
+    fireEvent.click(screen.getByRole('tab', { name: 'Growth' }))
+    fireEvent.click(screen.getByRole('button', { name: /delete measurement/i }))
+    await waitFor(() => expect(measurementsApi.delete).toHaveBeenCalledWith('plant-1', 'm1'))
   })
 })

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -179,6 +179,18 @@ export const recommendApi = {
   }),
 }
 
+export const measurementsApi = {
+  list: (id) => request(`/plants/${id}/measurements`),
+  add: (id, data) => request(`/plants/${id}/measurements`, { method: 'POST', body: JSON.stringify(data) }),
+  delete: (id, measurementId) => request(`/plants/${id}/measurements/${measurementId}`, { method: 'DELETE' }),
+}
+
+export const phenologyApi = {
+  list: (id) => request(`/plants/${id}/phenology`),
+  add: (id, data) => request(`/plants/${id}/phenology`, { method: 'POST', body: JSON.stringify(data) }),
+  delete: (id, eventId) => request(`/plants/${id}/phenology/${eventId}`, { method: 'DELETE' }),
+}
+
 export const billingApi = {
   getSubscription: () => request('/billing/subscription'),
   createCheckoutSession: (tier, interval = 'month') => request('/billing/create-checkout-session', {

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo, useContext } from 'react'
 import { Modal, Button, Form, Badge, Spinner, Row, Col, Pagination, Accordion } from 'react-bootstrap'
 import ImageAnalyser from './ImageAnalyser.jsx'
-import { imagesApi, recommendApi, plantsApi, analyseApi } from '../api/plants.js'
+import { imagesApi, recommendApi, plantsApi, analyseApi, measurementsApi, phenologyApi } from '../api/plants.js'
+import Chart from 'react-apexcharts'
 import { getWateringStatus, getAdjustedWaterAmount, isOutdoor, getMoistureDisplay } from '../utils/watering.js'
 import { analyseWateringPattern, getPatternMeta } from '../utils/wateringPattern.js'
 import { derivePlantName } from '../utils/plantName.js'
@@ -252,6 +253,15 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   const [moisturePage, setMoisturePage] = useState(1)
   const [wateringPage, setWateringPage] = useState(1)
 
+  // Growth tab state
+  const [measurements, setMeasurements] = useState(plant?.measurements || [])
+  const [phenologyEvents, setPhenologyEvents] = useState(plant?.phenologyEvents || [])
+  const [newMeasurement, setNewMeasurement] = useState({ height_cm: '', width_cm: '', leafCount: '', stemCount: '', notes: '' })
+  const [newPhenology, setNewPhenology] = useState({ event: '', date: new Date().toISOString().slice(0, 10), notes: '' })
+  const [measurementSaving, setMeasurementSaving] = useState(false)
+  const [measurementError, setMeasurementError] = useState(null)
+  const [phenologySaving, setPhenologySaving] = useState(false)
+
   // Validation + unsaved-change guard state. `isDirty` is set by user-initiated
   // edits only (not programmatic resyncs like the wateringRec effect).
   const [isDirty, setIsDirty] = useState(false)
@@ -428,6 +438,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       { id: 'edit', label: 'Plant' },
       { id: 'watering', label: 'Watering' },
       { id: 'care', label: 'Care' },
+      { id: 'growth', label: 'Growth' },
     ],
     [],
   )
@@ -460,6 +471,55 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       setDeletedPhotoUrls((prev) => [...prev, url.split('?')[0]])
     } catch (err) { console.error('Photo delete failed:', err) }
     finally { setDeletingPhoto(false); setConfirmDeletePhoto(null) }
+  }, [plant])
+
+  const handleAddMeasurement = useCallback(async () => {
+    const { height_cm, width_cm, leafCount, stemCount, notes } = newMeasurement
+    const payload = {}
+    if (height_cm !== '') payload.height_cm = Number(height_cm)
+    if (width_cm  !== '') payload.width_cm  = Number(width_cm)
+    if (leafCount  !== '') payload.leafCount  = Number(leafCount)
+    if (stemCount  !== '') payload.stemCount  = Number(stemCount)
+    if (Object.keys(payload).length === 0) {
+      setMeasurementError('Enter at least one measurement value (height, width, leaf count, or stem count).')
+      return
+    }
+    setMeasurementSaving(true)
+    setMeasurementError(null)
+    try {
+      const entry = await measurementsApi.add(plant.id, { ...payload, notes })
+      setMeasurements(prev => [...prev, entry])
+      setNewMeasurement({ height_cm: '', width_cm: '', leafCount: '', stemCount: '', notes: '' })
+    } catch (err) {
+      setMeasurementError(friendlyErrorMessage(err))
+    } finally {
+      setMeasurementSaving(false)
+    }
+  }, [newMeasurement, plant])
+
+  const handleDeleteMeasurement = useCallback(async (measurementId) => {
+    try {
+      await measurementsApi.delete(plant.id, measurementId)
+      setMeasurements(prev => prev.filter(m => m.id !== measurementId))
+    } catch (err) { console.error('Delete measurement failed:', err) }
+  }, [plant])
+
+  const handleAddPhenology = useCallback(async () => {
+    if (!newPhenology.event) return
+    setPhenologySaving(true)
+    try {
+      const entry = await phenologyApi.add(plant.id, newPhenology)
+      setPhenologyEvents(prev => [...prev, entry])
+      setNewPhenology({ event: '', date: new Date().toISOString().slice(0, 10), notes: '' })
+    } catch (err) { console.error('Add phenology event failed:', err) }
+    finally { setPhenologySaving(false) }
+  }, [newPhenology, plant])
+
+  const handleDeletePhenology = useCallback(async (eventId) => {
+    try {
+      await phenologyApi.delete(plant.id, eventId)
+      setPhenologyEvents(prev => prev.filter(e => e.id !== eventId))
+    } catch (err) { console.error('Delete phenology event failed:', err) }
   }, [plant])
 
   const wateringStatus = useMemo(() => plant ? getWateringStatus(plant, weather, floors) : null, [plant, weather, floors])
@@ -1302,6 +1362,165 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
             </div>
           )}
 
+        </Modal.Body>
+      )}
+
+      {/* Growth tab */}
+      {isEditing && activeTab === 'growth' && (
+        <Modal.Body role="tabpanel" id="plant-tabpanel-growth" aria-labelledby="plant-tab-growth">
+          {measurements.filter(m => m.height_cm != null).length >= 2 && (
+            <div className="mb-4">
+              <h6 className="fw-500 mb-2">Height over time</h6>
+              <Chart
+                type="line"
+                height={180}
+                options={{
+                  chart: { type: 'line', toolbar: { show: false }, background: 'transparent' },
+                  xaxis: { categories: measurements.filter(m => m.height_cm != null).map(m => m.date.slice(0, 10)), type: 'category' },
+                  yaxis: { title: { text: 'cm' }, min: 0 },
+                  stroke: { curve: 'smooth', width: 2 },
+                  markers: { size: 4 },
+                  tooltip: { x: { show: true } },
+                  grid: { borderColor: 'rgba(128,128,128,0.15)' },
+                }}
+                series={[{ name: 'Height (cm)', data: measurements.filter(m => m.height_cm != null).map(m => m.height_cm) }]}
+              />
+            </div>
+          )}
+
+          <div className="mb-4">
+            <h6 className="fw-500 mb-2">Log Measurement</h6>
+            <Row className="g-2">
+              <Col xs={6}>
+                <Form.Group controlId="growth-height-cm">
+                  <Form.Label className="fs-xs">Height (cm)</Form.Label>
+                  <Form.Control type="number" min="0" step="0.1" placeholder="e.g. 45"
+                    value={newMeasurement.height_cm}
+                    onChange={e => setNewMeasurement(prev => ({ ...prev, height_cm: e.target.value }))}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={6}>
+                <Form.Group controlId="growth-width-cm">
+                  <Form.Label className="fs-xs">Width (cm)</Form.Label>
+                  <Form.Control type="number" min="0" step="0.1" placeholder="e.g. 30"
+                    value={newMeasurement.width_cm}
+                    onChange={e => setNewMeasurement(prev => ({ ...prev, width_cm: e.target.value }))}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={6}>
+                <Form.Group controlId="growth-leaf-count">
+                  <Form.Label className="fs-xs">Leaf count</Form.Label>
+                  <Form.Control type="number" min="0" placeholder="e.g. 12"
+                    value={newMeasurement.leafCount}
+                    onChange={e => setNewMeasurement(prev => ({ ...prev, leafCount: e.target.value }))}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={6}>
+                <Form.Group controlId="growth-stem-count">
+                  <Form.Label className="fs-xs">Stem count</Form.Label>
+                  <Form.Control type="number" min="0" placeholder="e.g. 3"
+                    value={newMeasurement.stemCount}
+                    onChange={e => setNewMeasurement(prev => ({ ...prev, stemCount: e.target.value }))}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={12}>
+                <Form.Group controlId="growth-notes">
+                  <Form.Label className="fs-xs">Notes</Form.Label>
+                  <Form.Control as="textarea" rows={2} placeholder="Optional notes…"
+                    value={newMeasurement.notes}
+                    onChange={e => setNewMeasurement(prev => ({ ...prev, notes: e.target.value }))}
+                  />
+                </Form.Group>
+              </Col>
+            </Row>
+            {measurementError && <div className="text-danger fs-xs mt-2">{measurementError}</div>}
+            <Button variant="outline-primary" size="sm" className="mt-2" onClick={handleAddMeasurement} disabled={measurementSaving}>
+              {measurementSaving && <Spinner size="sm" className="me-1" />}
+              + Log Measurement
+            </Button>
+          </div>
+
+          {measurements.length > 0 && (
+            <div className="mb-4">
+              <h6 className="fw-500 mb-2">Measurement history</h6>
+              <div className="table-responsive">
+                <table className="table table-sm fs-xs mb-0">
+                  <thead><tr><th>Date</th><th>Height</th><th>Width</th><th>Leaves</th><th>Stems</th><th></th></tr></thead>
+                  <tbody>
+                    {[...measurements].reverse().map(m => (
+                      <tr key={m.id}>
+                        <td>{m.date.slice(0, 10)}</td>
+                        <td>{m.height_cm != null ? `${m.height_cm} cm` : '—'}</td>
+                        <td>{m.width_cm  != null ? `${m.width_cm} cm`  : '—'}</td>
+                        <td>{m.leafCount  != null ? m.leafCount  : '—'}</td>
+                        <td>{m.stemCount  != null ? m.stemCount  : '—'}</td>
+                        <td>
+                          <Button variant="link" size="sm" className="text-danger p-0" aria-label="Delete measurement"
+                            onClick={() => handleDeleteMeasurement(m.id)}>
+                            <svg className="sa-icon"><use href="/icons/sprite.svg#trash-2"></use></svg>
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          <div className="mb-2">
+            <h6 className="fw-500 mb-2">Phenology Events</h6>
+            <Row className="g-2 mb-2">
+              <Col xs={12} sm={6}>
+                <Form.Select size="sm" value={newPhenology.event}
+                  onChange={e => setNewPhenology(prev => ({ ...prev, event: e.target.value }))}>
+                  <option value="">Select event type…</option>
+                  <option value="first-leaf">First leaf</option>
+                  <option value="first-bud">First bud</option>
+                  <option value="first-bloom">First bloom</option>
+                  <option value="first-fruit">First fruit</option>
+                  <option value="leaf-drop">Leaf drop</option>
+                  <option value="dormancy">Dormancy</option>
+                  <option value="new-growth">New growth</option>
+                  <option value="other">Other</option>
+                </Form.Select>
+              </Col>
+              <Col xs={12} sm={6}>
+                <Form.Control type="date" size="sm" value={newPhenology.date}
+                  onChange={e => setNewPhenology(prev => ({ ...prev, date: e.target.value }))} />
+              </Col>
+              <Col xs={12}>
+                <Form.Control size="sm" placeholder="Notes (optional)" value={newPhenology.notes}
+                  onChange={e => setNewPhenology(prev => ({ ...prev, notes: e.target.value }))} />
+              </Col>
+            </Row>
+            <Button variant="outline-secondary" size="sm" className="mb-3"
+              onClick={handleAddPhenology} disabled={!newPhenology.event || phenologySaving}>
+              {phenologySaving && <Spinner size="sm" className="me-1" />}
+              + Log Event
+            </Button>
+            {phenologyEvents.length > 0 ? (
+              <ul className="list-unstyled mb-0">
+                {[...phenologyEvents].reverse().map(ev => (
+                  <li key={ev.id} className="d-flex align-items-center gap-2 mb-1 fs-xs">
+                    <Badge bg="secondary">{ev.event}</Badge>
+                    <span className="text-muted">{ev.date.slice(0, 10)}</span>
+                    {ev.notes && <span className="flex-grow-1">{ev.notes}</span>}
+                    <Button variant="link" size="sm" className="text-danger p-0 ms-auto" aria-label="Delete event"
+                      onClick={() => handleDeletePhenology(ev.id)}>
+                      <svg className="sa-icon" style={{ width: 14, height: 14 }}><use href="/icons/sprite.svg#x"></use></svg>
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-muted fs-xs mb-0">No phenology events logged yet. Record milestones like first bloom, first fruit, or leaf drop.</p>
+            )}
+          </div>
         </Modal.Body>
       )}
 


### PR DESCRIPTION
## Summary

- Adds a **Growth** tab to PlantModal for existing plants with a height-over-time ApexCharts line chart, manual measurement logging (height cm, width cm, leaf count, stem count, notes), and a phenology event timeline (first leaf, first bud, first bloom, first fruit, leaf drop, dormancy, new growth, other)
- Backend: `GET/POST/DELETE /plants/:id/measurements` and `GET/POST/DELETE /plants/:id/phenology` routes, data stored as arrays on the plant document (consistent with existing `wateringLog`/`moistureLog` pattern)
- Frontend: `measurementsApi` and `phenologyApi` added to `src/api/plants.js`; `react-apexcharts` chart renders once ≥2 height measurements exist
- Rate limiter stubbed out in `index.test.js` to prevent 429s under high test volume

## Test plan

- [ ] 28 new backend tests covering all measurement and phenology CRUD routes (auth, validation, 404, success, edge cases)
- [ ] 12 new PlantModal Growth tab component tests (tab visibility, form validation, chart rendering threshold, API call assertions, delete)
- [ ] Existing keyboard navigation tests updated to account for Growth being the 4th tab
- [ ] `App.test.jsx` gets `react-apexcharts` mock to prevent jsdom canvas issues
- [ ] All 572 frontend tests pass; all 227 backend tests pass
- [ ] Frontend coverage: lines 46% / functions 40% / branches 44% (all above enforced thresholds of 35/30/35)
- [ ] Backend coverage: statements 85% / branches 71% / functions 90% / lines 86%

Closes #209