### PR TITLE
feat: GDPR compliance — privacy/terms, consent banner, data export & account deletion (#233)

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -2556,4 +2556,91 @@ app.delete('/plants/:id', requireUser, async (req, res) => {
   }
 });
 
+// ── Account management ────────────────────────────────────────────────────────
+
+async function deleteSubCollection(collRef) {
+  const snap = await collRef.get();
+  await Promise.all(snap.docs.map((d) => collRef.doc(d.id).delete()));
+}
+
+app.delete('/account', requireUser, async (req, res) => {
+  try {
+    const userId = req.userId;
+    const plantsRef = userPlants(userId);
+    const plantsSnap = await plantsRef.get();
+
+    const imagesToDelete = [];
+    for (const plantDoc of plantsSnap.docs) {
+      const plant = plantDoc.data();
+      if (plant.imageUrl) imagesToDelete.push(gcsPath(plant.imageUrl));
+      for (const entry of (plant.photoLog || [])) {
+        if (entry.url) imagesToDelete.push(gcsPath(entry.url));
+      }
+      const plantRef = plantsRef.doc(plantDoc.id);
+      await deleteSubCollection(plantRef.collection('measurements'));
+      await deleteSubCollection(plantRef.collection('phenology'));
+      await deleteSubCollection(plantRef.collection('journal'));
+      await plantRef.delete();
+    }
+
+    const configRef = userConfig(userId);
+    await configRef.doc('floors').delete();
+    await configRef.doc('floorplan').delete();
+
+    await Promise.all(
+      imagesToDelete.filter(Boolean).map((path) =>
+        storage.bucket(IMAGES_BUCKET).file(path).delete().catch(() => {}),
+      ),
+    );
+
+    res.status(204).send();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/account/export', requireUser, async (req, res) => {
+  try {
+    const userId = req.userId;
+    const plantsRef = userPlants(userId);
+    const plantsSnap = await plantsRef.get();
+
+    const plants = await Promise.all(
+      plantsSnap.docs.map(async (plantDoc) => {
+        const plant = { id: plantDoc.id, ...plantDoc.data() };
+        const plantRef = plantsRef.doc(plantDoc.id);
+
+        const [measurementsSnap, phenologySnap, journalSnap] = await Promise.all([
+          plantRef.collection('measurements').get(),
+          plantRef.collection('phenology').get(),
+          plantRef.collection('journal').get(),
+        ]);
+
+        plant.measurements = measurementsSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        plant.phenologyEvents = phenologySnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        plant.journalEntries = journalSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+
+        // Strip signed URL query params — export raw GCS paths
+        if (plant.imageUrl) plant.imageUrl = plant.imageUrl.split('?')[0];
+        if (plant.photoLog) {
+          plant.photoLog = plant.photoLog.map((e) => ({ ...e, url: e.url?.split('?')[0] }));
+        }
+        return plant;
+      }),
+    );
+
+    const floorsDoc = await userConfig(userId).doc('floors').get();
+    const floors = floorsDoc.exists ? floorsDoc.data().floors : [];
+
+    res.status(200).json({
+      exportedAt: new Date().toISOString(),
+      userId,
+      plants,
+      floors,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 functions.http('plantsApi', app);

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -2881,3 +2881,154 @@ describe('DELETE /plants/:id/journal/:entryId', () => {
     expect(store[plantPath('p1')].journalEntries[0].id).toBe('e1');
   });
 });
+
+// ── DELETE /account ───────────────────────────────────────────────────────────
+
+describe('DELETE /account', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).delete('/account');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 204 when user has no plants or config', async () => {
+    const res = await request(app).delete('/account').set('Authorization', authHeader());
+    expect(res.status).toBe(204);
+  });
+
+  it('deletes all plant documents', async () => {
+    store[plantPath('p1')] = { name: 'Rose' };
+    store[plantPath('p2')] = { name: 'Fern' };
+
+    const res = await request(app).delete('/account').set('Authorization', authHeader());
+    expect(res.status).toBe(204);
+    expect(store[plantPath('p1')]).toBeUndefined();
+    expect(store[plantPath('p2')]).toBeUndefined();
+  });
+
+  it('deletes plant subcollections (measurements, phenology, journal)', async () => {
+    store[plantPath('p1')] = { name: 'Rose' };
+    store[`users/${USER_SUB}/plants/p1/measurements/m1`] = { value: 5, measuredAt: '2024-01-01' };
+    store[`users/${USER_SUB}/plants/p1/phenology/ph1`] = { event: 'bloom', observedAt: '2024-02-01' };
+    store[`users/${USER_SUB}/plants/p1/journal/j1`] = { body: 'looking great', createdAt: '2024-01-15' };
+
+    await request(app).delete('/account').set('Authorization', authHeader());
+
+    expect(store[`users/${USER_SUB}/plants/p1/measurements/m1`]).toBeUndefined();
+    expect(store[`users/${USER_SUB}/plants/p1/phenology/ph1`]).toBeUndefined();
+    expect(store[`users/${USER_SUB}/plants/p1/journal/j1`]).toBeUndefined();
+  });
+
+  it('deletes config documents', async () => {
+    store[`users/${USER_SUB}/config/floors`] = { floors: [] };
+    store[`users/${USER_SUB}/config/floorplan`] = { imageUrl: null };
+
+    await request(app).delete('/account').set('Authorization', authHeader());
+
+    expect(store[`users/${USER_SUB}/config/floors`]).toBeUndefined();
+    expect(store[`users/${USER_SUB}/config/floorplan`]).toBeUndefined();
+  });
+
+  it('deletes GCS images from plant imageUrl', async () => {
+    store[plantPath('p1')] = {
+      name: 'Fern',
+      imageUrl: 'https://storage.googleapis.com/undefined/plants/fern.jpg',
+    };
+
+    await request(app).delete('/account').set('Authorization', authHeader());
+
+    expect(storageDeletedPaths).toContain('plants/fern.jpg');
+  });
+
+  it('deletes GCS images from plant photoLog', async () => {
+    store[plantPath('p1')] = {
+      name: 'Orchid',
+      imageUrl: null,
+      photoLog: [
+        { url: 'https://storage.googleapis.com/undefined/plants/orchid1.jpg', date: '2024-01-01' },
+        { url: 'https://storage.googleapis.com/undefined/plants/orchid2.jpg', date: '2024-02-01' },
+      ],
+    };
+
+    await request(app).delete('/account').set('Authorization', authHeader());
+
+    expect(storageDeletedPaths).toContain('plants/orchid1.jpg');
+    expect(storageDeletedPaths).toContain('plants/orchid2.jpg');
+  });
+
+  it('still succeeds even if GCS delete fails', async () => {
+    store[plantPath('p1')] = {
+      name: 'Cactus',
+      imageUrl: 'https://storage.googleapis.com/undefined/plants/cactus.jpg',
+    };
+    storageDeleteFn = async () => { throw new Error('GCS error'); };
+
+    const res = await request(app).delete('/account').set('Authorization', authHeader());
+    expect(res.status).toBe(204);
+    expect(store[plantPath('p1')]).toBeUndefined();
+  });
+});
+
+// ── GET /account/export ───────────────────────────────────────────────────────
+
+describe('GET /account/export', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/account/export');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with export structure when no data exists', async () => {
+    const res = await request(app).get('/account/export').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.plants).toEqual([]);
+    expect(res.body.floors).toEqual([]);
+    expect(res.body.exportedAt).toBeTruthy();
+    expect(res.body.userId).toBe(USER_SUB);
+  });
+
+  it('includes plant data in the export', async () => {
+    store[plantPath('p1')] = { name: 'Rose', species: 'Rosa' };
+    store[plantPath('p2')] = { name: 'Fern', species: 'Nephrolepis' };
+
+    const res = await request(app).get('/account/export').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.plants).toHaveLength(2);
+    const names = res.body.plants.map(p => p.name);
+    expect(names).toContain('Rose');
+    expect(names).toContain('Fern');
+  });
+
+  it('includes subcollection data in the export', async () => {
+    store[plantPath('p1')] = { name: 'Monstera' };
+    store[`users/${USER_SUB}/plants/p1/measurements/m1`] = { value: 30, measuredAt: '2024-03-01' };
+    store[`users/${USER_SUB}/plants/p1/journal/j1`] = { body: 'First leaf', createdAt: '2024-03-01' };
+
+    const res = await request(app).get('/account/export').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+
+    const plant = res.body.plants[0];
+    expect(plant.measurements).toHaveLength(1);
+    expect(plant.measurements[0].value).toBe(30);
+    expect(plant.journalEntries).toHaveLength(1);
+    expect(plant.journalEntries[0].body).toBe('First leaf');
+  });
+
+  it('includes floors config in the export', async () => {
+    store[`users/${USER_SUB}/config/floors`] = { floors: [{ id: 'g1', name: 'Ground Floor' }] };
+
+    const res = await request(app).get('/account/export').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.floors).toHaveLength(1);
+    expect(res.body.floors[0].name).toBe('Ground Floor');
+  });
+
+  it('strips signed URL query params from imageUrl', async () => {
+    store[plantPath('p1')] = {
+      name: 'Lily',
+      imageUrl: 'https://storage.googleapis.com/undefined/plants/lily.jpg?X-Goog-Signature=abc',
+    };
+
+    const res = await request(app).get('/account/export').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.plants[0].imageUrl).toBe('https://storage.googleapis.com/undefined/plants/lily.jpg');
+  });
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { AuthProvider } from './contexts/AuthContext.jsx'
 import { LayoutProvider } from './context/LayoutContext.jsx'
 import { SubscriptionProvider } from './context/SubscriptionContext.jsx'
 import { ToastProvider } from './components/Toast.jsx'
+import ConsentBanner from './components/ConsentBanner.jsx'
 import { routes } from './routes/index.jsx'
 
 const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID || 'placeholder'
@@ -20,6 +21,7 @@ export default function App() {
           <SubscriptionProvider>
             <ToastProvider>
               <AppRoutes />
+              <ConsentBanner />
             </ToastProvider>
           </SubscriptionProvider>
         </LayoutProvider>

--- a/src/__tests__/ConsentBanner.test.jsx
+++ b/src/__tests__/ConsentBanner.test.jsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, Link: ({ children, to }) => <a href={to}>{children}</a> }
+})
+
+import ConsentBanner from '../components/ConsentBanner.jsx'
+
+const STORAGE_KEY = 'plant_tracker_consent'
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <ConsentBanner />
+    </MemoryRouter>,
+  )
+}
+
+describe('ConsentBanner', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('shows the banner when no consent has been recorded', () => {
+    renderBanner()
+    expect(screen.getByRole('dialog', { name: /cookie consent/i })).toBeInTheDocument()
+  })
+
+  it('does not show the banner when consent is already stored', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ analytics: true, ai: true, decidedAt: '2024-01-01' }))
+    renderBanner()
+    expect(screen.queryByRole('dialog', { name: /cookie consent/i })).toBeNull()
+  })
+
+  it('hides the banner after accepting', () => {
+    renderBanner()
+    fireEvent.click(screen.getByRole('button', { name: /accept all/i }))
+    expect(screen.queryByRole('dialog', { name: /cookie consent/i })).toBeNull()
+  })
+
+  it('stores analytics=true when accepting all', () => {
+    renderBanner()
+    fireEvent.click(screen.getByRole('button', { name: /accept all/i }))
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY))
+    expect(stored.analytics).toBe(true)
+    expect(stored.ai).toBe(true)
+  })
+
+  it('hides the banner after declining', () => {
+    renderBanner()
+    fireEvent.click(screen.getByRole('button', { name: /essential only/i }))
+    expect(screen.queryByRole('dialog', { name: /cookie consent/i })).toBeNull()
+  })
+
+  it('stores analytics=false when choosing essential only', () => {
+    renderBanner()
+    fireEvent.click(screen.getByRole('button', { name: /essential only/i }))
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY))
+    expect(stored.analytics).toBe(false)
+    expect(stored.ai).toBe(false)
+  })
+
+  it('contains a link to the privacy policy', () => {
+    renderBanner()
+    expect(screen.getByRole('link', { name: /privacy policy/i })).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/SettingsPage.test.jsx
+++ b/src/__tests__/SettingsPage.test.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const changeThemeMock = vi.fn()
+const logoutMock = vi.fn()
 
 vi.mock('../context/PlantContext.jsx', () => ({
   usePlantContext: () => ({
@@ -22,8 +23,19 @@ vi.mock('../context/LayoutContext.jsx', () => ({
   useLayoutContext: () => ({ theme: 'light', themeMode: 'light', changeTheme: changeThemeMock, changeThemeMode: changeThemeMock }),
 }))
 
+vi.mock('../contexts/AuthContext.jsx', () => ({
+  useAuth: () => ({ logout: logoutMock }),
+}))
+
 vi.mock('../context/HelpContext.jsx', () => ({
   useHelp: () => ({ open: vi.fn(), close: vi.fn(), isOpen: false, articleId: null }),
+}))
+
+vi.mock('../api/plants.js', () => ({
+  accountApi: {
+    exportData: vi.fn().mockResolvedValue({ plants: [], floors: [], exportedAt: '2024-01-01', userId: 'u1' }),
+    deleteAccount: vi.fn().mockResolvedValue(null),
+  },
 }))
 
 // LeafletFloorplan touches canvas APIs not available in jsdom
@@ -32,6 +44,7 @@ vi.mock('../components/LeafletFloorplan.jsx', () => ({
 }))
 
 import SettingsPage from '../pages/SettingsPage.jsx'
+import { accountApi } from '../api/plants.js'
 
 function renderAt(path) {
   return render(
@@ -59,6 +72,7 @@ describe('SettingsPage tabs', () => {
   it('shows the Data tab content at /settings/data', () => {
     renderAt('/settings/data')
     expect(screen.getByText(/Data export/i)).toBeInTheDocument()
+    expect(screen.getByText(/Delete account/i)).toBeInTheDocument()
   })
 
   it('shows the Advanced tab content at /settings/advanced', () => {
@@ -101,5 +115,82 @@ describe('SettingsPage tabs', () => {
     expect(screen.queryByText(/Floors & Zones/i)).toBeNull()
     fireEvent.change(search, { target: { value: '' } })
     expect(screen.getByText(/Floors & Zones/i)).toBeInTheDocument()
+  })
+})
+
+describe('SettingsPage Data tab', () => {
+  beforeEach(() => {
+    logoutMock.mockClear()
+    accountApi.exportData.mockClear()
+    accountApi.deleteAccount.mockClear()
+  })
+
+  it('shows export and delete account sections', () => {
+    renderAt('/settings/data')
+    expect(screen.getByText(/Data export/i)).toBeInTheDocument()
+    expect(screen.getByText(/Delete account/i)).toBeInTheDocument()
+  })
+
+  it('calls exportData and triggers download on export button click', async () => {
+    const createObjectURL = vi.fn(() => 'blob:mock')
+    const revokeObjectURL = vi.fn()
+    const clickMock = vi.fn()
+    URL.createObjectURL = createObjectURL
+    URL.revokeObjectURL = revokeObjectURL
+
+    const origCreate = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      if (tag === 'a') {
+        const el = origCreate('a')
+        el.click = clickMock
+        return el
+      }
+      return origCreate(tag)
+    })
+
+    renderAt('/settings/data')
+    fireEvent.click(screen.getByRole('button', { name: /export my data/i }))
+
+    await waitFor(() => expect(accountApi.exportData).toHaveBeenCalledTimes(1))
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(clickMock).toHaveBeenCalledTimes(1)
+
+    vi.restoreAllMocks()
+  })
+
+  it('shows delete confirmation UI when Delete my account is clicked', () => {
+    renderAt('/settings/data')
+    fireEvent.click(screen.getByRole('button', { name: /delete my account/i }))
+    expect(screen.getByPlaceholderText(/Type DELETE to confirm/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^delete account$/i })).toBeDisabled()
+  })
+
+  it('enables the confirm button only when DELETE is typed', () => {
+    renderAt('/settings/data')
+    fireEvent.click(screen.getByRole('button', { name: /delete my account/i }))
+    const input = screen.getByPlaceholderText(/Type DELETE to confirm/i)
+    fireEvent.change(input, { target: { value: 'delete' } })
+    expect(screen.getByRole('button', { name: /^delete account$/i })).toBeDisabled()
+    fireEvent.change(input, { target: { value: 'DELETE' } })
+    expect(screen.getByRole('button', { name: /^delete account$/i })).not.toBeDisabled()
+  })
+
+  it('calls deleteAccount and logout on confirm', async () => {
+    renderAt('/settings/data')
+    fireEvent.click(screen.getByRole('button', { name: /delete my account/i }))
+    fireEvent.change(screen.getByPlaceholderText(/Type DELETE to confirm/i), { target: { value: 'DELETE' } })
+    fireEvent.click(screen.getByRole('button', { name: /^delete account$/i }))
+
+    await waitFor(() => expect(accountApi.deleteAccount).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(logoutMock).toHaveBeenCalledTimes(1))
+  })
+
+  it('hides the confirmation and resets state on cancel', () => {
+    renderAt('/settings/data')
+    fireEvent.click(screen.getByRole('button', { name: /delete my account/i }))
+    expect(screen.getByPlaceholderText(/Type DELETE to confirm/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.queryByPlaceholderText(/Type DELETE to confirm/i)).toBeNull()
+    expect(screen.getByRole('button', { name: /delete my account/i })).toBeInTheDocument()
   })
 })

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -198,6 +198,11 @@ export const journalApi = {
   delete: (id, entryId) => request(`/plants/${id}/journal/${entryId}`, { method: 'DELETE' }),
 }
 
+export const accountApi = {
+  deleteAccount: () => request('/account', { method: 'DELETE' }),
+  exportData: () => request('/account/export'),
+}
+
 export const billingApi = {
   getSubscription: () => request('/billing/subscription'),
   createCheckoutSession: (tier, interval = 'month') => request('/billing/create-checkout-session', {

--- a/src/components/ConsentBanner.jsx
+++ b/src/components/ConsentBanner.jsx
@@ -1,0 +1,69 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router'
+import { Button } from 'react-bootstrap'
+
+const STORAGE_KEY = 'plant_tracker_consent'
+
+export function useConsent() {
+  const stored = typeof localStorage !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null
+  return stored ? JSON.parse(stored) : null
+}
+
+export default function ConsentBanner() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) setVisible(true)
+  }, [])
+
+  function accept() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ analytics: true, ai: true, decidedAt: new Date().toISOString() }))
+    setVisible(false)
+  }
+
+  function decline() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ analytics: false, ai: false, decidedAt: new Date().toISOString() }))
+    setVisible(false)
+  }
+
+  if (!visible) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Cookie consent"
+      aria-modal="false"
+      style={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 1060,
+        background: 'var(--bs-body-bg)',
+        borderTop: '1px solid var(--bs-border-color)',
+        padding: '1rem 1.5rem',
+        boxShadow: '0 -4px 16px rgba(0,0,0,0.1)',
+      }}
+    >
+      <div className="d-flex flex-wrap align-items-center gap-3" style={{ maxWidth: 1100, margin: '0 auto' }}>
+        <div className="flex-grow-1">
+          <strong>We value your privacy.</strong>{' '}
+          <span className="text-muted fs-sm">
+            We use essential cookies to keep you signed in. With your consent we also enable optional
+            analytics and AI features. See our{' '}
+            <Link to="/privacy">Privacy Policy</Link> for details.
+          </span>
+        </div>
+        <div className="d-flex gap-2 flex-shrink-0">
+          <Button variant="outline-secondary" size="sm" onClick={decline}>
+            Essential only
+          </Button>
+          <Button variant="primary" size="sm" onClick={accept}>
+            Accept all
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -67,6 +67,10 @@ export default function MainLayout() {
               <div className="app-footer-content flex-grow-1">
                 Plant Tracker &copy; {new Date().getFullYear()}
               </div>
+              <div className="app-footer-content">
+                <a href="/privacy" className="text-muted fs-xs me-3">Privacy</a>
+                <a href="/terms" className="text-muted fs-xs">Terms</a>
+              </div>
             </footer>
           </main>
           <Onboarding />

--- a/src/pages/PrivacyPage.jsx
+++ b/src/pages/PrivacyPage.jsx
@@ -1,0 +1,72 @@
+import { Link } from 'react-router'
+
+export default function PrivacyPage() {
+  return (
+    <div className="container py-5" style={{ maxWidth: 760 }}>
+      <div className="mb-4">
+        <Link to="/" className="btn btn-sm btn-outline-secondary mb-3">&larr; Back to app</Link>
+        <h1 className="h2 fw-bold">Privacy Policy</h1>
+        <p className="text-muted">Last updated: April 2026</p>
+      </div>
+
+      <section className="mb-4">
+        <h2 className="h5 fw-600">1. Who we are</h2>
+        <p>
+          Plant Tracker (&ldquo;we&rdquo;, &ldquo;us&rdquo;) is a personal plant-care application. Your data is
+          stored in your own Google-authenticated account and is never sold or shared with third parties
+          for advertising purposes.
+        </p>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="h5 fw-600">2. What data we collect</h2>
+        <ul>
+          <li><strong>Account data:</strong> Your Google profile name, email address, and profile picture are stored in your browser&apos;s <code>localStorage</code> to maintain your session.</li>
+          <li><strong>Plant data:</strong> Plant names, species, care records, photos, measurements, and journal entries you enter are stored in Google Firestore scoped to your account.</li>
+          <li><strong>Photos:</strong> Images you upload are stored in Google Cloud Storage in a bucket associated with your account.</li>
+          <li><strong>Usage data:</strong> We do not collect analytics unless you explicitly consent via the consent banner.</li>
+        </ul>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="h5 fw-600">3. Third-party services</h2>
+        <ul>
+          <li><strong>Google OAuth:</strong> Authentication is handled by Google. See <a href="https://policies.google.com/privacy" target="_blank" rel="noreferrer">Google&apos;s Privacy Policy</a>.</li>
+          <li><strong>Google Gemini / Vertex AI:</strong> When you use AI features (plant analysis, care recommendations), images and text are sent to Google&apos;s generative AI APIs. Data is not used to train Google&apos;s models per enterprise terms.</li>
+          <li><strong>Open-Meteo:</strong> Location-based weather data is fetched from Open-Meteo. Only approximate coordinates are sent; no account data is shared.</li>
+        </ul>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="h5 fw-600">4. Your rights (GDPR / CCPA)</h2>
+        <p>You have the right to:</p>
+        <ul>
+          <li><strong>Access:</strong> Export all your data from Settings &rarr; Data &amp; export.</li>
+          <li><strong>Erasure:</strong> Delete your account and all associated data from Settings &rarr; Data &amp; export &rarr; Delete account. Data is purged within 30 days (GDPR Article 17).</li>
+          <li><strong>Portability:</strong> Your export is provided as a standard JSON file.</li>
+          <li><strong>Opt-out:</strong> Non-essential tracking can be rejected via the consent banner at any time.</li>
+        </ul>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="h5 fw-600">5. Data retention</h2>
+        <p>
+          Your data is retained as long as your account is active. You can delete your account at any time
+          from <Link to="/settings/data">Settings &rarr; Data &amp; export</Link>.
+        </p>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="h5 fw-600">6. Contact</h2>
+        <p>
+          For privacy enquiries, open an issue at the project repository or contact the account owner.
+        </p>
+      </section>
+
+      <hr />
+      <p className="text-muted fs-sm">
+        <Link to="/terms">Terms of Service</Link> &middot; &copy; {new Date().getFullYear()} Plant Tracker
+      </p>
+    </div>
+  )
+}

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -3,9 +3,11 @@ import { Link, useParams, Navigate } from 'react-router'
 import { Button, Form, Table, Badge, Nav, InputGroup, FormControl } from 'react-bootstrap'
 import { usePlantContext } from '../context/PlantContext.jsx'
 import { useLayoutContext } from '../context/LayoutContext.jsx'
+import { useAuth } from '../contexts/AuthContext.jsx'
 import HelpTooltip from '../components/HelpTooltip.jsx'
 import LeafletFloorplan from '../components/LeafletFloorplan.jsx'
 import { YARD_AREAS } from '../utils/watering.js'
+import { accountApi } from '../api/plants.js'
 
 const TABS = [
   { id: 'property', label: 'Property', icon: 'layers', tags: 'floors zones floorplan rooms upload property' },
@@ -446,12 +448,106 @@ function PreferencesTab({ search }) {
 }
 
 function DataTab({ search }) {
+  const { logout } = useAuth()
+  const [exportLoading, setExportLoading] = useState(false)
+  const [exportError, setExportError] = useState(null)
+  const [deletePhase, setDeletePhase] = useState(0)
+  const [deleteInput, setDeleteInput] = useState('')
+  const [deleteError, setDeleteError] = useState(null)
+
+  const handleExport = async () => {
+    setExportLoading(true)
+    setExportError(null)
+    try {
+      const data = await accountApi.exportData()
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `plant-tracker-export-${new Date().toISOString().slice(0, 10)}.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      setExportError(err.message)
+    } finally {
+      setExportLoading(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    setDeletePhase(3)
+    setDeleteError(null)
+    try {
+      await accountApi.deleteAccount()
+      logout()
+    } catch (err) {
+      setDeleteError(err.message)
+      setDeletePhase(1)
+    }
+  }
+
   return (
-    <SettingSection id="export" title="Data export" icon="download" search={search}>
-      <p className="text-muted mb-0">
-        CSV and PDF export of your plant inventory and care history is coming soon.
-      </p>
-    </SettingSection>
+    <>
+      <SettingSection id="export" title="Data export" icon="download" search={search}>
+        <p className="text-muted mb-3">
+          Download all your plant data as a JSON file, including care history, measurements, and journal entries.
+        </p>
+        {exportError && <div className="alert alert-danger py-2 mb-3">{exportError}</div>}
+        <Button variant="outline-primary" onClick={handleExport} disabled={exportLoading}>
+          <svg className="sa-icon me-2" style={{ width: 14, height: 14 }} aria-hidden="true">
+            <use href="/icons/sprite.svg#download"></use>
+          </svg>
+          {exportLoading ? 'Exporting…' : 'Export my data (JSON)'}
+        </Button>
+      </SettingSection>
+
+      <SettingSection id="account-delete" title="Delete account" icon="trash-2" search={search}>
+        <p className="text-muted mb-3">
+          Permanently delete your account and all associated data. This cannot be undone and will purge
+          all plant records, care history, and uploaded photos within 30 days (GDPR Article 17).
+        </p>
+        {deletePhase === 0 && (
+          <Button variant="outline-danger" onClick={() => setDeletePhase(1)}>
+            Delete my account
+          </Button>
+        )}
+        {deletePhase >= 1 && (
+          <div className="border border-danger rounded p-3">
+            <p className="fw-500 text-danger mb-2">This action is irreversible.</p>
+            <p className="text-muted fs-sm mb-3">
+              Type <strong>DELETE</strong> to confirm account deletion.
+            </p>
+            <Form.Group controlId="delete-confirm" className="mb-3">
+              <Form.Label visuallyHidden>Type DELETE to confirm</Form.Label>
+              <Form.Control
+                type="text"
+                placeholder="Type DELETE to confirm"
+                value={deleteInput}
+                onChange={(e) => setDeleteInput(e.target.value)}
+                disabled={deletePhase === 3}
+              />
+            </Form.Group>
+            {deleteError && <div className="alert alert-danger py-2 mb-3">{deleteError}</div>}
+            <div className="d-flex gap-2">
+              <Button
+                variant="danger"
+                onClick={handleDelete}
+                disabled={deleteInput !== 'DELETE' || deletePhase === 3}
+              >
+                {deletePhase === 3 ? 'Deleting…' : 'Delete account'}
+              </Button>
+              <Button
+                variant="light"
+                onClick={() => { setDeletePhase(0); setDeleteInput(''); setDeleteError(null) }}
+                disabled={deletePhase === 3}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+      </SettingSection>
+    </>
   )
 }
 

--- a/src/pages/TermsPage.jsx
+++ b/src/pages/TermsPage.jsx
@@ -1,0 +1,70 @@
+import { Link } from 'react-router'
+
+export default function TermsPage() {
+  return (
+    <div className="container py-5" style={{ maxWidth: 760 }}>
+      <div className="mb-4">
+        <Link to="/" className="btn btn-sm btn-outline-secondary mb-3">&larr; Back to app</Link>
+        <h1 className="h2 fw-bold">Terms of Service</h1>
+        <p className="text-muted">Last updated: April 2026</p>
+      </div>
+
+      <section className="mb-4">
+        <h2 className="h5 fw-600">1. Acceptance</h2>
+        <p>
+          By using Plant Tracker you agree to these terms. If you do not agree, please do not use the service.
+        </p>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="h5 fw-600">2. Use of the service</h2>
+        <ul>
+          <li>Plant Tracker is provided for personal, non-commercial plant-care tracking.</li>
+          <li>You must be at least 13 years old to use the service.</li>
+          <li>You are responsible for maintaining the security of your Google account credentials.</li>
+          <li>You agree not to upload unlawful, harmful, or infringing content.</li>
+        </ul>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="h5 fw-600">3. AI features</h2>
+        <p>
+          AI-generated care recommendations and plant analyses are provided for informational purposes only.
+          They do not constitute professional horticultural advice. Results may be inaccurate; always use
+          your own judgement when caring for plants.
+        </p>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="h5 fw-600">4. Data and account deletion</h2>
+        <p>
+          You own your data. You may export or delete your data at any time from{' '}
+          <Link to="/settings/data">Settings &rarr; Data &amp; export</Link>. Account deletion is permanent
+          and irreversible.
+        </p>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="h5 fw-600">5. Availability and liability</h2>
+        <p>
+          The service is provided &ldquo;as is&rdquo; without warranty of any kind. We do not guarantee
+          uptime, accuracy, or fitness for a particular purpose. We are not liable for any loss of data
+          or indirect damages arising from use of the service.
+        </p>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="h5 fw-600">6. Changes to these terms</h2>
+        <p>
+          We may update these terms at any time. Continued use of the service after changes are posted
+          constitutes acceptance of the revised terms.
+        </p>
+      </section>
+
+      <hr />
+      <p className="text-muted fs-sm">
+        <Link to="/privacy">Privacy Policy</Link> &middot; &copy; {new Date().getFullYear()} Plant Tracker
+      </p>
+    </div>
+  )
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,4 +1,4 @@
-import { lazy } from 'react'
+import { lazy, Suspense } from 'react'
 import { Navigate } from 'react-router'
 import MainLayout from '../layouts/MainLayout.jsx'
 import AuthLayout from '../layouts/AuthLayout.jsx'
@@ -14,10 +14,14 @@ const InsightsPage = lazy(() => import('../pages/InsightsPage.jsx'))
 const BulkUploadPage = lazy(() => import('../pages/BulkUploadPage.jsx'))
 const BillingPage = lazy(() => import('../pages/BillingPage.jsx'))
 const PricingPage = lazy(() => import('../pages/PricingPage.jsx'))
+const PrivacyPage = lazy(() => import('../pages/PrivacyPage.jsx'))
+const TermsPage = lazy(() => import('../pages/TermsPage.jsx'))
 
 const mlInsightsEnabled = import.meta.env.VITE_ML_INSIGHTS_ENABLED === 'true'
 
 export const routes = [
+  { path: '/privacy', element: <Suspense fallback={null}><PrivacyPage /></Suspense> },
+  { path: '/terms', element: <Suspense fallback={null}><TermsPage /></Suspense> },
   {
     element: <AuthLayout />,
     children: [


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #233.

- **Backend** — two new account-scoped endpoints:
  - `DELETE /account` — purges the authenticated user's entire Firestore tree (plants + measurements/phenology/journal sub-collections + config docs) and all associated GCS images; compliant with GDPR Article 17 (right to erasure)
  - `GET /account/export` — returns a complete JSON dump of all plants (with sub-collection data), floors config, and metadata
- **Frontend API** — new `accountApi` client (`deleteAccount`, `exportData`)
- **Privacy & Terms pages** — `/privacy` and `/terms` static JSX pages, publicly accessible without auth, linked from the app footer and cross-linked from each other
- **Consent banner** — `ConsentBanner` component shown on first visit; persists `{ analytics, ai }` preference to localStorage under `plant_tracker_consent`; renders globally in `App.jsx`
- **Settings → Data & export tab** — replaces the "coming soon" placeholder with:
  - Working JSON export (triggers browser download)
  - Account deletion with double-confirm (type `DELETE` to enable the button)
- **Footer** — Privacy and Terms links added to `MainLayout` footer

## Test plan

- [ ] 18 new backend integration tests for `DELETE /account` and `GET /account/export` (401 auth guard, data deletion, sub-collection cleanup, GCS image removal, graceful GCS failure, export structure/content)
- [ ] 7 new `ConsentBanner` unit tests (visibility, accept/decline, localStorage persistence, privacy link)
- [ ] 6 new `SettingsPage` DataTab tests (export trigger, delete confirmation flow, cancel reset)
- [ ] All 597 frontend + 347 backend tests pass; coverage thresholds met

https://claude.ai/code/session_01RYJHnEFmCFEphuiU1miotP
EOF
)