### PR TITLE
feat(#257): rain-aware auto-skip for outdoor plant watering

### DIFF
--- a/src/__tests__/watering.test.js
+++ b/src/__tests__/watering.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getWateringStatus, getAdjustedWaterAmount, isOutdoor, urgencyColor, urgencyLabel, OUTDOOR_ROOMS, getSeason, SEASONAL_MULTIPLIERS, getPlantAttributeMultiplier, getSuggestedFrequency, getMoistureStatusAdjustment, getMoistureFrequencySuggestion, getMoistureDisplay } from '../utils/watering.js'
+import { getWateringStatus, getAdjustedWaterAmount, isOutdoor, urgencyColor, urgencyLabel, OUTDOOR_ROOMS, getSeason, SEASONAL_MULTIPLIERS, getPlantAttributeMultiplier, getSuggestedFrequency, getMoistureStatusAdjustment, getMoistureFrequencySuggestion, getMoistureDisplay, computeRainCredit } from '../utils/watering.js'
 
 function makePlant(overrides = {}) {
   return {
@@ -888,5 +888,65 @@ describe('getMoistureDisplay', () => {
     expect(getMoistureDisplay(2).color).toBe('#d97706')
     expect(getMoistureDisplay(5).color).toBe('#22c55e')
     expect(getMoistureDisplay(8).color).toBe('#3b82f6')
+  })
+})
+
+// ── computeRainCredit ────────────────────────────────────────────────────────
+
+describe('computeRainCredit', () => {
+  it('returns shouldSkip=false when rainfall is below threshold', () => {
+    const result = computeRainCredit({ frequencyDays: 7 }, { recentMm: 3, forecastMm: 0 })
+    expect(result.shouldSkip).toBe(false)
+    expect(result.advanceByDays).toBe(0)
+  })
+
+  it('returns shouldSkip=true when recent rainfall meets threshold', () => {
+    const result = computeRainCredit({ frequencyDays: 7 }, { recentMm: 10, forecastMm: 0 })
+    expect(result.shouldSkip).toBe(true)
+    expect(result.advanceByDays).toBe(4) // 50% of 7d, rounded
+    expect(result.effectiveMm).toBeCloseTo(10)
+  })
+
+  it('combines recent and forecast rainfall', () => {
+    const result = computeRainCredit({ frequencyDays: 7 }, { recentMm: 3, forecastMm: 3 })
+    expect(result.shouldSkip).toBe(true)
+    expect(result.effectiveMm).toBeCloseTo(6)
+  })
+
+  it('applies 0.7x shelter factor for under-cover plants', () => {
+    // 8mm * 0.7 = 5.6mm >= 5mm threshold → skip
+    const result = computeRainCredit({ frequencyDays: 7, isUnderCover: true }, { recentMm: 8 })
+    expect(result.shouldSkip).toBe(true)
+    expect(result.effectiveMm).toBeCloseTo(5.6)
+    expect(result.reason).toMatch(/partial shelter/i)
+  })
+
+  it('does NOT skip for under-cover plants when rain is too low', () => {
+    // 6mm * 0.7 = 4.2mm < 5mm threshold → no skip
+    const result = computeRainCredit({ frequencyDays: 7, isUnderCover: true }, { recentMm: 6 })
+    expect(result.shouldSkip).toBe(false)
+  })
+
+  it('uses full interval for succulent category', () => {
+    const result = computeRainCredit({ frequencyDays: 14, category: 'succulent' }, { recentMm: 20 })
+    expect(result.shouldSkip).toBe(true)
+    expect(result.advanceByDays).toBe(14) // 100% of 14d
+  })
+
+  it('respects explicit rainSkipMultiplier override', () => {
+    const result = computeRainCredit({ frequencyDays: 10, rainSkipMultiplier: 0.3 }, { recentMm: 20 })
+    expect(result.shouldSkip).toBe(true)
+    expect(result.advanceByDays).toBe(3) // 30% of 10d
+  })
+
+  it('handles missing rainfall input gracefully', () => {
+    const result = computeRainCredit({ frequencyDays: 7 }, {})
+    expect(result.shouldSkip).toBe(false)
+    expect(result.effectiveMm).toBe(0)
+  })
+
+  it('clamps rainSkipMultiplier to [0, 1]', () => {
+    const result = computeRainCredit({ frequencyDays: 7, rainSkipMultiplier: 2 }, { recentMm: 20 })
+    expect(result.advanceByDays).toBe(7) // clamped to 1.0 × 7
   })
 })

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -228,6 +228,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
     plantedIn: null,
     emoji: null,
     category: null,
+    isUnderCover: false,
   })
   const [isSaving, setIsSaving] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
@@ -348,6 +349,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
         plantedIn: plant.plantedIn || null,
         emoji: plant.emoji || null,
         category: plant.category || null,
+        isUnderCover: plant.isUnderCover ?? false,
       })
     }
   }, [plant, activeFloorId])
@@ -437,6 +439,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       plantedIn: form.plantedIn,
       emoji: form.emoji || null,
       category: form.category || null,
+      isUnderCover: form.isUnderCover ?? false,
     })
     setIsDirty(false)
     setIsSaving(false)
@@ -935,6 +938,17 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
                     </Form.Group>
                   </Col>
                 </Row>
+                {isOutdoor({ room: form.room, floor: form.floor }, floors) && (
+                  <Form.Group className="mb-3">
+                    <Form.Check
+                      type="checkbox"
+                      id="is-under-cover"
+                      label={<>Under cover <span className="text-muted fs-xs">(patio, porch, greenhouse — reduces effective rainfall)</span></>}
+                      checked={!!form.isUnderCover}
+                      onChange={e => update('isUnderCover', e.target.checked)}
+                    />
+                  </Form.Group>
+                )}
                 <Form.Group className="mb-3">
                   <Form.Label>Plant Category</Form.Label>
                   <Form.Select value={form.category || ''} onChange={(e) => update('category', e.target.value || null)}>

--- a/src/utils/watering.js
+++ b/src/utils/watering.js
@@ -169,6 +169,23 @@ export function getWateringStatus(plant, weather = null, floors = []) {
     }
   }
 
+  // Outdoor + sufficient recent/forecast rain → apply rain credit
+  if (outdoor && weather?.precipitation != null) {
+    const forecastMm = weather.days?.slice(0, 1).reduce((s, d) => s + (d.precipitation || 0), 0) ?? 0
+    const rainCredit = computeRainCredit(plant, { recentMm: weather.precipitation, forecastMm })
+    if (rainCredit.shouldSkip) {
+      return {
+        daysUntil:      rainCredit.advanceByDays,
+        skippedRain:    true,
+        note:           rainCredit.reason,
+        color:          '#60a5fa',
+        label:          `Skipped by rain`,
+        season,
+        seasonNote,
+      }
+    }
+  }
+
   // Layer 1: Season
   const base = plant.frequencyDays ?? 7
   let effective = base / seasonMultiplier
@@ -481,4 +498,52 @@ export function getMoistureDisplay(reading) {
   if (reading <= 3) return { label: 'Dry', color: '#d97706' }
   if (reading <= 6) return { label: 'Moist', color: '#22c55e' }
   return { label: 'Wet', color: '#3b82f6' }
+}
+
+// ── Rain credit (outdoor plants) ────────────────────────────────────────────
+
+// Minimum effective rainfall (mm) that earns a skip
+const RAIN_SKIP_THRESHOLD_MM = 5
+
+/**
+ * Compute how much of the plant's next watering should be skipped due to
+ * recent or forecast rainfall.  Only meaningful for outdoor plants.
+ *
+ * @param {object} plant
+ *   - isUnderCover {boolean}       — patio/porch/greenhouse (partial rain shelter)
+ *   - rainSkipMultiplier {number}  — override fraction of interval to skip (0–1)
+ *   - frequencyDays {number}
+ *   - category {string}            — 'succulent' plants get a full-interval skip
+ * @param {object} rainfall
+ *   - recentMm {number}  — total precipitation in the last 72 h
+ *   - forecastMm {number} — expected precipitation in the next 24 h (default 0)
+ * @returns {{ shouldSkip: boolean, advanceByDays: number, effectiveMm: number, reason: string }}
+ */
+export function computeRainCredit(plant, rainfall = {}) {
+  const { recentMm = 0, forecastMm = 0 } = rainfall
+  const totalMm = (recentMm || 0) + (forecastMm || 0)
+
+  // Plants under cover receive only a fraction of open-sky rainfall
+  const shelterFactor = plant.isUnderCover ? 0.7 : 1.0
+  const effectiveMm = totalMm * shelterFactor
+
+  if (effectiveMm < RAIN_SKIP_THRESHOLD_MM) {
+    return { shouldSkip: false, advanceByDays: 0, effectiveMm, reason: 'Insufficient rain for a skip' }
+  }
+
+  // Determine what fraction of the interval the rain credit covers
+  // Drought-tolerant plants (succulents) skip a full interval; others half
+  const defaultFraction = plant.category === 'succulent' ? 1.0 : 0.5
+  const fraction = plant.rainSkipMultiplier != null
+    ? Math.min(1, Math.max(0, plant.rainSkipMultiplier))
+    : defaultFraction
+
+  const frequencyDays = plant.frequencyDays || 7
+  const advanceByDays = Math.round(frequencyDays * fraction)
+
+  const source = recentMm >= RAIN_SKIP_THRESHOLD_MM ? 'Recent rain' : 'Forecast rain'
+  const coverNote = plant.isUnderCover ? ' (partial shelter applied)' : ''
+  const reason = `${source} — ${effectiveMm.toFixed(1)} mm effective${coverNote}`
+
+  return { shouldSkip: true, advanceByDays, effectiveMm, reason }
 }


### PR DESCRIPTION
## Summary
- New `computeRainCredit(plant, rainfall)` utility in `watering.js` — computes whether recent + forecast rainfall is sufficient to skip an outdoor watering
- Effective rainfall = `recentMm + forecastMm`, with `0.7×` shelter factor applied for `isUnderCover` plants (patios, porches, greenhouses)
- Skip threshold: 5 mm effective rainfall; advance fraction: 50% of interval by default, 100% for `category=succulent`, overridable via `rainSkipMultiplier`
- `getWateringStatus` now calls `computeRainCredit` for outdoor plants when `weather.precipitation` is present, returning a blue "Skipped by rain" status
- New `isUnderCover` boolean on plants: stored in form state, submitted via existing PUT endpoint
- PlantModal: "Under cover" checkbox shown for outdoor-room plants

## Test plan
- [x] 606 frontend tests pass (9 new `computeRainCredit` unit tests)
- [ ] Outdoor plant with 10mm recent rain → "Skipped by rain" badge in watering status
- [ ] Under-cover plant with 6mm rain → no skip (4.2mm effective < 5mm threshold)
- [ ] Succulent with 10mm rain → full interval advance (e.g. 14d → skip 14d)
- [ ] Indoor plant unaffected by precipitation data

Closes #257

https://claude.ai/code/session_01LJtkErcU1Ga97NMekh2NpY