### PR TITLE
feat(#258): pest & disease outbreak log with floorplan spread visualisation

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1625,6 +1625,295 @@ app.delete('/plants/:id/harvests/:harvestId', requireUser, async (req, res) => {
   }
 });
 
+// ── Incident log (pest, disease, deficiency, environmental) ──────────────────
+
+const INCIDENT_CATEGORIES = new Set(['pest', 'disease', 'deficiency', 'environmental']);
+const OUTBREAK_WINDOW_DAYS = 14;
+
+app.get('/plants/:id/incidents', requireUser, async (req, res) => {
+  try {
+    const doc = await userPlants(req.userId).doc(req.params.id).get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+    const entries = (doc.data().incidents || []).sort((a, b) => new Date(b.firstObservedAt) - new Date(a.firstObservedAt));
+    res.status(200).json(entries);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/plants/:id/incidents', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const { category, specificType, severity, firstObservedAt, notes } = req.body || {};
+    if (!category || !INCIDENT_CATEGORIES.has(category)) {
+      return res.status(400).json({ error: `category must be one of: ${[...INCIDENT_CATEGORIES].join(', ')}` });
+    }
+    if (!specificType || !String(specificType).trim()) {
+      return res.status(400).json({ error: 'specificType is required' });
+    }
+    if (severity != null && (Number(severity) < 1 || Number(severity) > 5)) {
+      return res.status(400).json({ error: 'severity must be between 1 and 5' });
+    }
+
+    const now = new Date().toISOString();
+    const observedAt = firstObservedAt || now;
+    const plantData = doc.data();
+
+    // Auto-group outbreak: scan other plants in same room for same category+specificType within 14 days
+    const windowStart = new Date(observedAt);
+    windowStart.setDate(windowStart.getDate() - OUTBREAK_WINDOW_DAYS);
+    let outbreakId = null;
+
+    if (plantData.room) {
+      const plantsSnap = await userPlants(req.userId).get();
+      for (const plantDoc of plantsSnap.docs) {
+        if (plantDoc.id === req.params.id) continue;
+        const other = plantDoc.data();
+        if (other.room !== plantData.room) continue;
+        const linked = (other.incidents || []).find(i =>
+          !i.resolvedAt &&
+          i.category === category &&
+          i.specificType === specificType &&
+          new Date(i.firstObservedAt) >= windowStart,
+        );
+        if (linked) {
+          outbreakId = outbreakId || linked.outbreakId || crypto.randomUUID();
+          if (!linked.outbreakId) {
+            const updatedIncidents = (other.incidents || []).map(i =>
+              i.id === linked.id ? { ...i, outbreakId } : i,
+            );
+            await userPlants(req.userId).doc(plantDoc.id).set(
+              { incidents: updatedIncidents, updatedAt: now }, { merge: true },
+            );
+          }
+        }
+      }
+    }
+
+    const entry = {
+      id: crypto.randomUUID(),
+      category,
+      specificType: String(specificType).trim(),
+      severity: severity != null ? Number(severity) : null,
+      firstObservedAt: observedAt,
+      resolvedAt: null,
+      treatments: [],
+      notes: notes ? String(notes).trim() : null,
+      outbreakId: outbreakId || null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const incidents = [...(plantData.incidents || []), entry];
+    await ref.set({ incidents, updatedAt: now }, { merge: true });
+    res.status(201).json(entry);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.put('/plants/:id/incidents/:incidentId', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const { category, specificType, severity, notes } = req.body || {};
+    if (category !== undefined && !INCIDENT_CATEGORIES.has(category)) {
+      return res.status(400).json({ error: `category must be one of: ${[...INCIDENT_CATEGORIES].join(', ')}` });
+    }
+    if (severity != null && (Number(severity) < 1 || Number(severity) > 5)) {
+      return res.status(400).json({ error: 'severity must be between 1 and 5' });
+    }
+
+    const now = new Date().toISOString();
+    const existing = doc.data();
+    const incidents = (existing.incidents || []).map(e => {
+      if (e.id !== req.params.incidentId) return e;
+      return {
+        ...e,
+        ...(category !== undefined ? { category } : {}),
+        ...(specificType !== undefined ? { specificType: String(specificType).trim() } : {}),
+        ...(severity !== undefined ? { severity: severity != null ? Number(severity) : null } : {}),
+        ...(notes !== undefined ? { notes: notes ? String(notes).trim() : null } : {}),
+        updatedAt: now,
+      };
+    });
+    await ref.set({ incidents, updatedAt: now }, { merge: true });
+    const updated = incidents.find(e => e.id === req.params.incidentId);
+    if (!updated) return res.status(404).json({ error: 'Incident not found' });
+    res.status(200).json(updated);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/plants/:id/incidents/:incidentId/treatments', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const { treatment, appliedAt, outcome } = req.body || {};
+    if (!treatment || !String(treatment).trim()) {
+      return res.status(400).json({ error: 'treatment is required' });
+    }
+
+    const now = new Date().toISOString();
+    const treatmentEntry = {
+      id: crypto.randomUUID(),
+      treatment: String(treatment).trim(),
+      appliedAt: appliedAt || now,
+      outcome: outcome ? String(outcome).trim() : null,
+      createdAt: now,
+    };
+    const existing = doc.data();
+    let found = false;
+    const incidents = (existing.incidents || []).map(e => {
+      if (e.id !== req.params.incidentId) return e;
+      found = true;
+      return { ...e, treatments: [...(e.treatments || []), treatmentEntry], updatedAt: now };
+    });
+    if (!found) return res.status(404).json({ error: 'Incident not found' });
+    await ref.set({ incidents, updatedAt: now }, { merge: true });
+    res.status(201).json(treatmentEntry);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/plants/:id/incidents/:incidentId/resolve', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const now = new Date().toISOString();
+    const existing = doc.data();
+    let found = false;
+    const incidents = (existing.incidents || []).map(e => {
+      if (e.id !== req.params.incidentId) return e;
+      found = true;
+      return { ...e, resolvedAt: req.body?.resolvedAt || now, updatedAt: now };
+    });
+    if (!found) return res.status(404).json({ error: 'Incident not found' });
+    await ref.set({ incidents, updatedAt: now }, { merge: true });
+    res.status(200).json(incidents.find(e => e.id === req.params.incidentId));
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.delete('/plants/:id/incidents/:incidentId', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+    const existing = doc.data();
+    const incidents = (existing.incidents || []).filter(e => e.id !== req.params.incidentId);
+    await ref.set({ incidents, updatedAt: new Date().toISOString() }, { merge: true });
+    res.status(200).json({ deleted: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/outbreaks', requireUser, async (req, res) => {
+  try {
+    const plantsSnap = await userPlants(req.userId).get();
+    const outbreakMap = {};
+
+    for (const plantDoc of plantsSnap.docs) {
+      const plant = plantDoc.data();
+      for (const incident of (plant.incidents || [])) {
+        if (incident.resolvedAt) continue;
+        if (!incident.outbreakId) continue;
+        if (!outbreakMap[incident.outbreakId]) {
+          outbreakMap[incident.outbreakId] = {
+            outbreakId: incident.outbreakId,
+            category: incident.category,
+            specificType: incident.specificType,
+            plants: [],
+            firstObservedAt: incident.firstObservedAt,
+            maxSeverity: incident.severity || 0,
+          };
+        }
+        const ob = outbreakMap[incident.outbreakId];
+        ob.plants.push({ plantId: plantDoc.id, plantName: plant.name, room: plant.room, incidentId: incident.id, severity: incident.severity });
+        if ((incident.severity || 0) > ob.maxSeverity) ob.maxSeverity = incident.severity || 0;
+        if (new Date(incident.firstObservedAt) < new Date(ob.firstObservedAt)) ob.firstObservedAt = incident.firstObservedAt;
+      }
+    }
+
+    const outbreaks = Object.values(outbreakMap)
+      .filter(ob => ob.plants.length > 0)
+      .sort((a, b) => (b.maxSeverity * b.plants.length) - (a.maxSeverity * a.plants.length));
+
+    res.status(200).json(outbreaks);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/outbreaks/:outbreakId/treat', requireUser, async (req, res) => {
+  try {
+    const { treatment, appliedAt, outcome } = req.body || {};
+    if (!treatment || !String(treatment).trim()) {
+      return res.status(400).json({ error: 'treatment is required' });
+    }
+    const now = new Date().toISOString();
+    const treatmentEntry = {
+      id: crypto.randomUUID(),
+      treatment: String(treatment).trim(),
+      appliedAt: appliedAt || now,
+      outcome: outcome ? String(outcome).trim() : null,
+      createdAt: now,
+    };
+
+    const plantsSnap = await userPlants(req.userId).get();
+    let updatedCount = 0;
+    for (const plantDoc of plantsSnap.docs) {
+      const plant = plantDoc.data();
+      const hasMatch = (plant.incidents || []).some(i => i.outbreakId === req.params.outbreakId && !i.resolvedAt);
+      if (!hasMatch) continue;
+      const incidents = (plant.incidents || []).map(i => {
+        if (i.outbreakId !== req.params.outbreakId || i.resolvedAt) return i;
+        return { ...i, treatments: [...(i.treatments || []), treatmentEntry], updatedAt: now };
+      });
+      await userPlants(req.userId).doc(plantDoc.id).set({ incidents, updatedAt: now }, { merge: true });
+      updatedCount++;
+    }
+    res.status(200).json({ applied: updatedCount, treatment: treatmentEntry });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/outbreaks/:outbreakId/resolve', requireUser, async (req, res) => {
+  try {
+    const now = new Date().toISOString();
+    const resolvedAt = req.body?.resolvedAt || now;
+    const plantsSnap = await userPlants(req.userId).get();
+    let updatedCount = 0;
+    for (const plantDoc of plantsSnap.docs) {
+      const plant = plantDoc.data();
+      const hasMatch = (plant.incidents || []).some(i => i.outbreakId === req.params.outbreakId && !i.resolvedAt);
+      if (!hasMatch) continue;
+      const incidents = (plant.incidents || []).map(i => {
+        if (i.outbreakId !== req.params.outbreakId || i.resolvedAt) return i;
+        return { ...i, resolvedAt, updatedAt: now };
+      });
+      await userPlants(req.userId).doc(plantDoc.id).set({ incidents, updatedAt: now }, { merge: true });
+      updatedCount++;
+    }
+    res.status(200).json({ resolved: updatedCount });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Fertiliser recommendation (Gemini, structured) ───────────────────────────
 
 const FERTILISER_RECOMMEND_SCHEMA = {

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -3275,3 +3275,287 @@ describe('POST /plants — shortCode generation', () => {
     expect(res.body.shortCode).toMatch(/^hp-[a-z0-9]{5}$/);
   });
 });
+
+// ── Incident log ──────────────────────────────────────────────────────────────
+
+describe('GET /plants/:id/incidents', () => {
+  beforeEach(clearStore);
+
+  it('returns empty array when no incidents', async () => {
+    store[plantPath('p1')] = { species: 'Basil' };
+    const res = await request(app).get('/plants/p1/incidents').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('returns incidents sorted newest first', async () => {
+    const incidents = [
+      { id: 'i1', category: 'pest', specificType: 'Aphids', firstObservedAt: '2026-01-01T00:00:00.000Z', resolvedAt: null, treatments: [], createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'i2', category: 'disease', specificType: 'Powdery mildew', firstObservedAt: '2026-02-01T00:00:00.000Z', resolvedAt: null, treatments: [], createdAt: '2026-02-01T00:00:00.000Z', updatedAt: '2026-02-01T00:00:00.000Z' },
+    ];
+    store[plantPath('p1')] = { species: 'Basil', incidents };
+    const res = await request(app).get('/plants/p1/incidents').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body[0].id).toBe('i2');
+    expect(res.body[1].id).toBe('i1');
+  });
+
+  it('returns 404 for unknown plant', async () => {
+    const res = await request(app).get('/plants/nope/incidents').set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /plants/:id/incidents', () => {
+  beforeEach(clearStore);
+
+  it('creates an incident with valid fields', async () => {
+    store[plantPath('p1')] = { species: 'Tomato', room: 'Greenhouse' };
+    const res = await request(app).post('/plants/p1/incidents')
+      .send({ category: 'pest', specificType: 'Spider mites', severity: 3, firstObservedAt: '2026-04-01T00:00:00.000Z' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBeTruthy();
+    expect(res.body.category).toBe('pest');
+    expect(res.body.specificType).toBe('Spider mites');
+    expect(res.body.severity).toBe(3);
+    expect(res.body.outbreakId).toBeNull();
+    expect(store[plantPath('p1')].incidents).toHaveLength(1);
+  });
+
+  it('rejects invalid category', async () => {
+    store[plantPath('p1')] = { species: 'Tomato' };
+    const res = await request(app).post('/plants/p1/incidents')
+      .send({ category: 'alien', specificType: 'Something' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects missing specificType', async () => {
+    store[plantPath('p1')] = { species: 'Tomato' };
+    const res = await request(app).post('/plants/p1/incidents')
+      .send({ category: 'pest' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects out-of-range severity', async () => {
+    store[plantPath('p1')] = { species: 'Tomato' };
+    const res = await request(app).post('/plants/p1/incidents')
+      .send({ category: 'pest', specificType: 'Aphids', severity: 6 })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+  });
+
+  it('auto-groups outbreak when same room / same type within 14 days', async () => {
+    const existingIncident = {
+      id: 'i-existing', category: 'pest', specificType: 'Spider mites',
+      firstObservedAt: new Date(Date.now() - 5 * 86400000).toISOString(),
+      resolvedAt: null, treatments: [], outbreakId: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+    };
+    store[plantPath('p1')] = { species: 'Tomato', room: 'Greenhouse', incidents: [existingIncident] };
+    store[plantPath('p2')] = { species: 'Basil', room: 'Greenhouse' };
+
+    const res = await request(app).post('/plants/p2/incidents')
+      .send({ category: 'pest', specificType: 'Spider mites', severity: 2 })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(201);
+    expect(res.body.outbreakId).toBeTruthy();
+    // The existing incident on p1 should also have been updated with the outbreakId
+    const p1Incidents = store[plantPath('p1')].incidents;
+    expect(p1Incidents[0].outbreakId).toBe(res.body.outbreakId);
+  });
+
+  it('does not group outbreak across different rooms', async () => {
+    const existingIncident = {
+      id: 'i-existing', category: 'pest', specificType: 'Aphids',
+      firstObservedAt: new Date(Date.now() - 3 * 86400000).toISOString(),
+      resolvedAt: null, treatments: [], outbreakId: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+    };
+    store[plantPath('p1')] = { species: 'Rose', room: 'Garden', incidents: [existingIncident] };
+    store[plantPath('p2')] = { species: 'Fern', room: 'Kitchen' };
+
+    const res = await request(app).post('/plants/p2/incidents')
+      .send({ category: 'pest', specificType: 'Aphids', severity: 1 })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(201);
+    expect(res.body.outbreakId).toBeNull();
+  });
+
+  it('does not group outbreak if existing incident is outside 14-day window', async () => {
+    const existingIncident = {
+      id: 'i-old', category: 'pest', specificType: 'Fungus gnats',
+      firstObservedAt: new Date(Date.now() - 20 * 86400000).toISOString(),
+      resolvedAt: null, treatments: [], outbreakId: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+    };
+    store[plantPath('p1')] = { species: 'Orchid', room: 'Bathroom', incidents: [existingIncident] };
+    store[plantPath('p2')] = { species: 'Fern', room: 'Bathroom' };
+
+    const res = await request(app).post('/plants/p2/incidents')
+      .send({ category: 'pest', specificType: 'Fungus gnats' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(201);
+    expect(res.body.outbreakId).toBeNull();
+  });
+});
+
+describe('PUT /plants/:id/incidents/:incidentId', () => {
+  beforeEach(clearStore);
+
+  it('updates severity and notes on an incident', async () => {
+    const inc = { id: 'i1', category: 'pest', specificType: 'Aphids', severity: 2, resolvedAt: null, treatments: [], firstObservedAt: '2026-04-01T00:00:00.000Z', createdAt: '2026-04-01T00:00:00.000Z', updatedAt: '2026-04-01T00:00:00.000Z' };
+    store[plantPath('p1')] = { species: 'Rosemary', incidents: [inc] };
+    const res = await request(app).put('/plants/p1/incidents/i1')
+      .send({ severity: 4, notes: 'Getting worse' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.severity).toBe(4);
+    expect(res.body.notes).toBe('Getting worse');
+  });
+
+  it('returns 404 for unknown incident', async () => {
+    store[plantPath('p1')] = { species: 'Basil', incidents: [] };
+    const res = await request(app).put('/plants/p1/incidents/nope')
+      .send({ severity: 3 })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /plants/:id/incidents/:incidentId/treatments', () => {
+  beforeEach(clearStore);
+
+  it('adds a treatment to an incident', async () => {
+    const inc = { id: 'i1', category: 'disease', specificType: 'Powdery mildew', severity: 3, resolvedAt: null, treatments: [], firstObservedAt: '2026-04-01T00:00:00.000Z', createdAt: '2026-04-01T00:00:00.000Z', updatedAt: '2026-04-01T00:00:00.000Z' };
+    store[plantPath('p1')] = { species: 'Squash', incidents: [inc] };
+    const res = await request(app).post('/plants/p1/incidents/i1/treatments')
+      .send({ treatment: 'Neem oil spray', outcome: 'Reduced spread' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(201);
+    expect(res.body.treatment).toBe('Neem oil spray');
+    expect(res.body.outcome).toBe('Reduced spread');
+    expect(store[plantPath('p1')].incidents[0].treatments).toHaveLength(1);
+  });
+
+  it('rejects missing treatment text', async () => {
+    store[plantPath('p1')] = { species: 'Squash', incidents: [{ id: 'i1', category: 'pest', specificType: 'Aphids', treatments: [], resolvedAt: null }] };
+    const res = await request(app).post('/plants/p1/incidents/i1/treatments')
+      .send({})
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /plants/:id/incidents/:incidentId/resolve', () => {
+  beforeEach(clearStore);
+
+  it('sets resolvedAt on the incident', async () => {
+    const inc = { id: 'i1', category: 'pest', specificType: 'Aphids', resolvedAt: null, treatments: [], firstObservedAt: '2026-04-01T00:00:00.000Z', createdAt: '2026-04-01T00:00:00.000Z', updatedAt: '2026-04-01T00:00:00.000Z' };
+    store[plantPath('p1')] = { species: 'Basil', incidents: [inc] };
+    const res = await request(app).post('/plants/p1/incidents/i1/resolve')
+      .send({})
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.resolvedAt).toBeTruthy();
+    expect(store[plantPath('p1')].incidents[0].resolvedAt).toBeTruthy();
+  });
+});
+
+describe('DELETE /plants/:id/incidents/:incidentId', () => {
+  beforeEach(clearStore);
+
+  it('removes incident from the array', async () => {
+    const inc = { id: 'i1', category: 'pest', specificType: 'Mealybugs', resolvedAt: null, treatments: [], firstObservedAt: '2026-04-01T00:00:00.000Z', createdAt: '2026-04-01T00:00:00.000Z', updatedAt: '2026-04-01T00:00:00.000Z' };
+    store[plantPath('p1')] = { species: 'Cactus', incidents: [inc] };
+    const res = await request(app).delete('/plants/p1/incidents/i1').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(store[plantPath('p1')].incidents).toHaveLength(0);
+  });
+});
+
+describe('GET /outbreaks', () => {
+  beforeEach(clearStore);
+
+  it('returns empty array when no outbreaks', async () => {
+    store[plantPath('p1')] = { species: 'Basil', incidents: [] };
+    const res = await request(app).get('/outbreaks').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('groups linked incidents by outbreakId', async () => {
+    const obId = 'ob-test-123';
+    store[plantPath('p1')] = { name: 'Tomato', species: 'Tomato', room: 'Greenhouse', incidents: [
+      { id: 'i1', category: 'pest', specificType: 'Spider mites', severity: 3, outbreakId: obId, resolvedAt: null, treatments: [], firstObservedAt: '2026-04-10T00:00:00.000Z', createdAt: '2026-04-10T00:00:00.000Z', updatedAt: '2026-04-10T00:00:00.000Z' },
+    ]};
+    store[plantPath('p2')] = { name: 'Basil', species: 'Basil', room: 'Greenhouse', incidents: [
+      { id: 'i2', category: 'pest', specificType: 'Spider mites', severity: 4, outbreakId: obId, resolvedAt: null, treatments: [], firstObservedAt: '2026-04-12T00:00:00.000Z', createdAt: '2026-04-12T00:00:00.000Z', updatedAt: '2026-04-12T00:00:00.000Z' },
+    ]};
+    const res = await request(app).get('/outbreaks').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].outbreakId).toBe(obId);
+    expect(res.body[0].plants).toHaveLength(2);
+    expect(res.body[0].maxSeverity).toBe(4);
+  });
+
+  it('excludes resolved incidents from outbreaks', async () => {
+    const obId = 'ob-resolved';
+    store[plantPath('p1')] = { name: 'Fern', species: 'Fern', room: 'Hall', incidents: [
+      { id: 'i1', category: 'disease', specificType: 'Root rot', outbreakId: obId, resolvedAt: '2026-04-15T00:00:00.000Z', treatments: [], firstObservedAt: '2026-04-01T00:00:00.000Z', createdAt: '2026-04-01T00:00:00.000Z', updatedAt: '2026-04-15T00:00:00.000Z' },
+    ]};
+    const res = await request(app).get('/outbreaks').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+});
+
+describe('POST /outbreaks/:outbreakId/resolve', () => {
+  beforeEach(clearStore);
+
+  it('resolves all open incidents in the outbreak across plants', async () => {
+    const obId = 'ob-multi';
+    store[plantPath('p1')] = { species: 'Mint', room: 'Kitchen', incidents: [
+      { id: 'i1', category: 'pest', specificType: 'Whitefly', outbreakId: obId, resolvedAt: null, treatments: [], firstObservedAt: '2026-04-10T00:00:00.000Z', createdAt: '2026-04-10T00:00:00.000Z', updatedAt: '2026-04-10T00:00:00.000Z' },
+    ]};
+    store[plantPath('p2')] = { species: 'Chives', room: 'Kitchen', incidents: [
+      { id: 'i2', category: 'pest', specificType: 'Whitefly', outbreakId: obId, resolvedAt: null, treatments: [], firstObservedAt: '2026-04-11T00:00:00.000Z', createdAt: '2026-04-11T00:00:00.000Z', updatedAt: '2026-04-11T00:00:00.000Z' },
+    ]};
+    const res = await request(app).post(`/outbreaks/${obId}/resolve`)
+      .send({})
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.resolved).toBe(2);
+    expect(store[plantPath('p1')].incidents[0].resolvedAt).toBeTruthy();
+    expect(store[plantPath('p2')].incidents[0].resolvedAt).toBeTruthy();
+  });
+});
+
+describe('POST /outbreaks/:outbreakId/treat', () => {
+  beforeEach(clearStore);
+
+  it('adds treatment to all open incidents in the outbreak', async () => {
+    const obId = 'ob-treat';
+    store[plantPath('p1')] = { species: 'Pepper', room: 'Garden', incidents: [
+      { id: 'i1', category: 'pest', specificType: 'Aphids', outbreakId: obId, resolvedAt: null, treatments: [], firstObservedAt: '2026-04-10T00:00:00.000Z', createdAt: '2026-04-10T00:00:00.000Z', updatedAt: '2026-04-10T00:00:00.000Z' },
+    ]};
+    store[plantPath('p2')] = { species: 'Cucumber', room: 'Garden', incidents: [
+      { id: 'i2', category: 'pest', specificType: 'Aphids', outbreakId: obId, resolvedAt: null, treatments: [], firstObservedAt: '2026-04-11T00:00:00.000Z', createdAt: '2026-04-11T00:00:00.000Z', updatedAt: '2026-04-11T00:00:00.000Z' },
+    ]};
+    const res = await request(app).post(`/outbreaks/${obId}/treat`)
+      .send({ treatment: 'Insecticidal soap' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.applied).toBe(2);
+    expect(res.body.treatment.treatment).toBe('Insecticidal soap');
+    expect(store[plantPath('p1')].incidents[0].treatments).toHaveLength(1);
+    expect(store[plantPath('p2')].incidents[0].treatments).toHaveLength(1);
+  });
+
+  it('rejects missing treatment text', async () => {
+    const res = await request(app).post('/outbreaks/ob-x/treat')
+      .send({})
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -32,6 +32,7 @@ vi.mock('../api/plants.js', () => ({
     createCheckoutSession: vi.fn(),
     createPortalSession:   vi.fn(),
   },
+  outbreakApi: { list: vi.fn().mockResolvedValue([]) },
 }))
 
 vi.mock('../contexts/AuthContext.jsx', async (importOriginal) => {

--- a/src/__tests__/PlantModal.test.jsx
+++ b/src/__tests__/PlantModal.test.jsx
@@ -92,6 +92,14 @@ vi.mock('../api/plants.js', () => ({
     getShortCode: vi.fn().mockResolvedValue({ shortCode: 'hp-test1', plantId: 'plant-1' }),
     scan: vi.fn().mockResolvedValue({ plantId: 'plant-1' }),
   },
+  incidentApi: {
+    list: vi.fn().mockResolvedValue([]),
+    add: vi.fn().mockResolvedValue({ id: 'inc1', category: 'pest', specificType: 'Aphids', severity: 2, firstObservedAt: '2026-04-21T00:00:00.000Z', resolvedAt: null, treatments: [] }),
+    update: vi.fn().mockResolvedValue({}),
+    addTreatment: vi.fn().mockResolvedValue({ id: 't1', treatment: 'Neem oil', appliedAt: '2026-04-21T00:00:00.000Z' }),
+    resolve: vi.fn().mockResolvedValue({ id: 'inc1', resolvedAt: '2026-04-21T00:00:00.000Z' }),
+    delete: vi.fn().mockResolvedValue({ deleted: true }),
+  },
 }))
 
 const floors = [
@@ -839,7 +847,7 @@ describe('PlantModal', () => {
     renderModal({ plant: existingPlant })
     expect(screen.getByRole('tablist', { name: /plant sections/i })).toBeInTheDocument()
     const tabs = screen.getAllByRole('tab')
-    expect(tabs.map((t) => t.textContent)).toEqual(['Plant', 'Watering', 'Care', 'Growth', 'Journal'])
+    expect(tabs.map((t) => t.textContent)).toEqual(['Plant', 'Watering', 'Care', 'Growth', 'Journal', 'Health'])
   })
 
   it('marks the active tab with aria-selected="true"', () => {
@@ -870,9 +878,9 @@ describe('PlantModal', () => {
 
   it('wraps to the first tab when ArrowRight is pressed on the last tab', () => {
     renderModal({ plant: existingPlant })
-    fireEvent.click(screen.getByText('Journal'))
-    const journalTab = screen.getAllByRole('tab')[4]
-    fireEvent.keyDown(journalTab, { key: 'ArrowRight' })
+    fireEvent.click(screen.getByText('Health'))
+    const healthTab = screen.getAllByRole('tab')[5]
+    fireEvent.keyDown(healthTab, { key: 'ArrowRight' })
     expect(screen.getAllByRole('tab')[0]).toHaveAttribute('aria-selected', 'true')
   })
 
@@ -889,8 +897,8 @@ describe('PlantModal', () => {
     fireEvent.click(screen.getByText('Watering'))
     const wateringTab = screen.getAllByRole('tab')[1]
     fireEvent.keyDown(wateringTab, { key: 'End' })
-    expect(screen.getAllByRole('tab')[4]).toHaveAttribute('aria-selected', 'true')
-    fireEvent.keyDown(screen.getAllByRole('tab')[4], { key: 'Home' })
+    expect(screen.getAllByRole('tab')[5]).toHaveAttribute('aria-selected', 'true')
+    fireEvent.keyDown(screen.getAllByRole('tab')[5], { key: 'Home' })
     expect(screen.getAllByRole('tab')[0]).toHaveAttribute('aria-selected', 'true')
   })
 })

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -209,6 +209,21 @@ export const qrApi = {
   scan: (shortCode) => request(`/scan/${encodeURIComponent(shortCode)}`),
 }
 
+export const incidentApi = {
+  list: (id) => request(`/plants/${id}/incidents`),
+  add: (id, data) => request(`/plants/${id}/incidents`, { method: 'POST', body: JSON.stringify(data) }),
+  update: (id, incidentId, data) => request(`/plants/${id}/incidents/${incidentId}`, { method: 'PUT', body: JSON.stringify(data) }),
+  addTreatment: (id, incidentId, data) => request(`/plants/${id}/incidents/${incidentId}/treatments`, { method: 'POST', body: JSON.stringify(data) }),
+  resolve: (id, incidentId, data) => request(`/plants/${id}/incidents/${incidentId}/resolve`, { method: 'POST', body: JSON.stringify(data || {}) }),
+  delete: (id, incidentId) => request(`/plants/${id}/incidents/${incidentId}`, { method: 'DELETE' }),
+}
+
+export const outbreakApi = {
+  list: () => request('/outbreaks'),
+  bulkTreat: (outbreakId, data) => request(`/outbreaks/${outbreakId}/treat`, { method: 'POST', body: JSON.stringify(data) }),
+  bulkResolve: (outbreakId, data) => request(`/outbreaks/${outbreakId}/resolve`, { method: 'POST', body: JSON.stringify(data || {}) }),
+}
+
 export const accountApi = {
   deleteAccount: () => request('/account', { method: 'DELETE' }),
   exportData: () => request('/account/export'),

--- a/src/assets/sass/app/_leaflet-overrides.scss
+++ b/src/assets/sass/app/_leaflet-overrides.scss
@@ -89,6 +89,18 @@
   animation: plant-bounce 1.8s ease-in-out infinite;
 }
 
+.plant-lf-incident {
+  animation: incident-pulse 1.4s ease-in-out infinite;
+  outline: 2px solid #dc3545;
+  outline-offset: 2px;
+  border-radius: 50%;
+}
+
+@keyframes incident-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(220, 53, 69, 0.6); }
+  50% { box-shadow: 0 0 0 6px rgba(220, 53, 69, 0); }
+}
+
 /* Gnome watering animation */
 @keyframes gnome-walk {
   0%, 100% { transform: translateY(0) scaleX(var(--gnome-dir, 1)); }

--- a/src/components/LeafletFloorplan.jsx
+++ b/src/components/LeafletFloorplan.jsx
@@ -20,10 +20,12 @@ function makePlantIcon(plant, weather, floors) {
   const attention = daysUntil >= 0 && daysUntil <= 2
   const emoji = getPlantEmoji(plant)
   const cls = overdue ? ' plant-lf-overdue' : attention ? ' plant-lf-attention' : ''
+  const hasActiveIncident = (plant.incidents || []).some(i => !i.resolvedAt)
+  const incidentPulse = hasActiveIncident ? ' plant-lf-incident' : ''
 
   return L.divIcon({
     className: 'plant-lf-icon',
-    html: `<div class="plant-lf-inner${cls}"
+    html: `<div class="plant-lf-inner${cls}${incidentPulse}"
                 style="width:32px;height:32px;border-radius:50%;
                        border:2px solid ${color};
                        background:#fff;

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useRef, useMemo, useContext } 
 import { Modal, Button, Form, Badge, Spinner, Row, Col, Pagination, Accordion } from 'react-bootstrap'
 import ImageAnalyser from './ImageAnalyser.jsx'
 import PlantQRTag from './PlantQRTag.jsx'
-import { imagesApi, recommendApi, plantsApi, analyseApi, measurementsApi, phenologyApi, journalApi, harvestApi } from '../api/plants.js'
+import { imagesApi, recommendApi, plantsApi, analyseApi, measurementsApi, phenologyApi, journalApi, harvestApi, incidentApi } from '../api/plants.js'
 import Chart from 'react-apexcharts'
 import { getWateringStatus, getAdjustedWaterAmount, isOutdoor, getMoistureDisplay } from '../utils/watering.js'
 import { analyseWateringPattern, getPatternMeta } from '../utils/wateringPattern.js'
@@ -284,6 +284,16 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   const [harvestSaving, setHarvestSaving] = useState(false)
   const [harvestError, setHarvestError] = useState(null)
 
+  // Health tab state (incidents)
+  const [incidents, setIncidents] = useState(
+    () => [...(plant?.incidents || [])].sort((a, b) => new Date(b.firstObservedAt) - new Date(a.firstObservedAt))
+  )
+  const [newIncident, setNewIncident] = useState({ category: 'pest', specificType: '', severity: '', firstObservedAt: new Date().toISOString().slice(0, 10), notes: '' })
+  const [incidentSaving, setIncidentSaving] = useState(false)
+  const [incidentError, setIncidentError] = useState(null)
+  const [treatmentInput, setTreatmentInput] = useState({})
+  const [treatmentSaving, setTreatmentSaving] = useState({})
+
   // Validation + unsaved-change guard state. `isDirty` is set by user-initiated
   // edits only (not programmatic resyncs like the wateringRec effect).
   const [isDirty, setIsDirty] = useState(false)
@@ -467,8 +477,9 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       { id: 'growth', label: 'Growth' },
       { id: 'journal', label: 'Journal' },
       ...(isEdiblePlant ? [{ id: 'harvest', label: 'Harvest' }] : []),
+      ...(isEditing ? [{ id: 'health', label: 'Health' }] : []),
     ],
-    [isEdiblePlant],
+    [isEdiblePlant, isEditing],
   )
 
   const handleTabKeyDown = useCallback((e, index) => {
@@ -619,6 +630,58 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       await harvestApi.delete(plant.id, harvestId)
       setHarvestEntries(prev => prev.filter(e => e.id !== harvestId))
     } catch (err) { console.error('Delete harvest entry failed:', err) }
+  }, [plant])
+
+  const handleAddIncident = useCallback(async () => {
+    const { category, specificType, severity, firstObservedAt, notes } = newIncident
+    if (!specificType.trim()) {
+      setIncidentError('Specify the pest or disease type.')
+      return
+    }
+    setIncidentSaving(true)
+    setIncidentError(null)
+    try {
+      const entry = await incidentApi.add(plant.id, {
+        category, specificType: specificType.trim(),
+        severity: severity ? Number(severity) : null,
+        firstObservedAt, notes: notes.trim() || null,
+      })
+      setIncidents(prev => [entry, ...prev])
+      setNewIncident({ category: 'pest', specificType: '', severity: '', firstObservedAt: new Date().toISOString().slice(0, 10), notes: '' })
+    } catch (err) {
+      setIncidentError(friendlyErrorMessage(err))
+    } finally {
+      setIncidentSaving(false)
+    }
+  }, [newIncident, plant])
+
+  const handleResolveIncident = useCallback(async (incidentId) => {
+    try {
+      const updated = await incidentApi.resolve(plant.id, incidentId)
+      setIncidents(prev => prev.map(e => e.id === incidentId ? updated : e))
+    } catch (err) { console.error('Resolve incident failed:', err) }
+  }, [plant])
+
+  const handleAddTreatment = useCallback(async (incidentId) => {
+    const treatment = treatmentInput[incidentId] || ''
+    if (!treatment.trim()) return
+    setTreatmentSaving(prev => ({ ...prev, [incidentId]: true }))
+    try {
+      const entry = await incidentApi.addTreatment(plant.id, incidentId, { treatment: treatment.trim() })
+      setIncidents(prev => prev.map(e => e.id === incidentId
+        ? { ...e, treatments: [...(e.treatments || []), entry] }
+        : e,
+      ))
+      setTreatmentInput(prev => ({ ...prev, [incidentId]: '' }))
+    } catch (err) { console.error('Add treatment failed:', err) }
+    finally { setTreatmentSaving(prev => ({ ...prev, [incidentId]: false })) }
+  }, [plant, treatmentInput])
+
+  const handleDeleteIncident = useCallback(async (incidentId) => {
+    try {
+      await incidentApi.delete(plant.id, incidentId)
+      setIncidents(prev => prev.filter(e => e.id !== incidentId))
+    } catch (err) { console.error('Delete incident failed:', err) }
   }, [plant])
 
   const wateringStatus = useMemo(() => plant ? getWateringStatus(plant, weather, floors) : null, [plant, weather, floors])
@@ -1840,6 +1903,107 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
               No harvests logged yet. Log your first harvest to start tracking yield over time.
             </p>
           )}
+        </Modal.Body>
+      )}
+
+      {/* Health tab — incident log */}
+      {isEditing && activeTab === 'health' && (
+        <Modal.Body className="pt-3 pb-4">
+          <h6 className="fw-600 mb-3">Log Pest / Disease Incident</h6>
+          {incidentError && <div className="alert alert-danger py-2 fs-sm mb-3">{incidentError}</div>}
+          <Row className="g-2 mb-2">
+            <Col xs={6}>
+              <Form.Select size="sm" value={newIncident.category}
+                onChange={e => setNewIncident(p => ({ ...p, category: e.target.value }))}>
+                <option value="pest">Pest</option>
+                <option value="disease">Disease</option>
+                <option value="deficiency">Deficiency</option>
+                <option value="environmental">Environmental</option>
+              </Form.Select>
+            </Col>
+            <Col xs={6}>
+              <Form.Control size="sm" placeholder="Type (e.g. Spider mites)" value={newIncident.specificType}
+                onChange={e => setNewIncident(p => ({ ...p, specificType: e.target.value }))} />
+            </Col>
+            <Col xs={4}>
+              <Form.Control size="sm" type="date" value={newIncident.firstObservedAt}
+                onChange={e => setNewIncident(p => ({ ...p, firstObservedAt: e.target.value }))} />
+            </Col>
+            <Col xs={4}>
+              <Form.Select size="sm" value={newIncident.severity}
+                onChange={e => setNewIncident(p => ({ ...p, severity: e.target.value }))}>
+                <option value="">Severity</option>
+                {[1,2,3,4,5].map(n => <option key={n} value={n}>{n} — {['Minimal','Moderate','Significant','Severe','Critical'][n-1]}</option>)}
+              </Form.Select>
+            </Col>
+            <Col xs={4}>
+              <Button size="sm" variant="primary" className="w-100" onClick={handleAddIncident} disabled={incidentSaving || !newIncident.specificType.trim()}>
+                {incidentSaving ? <Spinner size="sm" /> : 'Log Incident'}
+              </Button>
+            </Col>
+            <Col xs={12}>
+              <Form.Control size="sm" as="textarea" rows={2} placeholder="Notes (optional)" value={newIncident.notes}
+                onChange={e => setNewIncident(p => ({ ...p, notes: e.target.value }))} />
+            </Col>
+          </Row>
+
+          <hr className="my-3" />
+          <h6 className="fw-600 mb-2">Incident History</h6>
+          {incidents.length === 0 ? (
+            <p className="text-muted text-center py-3 mb-0 fs-sm">No incidents logged yet.</p>
+          ) : incidents.map(incident => (
+            <div key={incident.id} className="border rounded p-3 mb-3">
+              <div className="d-flex align-items-start gap-2 mb-1">
+                <Badge bg={incident.category === 'pest' ? 'danger' : incident.category === 'disease' ? 'warning' : 'secondary'}
+                  text={incident.category === 'disease' ? 'dark' : undefined} className="fs-xs text-capitalize">
+                  {incident.category}
+                </Badge>
+                <span className="fw-500 fs-sm">{incident.specificType}</span>
+                {incident.severity && (
+                  <Badge bg="light" text="dark" className="fs-xs ms-1">Severity {incident.severity}/5</Badge>
+                )}
+                {incident.outbreakId && (
+                  <Badge bg="danger" className="fs-xs ms-1">Outbreak</Badge>
+                )}
+                <span className="ms-auto fs-xs text-muted">{incident.firstObservedAt?.slice(0,10)}</span>
+              </div>
+              {incident.notes && <p className="fs-xs text-muted mb-2">{incident.notes}</p>}
+
+              {/* Treatments */}
+              {(incident.treatments || []).length > 0 && (
+                <div className="mb-2">
+                  <span className="fs-xs fw-600 text-muted d-block mb-1">Treatments applied:</span>
+                  {incident.treatments.map(t => (
+                    <div key={t.id} className="fs-xs text-muted ps-2 border-start border-2">
+                      {t.appliedAt?.slice(0,10)} — {t.treatment}{t.outcome ? ` → ${t.outcome}` : ''}
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {!incident.resolvedAt && (
+                <div className="d-flex gap-2 mt-2">
+                  <Form.Control size="sm" placeholder="Add treatment…" value={treatmentInput[incident.id] || ''}
+                    onChange={e => setTreatmentInput(p => ({ ...p, [incident.id]: e.target.value }))} />
+                  <Button size="sm" variant="outline-secondary" disabled={treatmentSaving[incident.id] || !treatmentInput[incident.id]?.trim()}
+                    onClick={() => handleAddTreatment(incident.id)}>
+                    {treatmentSaving[incident.id] ? <Spinner size="sm" /> : 'Add'}
+                  </Button>
+                  <Button size="sm" variant="outline-success" onClick={() => handleResolveIncident(incident.id)}>
+                    Resolve
+                  </Button>
+                </div>
+              )}
+              {incident.resolvedAt && (
+                <div className="mt-1">
+                  <Badge bg="success" className="fs-xs">Resolved {incident.resolvedAt.slice(0,10)}</Badge>
+                </div>
+              )}
+              <Button variant="link" size="sm" className="text-danger p-0 fs-xs d-block mt-2" onClick={() => handleDeleteIncident(incident.id)}>
+                Delete
+              </Button>
+            </div>
+          ))}
         </Modal.Body>
       )}
 

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { Row, Col, Card, Nav, Form, Badge } from 'react-bootstrap'
+import { Row, Col, Nav, Form, Badge } from 'react-bootstrap'
 import Chart from 'react-apexcharts'
 import { usePlantContext } from '../context/PlantContext.jsx'
 import { useLayoutContext } from '../context/LayoutContext.jsx'
@@ -50,12 +50,35 @@ function heatColor(count) {
   return '#047857'
 }
 
+function incidentStats(plants) {
+  const typeCounts = {}
+  let totalResolved = 0
+  let totalResolutionDays = 0
+  for (const p of plants) {
+    for (const inc of (p.incidents || [])) {
+      const key = `${inc.category}:${inc.specificType}`
+      typeCounts[key] = (typeCounts[key] || { category: inc.category, type: inc.specificType, count: 0 })
+      typeCounts[key].count++
+      if (inc.resolvedAt && inc.firstObservedAt) {
+        const days = Math.round((new Date(inc.resolvedAt) - new Date(inc.firstObservedAt)) / 86400000)
+        if (days >= 0) { totalResolved++; totalResolutionDays += days }
+      }
+    }
+  }
+  const topTypes = Object.values(typeCounts).sort((a, b) => b.count - a.count).slice(0, 5)
+  const avgResolutionDays = totalResolved > 0 ? Math.round(totalResolutionDays / totalResolved) : null
+  const activeIncidents = plants.flatMap(p => (p.incidents || []).filter(i => !i.resolvedAt))
+  return { topTypes, avgResolutionDays, activeCount: activeIncidents.length }
+}
+
 function OverviewTab({ plants, theme }) {
   const healthData = useMemo(() => {
     const counts = {}
     for (const p of plants) { counts[p.health || 'Unknown'] = (counts[p.health || 'Unknown'] || 0) + 1 }
     return HEALTH_ORDER.filter((h) => counts[h]).map((h) => ({ name: h, value: counts[h], color: HEALTH_COLORS[h] }))
   }, [plants])
+
+  const pestStats = useMemo(() => incidentStats(plants), [plants])
 
   const atRisk = useMemo(() => {
     const now = Date.now()
@@ -180,6 +203,39 @@ function OverviewTab({ plants, theme }) {
               ))}
             </tbody>
           </table>
+        </div></div>
+      </div>
+
+      {/* Pest & Disease */}
+      <div className="panel panel-icon">
+        <div className="panel-hdr"><span>Pest &amp; Disease</span></div>
+        <div className="panel-container"><div className="panel-content">
+          <Row>
+            <Col xs={6} md={3} className="mb-3 text-center">
+              <div className="fs-3 fw-700 text-danger">{pestStats.activeCount}</div>
+              <div className="fs-xs text-muted">Active incidents</div>
+            </Col>
+            <Col xs={6} md={3} className="mb-3 text-center">
+              <div className="fs-3 fw-700">{pestStats.avgResolutionDays !== null ? `${pestStats.avgResolutionDays}d` : '—'}</div>
+              <div className="fs-xs text-muted">Avg. resolution time</div>
+            </Col>
+            <Col md={6} className="mb-3">
+              <div className="fs-xs fw-600 text-muted mb-2">Most common issues</div>
+              {pestStats.topTypes.length === 0
+                ? <p className="text-muted fs-sm mb-0">No incidents logged yet.</p>
+                : pestStats.topTypes.map(t => (
+                  <div key={`${t.category}:${t.type}`} className="d-flex align-items-center gap-2 mb-1">
+                    <Badge bg={t.category === 'pest' ? 'danger' : t.category === 'disease' ? 'warning' : 'secondary'}
+                      text={t.category === 'disease' ? 'dark' : undefined} className="fs-xs text-capitalize">
+                      {t.category}
+                    </Badge>
+                    <span className="fs-sm">{t.type}</span>
+                    <span className="ms-auto fs-xs text-muted">{t.count}×</span>
+                  </div>
+                ))
+              }
+            </Col>
+          </Row>
         </div></div>
       </div>
     </div>

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,4 +1,5 @@
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { Badge, Button } from 'react-bootstrap'
 import { usePlantContext } from '../context/PlantContext.jsx'
 import FloorplanPanel from '../components/FloorplanPanel.jsx'
 import PlantModal from '../components/PlantModal.jsx'
@@ -6,10 +7,35 @@ import UpgradePrompt from '../components/UpgradePrompt.jsx'
 import ErrorAlert from '../components/ErrorAlert.jsx'
 import EmptyState from '../components/EmptyState.jsx'
 import { SkeletonRect, SkeletonPlantCard } from '../components/Skeleton.jsx'
+import { outbreakApi } from '../api/plants.js'
 
 export default function DashboardPage() {
   const { floors, activeFloorId, weather, handleSavePlant, handleDeletePlant, handleWaterPlant, handleMoisturePlant, plantsError, plants, plantsLoading, reloadPlants, isGuest } = usePlantContext()
   const gnomeWaterRef = useRef(null)
+  const [outbreaks, setOutbreaks] = useState([])
+  const [bulkTreating, setBulkTreating] = useState(null)
+  const [bulkTreatInput, setBulkTreatInput] = useState('')
+
+  useEffect(() => {
+    if (isGuest) return
+    outbreakApi.list().then(setOutbreaks).catch(() => {})
+  }, [isGuest, plants])
+
+  const handleBulkResolve = useCallback(async (outbreakId) => {
+    try {
+      await outbreakApi.bulkResolve(outbreakId)
+      setOutbreaks(prev => prev.filter(o => o.outbreakId !== outbreakId))
+    } catch (err) { console.error('Bulk resolve failed:', err) }
+  }, [])
+
+  const handleBulkTreat = useCallback(async (outbreakId) => {
+    if (!bulkTreatInput.trim()) return
+    try {
+      await outbreakApi.bulkTreat(outbreakId, { treatment: bulkTreatInput.trim() })
+      setBulkTreating(null)
+      setBulkTreatInput('')
+    } catch (err) { console.error('Bulk treat failed:', err) }
+  }, [bulkTreatInput])
 
   const hasFloors = floors.length > 0
 
@@ -74,6 +100,51 @@ export default function DashboardPage() {
             You've reached your Free-tier plant limit. Unlock unlimited plants with Home Pro.
           </UpgradePrompt>
         </div>
+        {outbreaks.length > 0 && (
+          <div className="mx-3 mt-3">
+            {outbreaks.map(ob => (
+              <div key={ob.outbreakId} className="alert alert-danger d-flex flex-wrap align-items-start gap-2 py-2 mb-2" role="alert">
+                <svg className="sa-icon sa-icon-lg text-danger mt-1 flex-shrink-0"><use href="/icons/sprite.svg#alert-triangle" /></svg>
+                <div className="flex-grow-1">
+                  <strong className="text-capitalize">{ob.category} Outbreak — {ob.specificType}</strong>
+                  <span className="ms-2 text-muted fs-xs">
+                    {ob.plants.length} plant{ob.plants.length !== 1 ? 's' : ''} affected
+                    {ob.maxSeverity ? ` · Severity ${ob.maxSeverity}/5` : ''}
+                  </span>
+                  <div className="mt-1 fs-xs">
+                    {ob.plants.map(p => (
+                      <Badge key={p.plantId} bg="light" text="dark" className="me-1">{p.plantName}</Badge>
+                    ))}
+                  </div>
+                  {bulkTreating === ob.outbreakId && (
+                    <div className="d-flex gap-2 mt-2">
+                      <input className="form-control form-control-sm" style={{ maxWidth: 260 }}
+                        placeholder="Treatment applied…" value={bulkTreatInput}
+                        onChange={e => setBulkTreatInput(e.target.value)} />
+                      <Button size="sm" variant="danger" onClick={() => handleBulkTreat(ob.outbreakId)}>
+                        Apply to all
+                      </Button>
+                      <Button size="sm" variant="light" onClick={() => setBulkTreating(null)}>
+                        Cancel
+                      </Button>
+                    </div>
+                  )}
+                </div>
+                <div className="d-flex gap-2 flex-shrink-0">
+                  {bulkTreating !== ob.outbreakId && (
+                    <Button size="sm" variant="outline-danger" onClick={() => { setBulkTreating(ob.outbreakId); setBulkTreatInput('') }}>
+                      Treat all
+                    </Button>
+                  )}
+                  <Button size="sm" variant="outline-success" onClick={() => handleBulkResolve(ob.outbreakId)}>
+                    Resolve all
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
         {plantsError && (
           <div className="mx-3 mt-3">
             <ErrorAlert error={plantsError} context="plants" onRetry={reloadPlants} />


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- New **incident log** on every plant: track pests, diseases, deficiencies, and environmental issues with severity (1–5), treatment log, and resolution date
- **Auto-outbreak grouping**: logging an incident of the same category+type on plants in the same room within 14 days auto-assigns a shared `outbreakId` linking them
- **Dashboard outbreak banner**: active outbreaks show an alert with affected plant names, bulk-treat and bulk-resolve actions
- **Floorplan pulse markers**: plants with open incidents render with a red CSS pulse animation on the Leaflet map
- **Analytics Pest & Disease section**: active incident count, average resolution time, top incident types
- 22 new backend tests covering all routes, outbreak grouping logic, cross-plant linking, bulk treat/resolve

## Backend routes added
- `GET/POST /plants/:id/incidents`
- `PUT /plants/:id/incidents/:incidentId`
- `POST /plants/:id/incidents/:incidentId/treatments`
- `POST /plants/:id/incidents/:incidentId/resolve`
- `DELETE /plants/:id/incidents/:incidentId`
- `GET /outbreaks`
- `POST /outbreaks/:outbreakId/treat`
- `POST /outbreaks/:outbreakId/resolve`

## Test plan
- [x] 597 frontend tests pass (PlantModal + App mocks updated)
- [x] 393 backend tests pass (22 new incident/outbreak tests)
- [ ] Log a pest incident on one plant in a room, log same type on another plant in same room within 14 days → outbreak banner appears on dashboard
- [ ] Bulk-treat applies treatment to all affected plants
- [ ] Bulk-resolve removes outbreak from dashboard
- [ ] Plant with active incident shows pulsing red ring on floorplan
- [ ] Analytics shows active incident count and avg resolution time

Closes #258

https://claude.ai/code/session_01LJtkErcU1Ga97NMekh2NpY
EOF
)