### PR TITLE
feat(#165): data export — plant CSV, watering-history CSV & printable care schedule

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -3222,4 +3222,156 @@ Return ONLY valid JSON matching this schema:
   }
 });
 
+// ── Data export (CSV + printable HTML) ───────────────────────────────────────
+
+function csvEscape(v) {
+  if (v == null) return '';
+  const s = String(v);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
+function toCsv(headers, rows) {
+  const lines = [headers.map(h => csvEscape(h.label)).join(',')];
+  for (const row of rows) {
+    lines.push(headers.map(h => csvEscape(row[h.key])).join(','));
+  }
+  return lines.join('\n');
+}
+
+// GET /export/plants?format=csv|json — plant inventory (home_pro+)
+app.get('/export/plants', requireUser, requireTier('home_pro'), async (req, res) => {
+  try {
+    const snap = await userPlants(req.userId).get();
+    const plants = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+
+    if (req.query.format === 'csv') {
+      const HEADERS = [
+        { key: 'id',                  label: 'ID' },
+        { key: 'name',                label: 'Name' },
+        { key: 'species',             label: 'Species' },
+        { key: 'room',                label: 'Room' },
+        { key: 'floor',               label: 'Floor' },
+        { key: 'health',              label: 'Health' },
+        { key: 'maturity',            label: 'Maturity' },
+        { key: 'frequencyDays',       label: 'Watering Frequency (days)' },
+        { key: 'lastWatered',         label: 'Last Watered' },
+        { key: 'lastFertilised',      label: 'Last Fertilised' },
+        { key: 'potSize',             label: 'Pot Size' },
+        { key: 'soilType',            label: 'Soil Type' },
+        { key: 'plantedIn',           label: 'Planted In' },
+        { key: 'isOutdoor',           label: 'Outdoor' },
+        { key: 'parentPropagationId', label: 'Parent Propagation ID' },
+        { key: 'notes',               label: 'Notes' },
+      ];
+      const csv = toCsv(HEADERS, plants);
+      const filename = `plant-tracker-plants-${new Date().toISOString().slice(0, 10)}.csv`;
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      return res.status(200).send(csv);
+    }
+
+    res.status(200).json(plants);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /export/watering-history?format=csv&from=YYYY-MM-DD&to=YYYY-MM-DD (home_pro+)
+app.get('/export/watering-history', requireUser, requireTier('home_pro'), async (req, res) => {
+  try {
+    const fromDate = req.query.from ? new Date(req.query.from) : null;
+    const toDate   = req.query.to   ? new Date(req.query.to)   : null;
+
+    const snap = await userPlants(req.userId).get();
+    const rows = [];
+    for (const doc of snap.docs) {
+      const plant = { id: doc.id, ...doc.data() };
+      for (const entry of plant.wateringLog || []) {
+        const d = new Date(entry.date);
+        if (fromDate && d < fromDate) continue;
+        if (toDate   && d > toDate)   continue;
+        rows.push({
+          date:      entry.date,
+          plantName: plant.name,
+          species:   plant.species || '',
+          room:      plant.room    || '',
+          method:    entry.method  || '',
+          amount:    entry.amount  || '',
+          notes:     entry.notes   || '',
+          plantId:   plant.id,
+        });
+      }
+    }
+    rows.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+    if (req.query.format === 'csv') {
+      const HEADERS = [
+        { key: 'date',      label: 'Date' },
+        { key: 'plantName', label: 'Plant Name' },
+        { key: 'species',   label: 'Species' },
+        { key: 'room',      label: 'Room' },
+        { key: 'method',    label: 'Method' },
+        { key: 'amount',    label: 'Amount' },
+        { key: 'notes',     label: 'Notes' },
+        { key: 'plantId',   label: 'Plant ID' },
+      ];
+      const csv = toCsv(HEADERS, rows);
+      const filename = `plant-tracker-watering-${new Date().toISOString().slice(0, 10)}.csv`;
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      return res.status(200).send(csv);
+    }
+
+    res.status(200).json(rows);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /export/care-schedule?format=html — printable care schedule (home_pro+)
+app.get('/export/care-schedule', requireUser, requireTier('home_pro'), async (req, res) => {
+  try {
+    const snap = await userPlants(req.userId).get();
+    const plants = snap.docs
+      .map(d => ({ id: d.id, ...d.data() }))
+      .filter(p => p.frequencyDays)
+      .sort((a, b) => (a.room || '').localeCompare(b.room || '') || (a.name || '').localeCompare(b.name || ''));
+
+    const today = new Date().toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' });
+    const rows = plants.map(p => {
+      const lastW = p.lastWatered
+        ? new Date(p.lastWatered).toLocaleDateString('en-GB') : '—';
+      const nextW = p.lastWatered && p.frequencyDays
+        ? new Date(new Date(p.lastWatered).getTime() + p.frequencyDays * 86400000).toLocaleDateString('en-GB')
+        : '—';
+      return `<tr><td>${p.name||''}</td><td>${p.species||''}</td><td>${p.room||''}</td>`
+           + `<td>${p.frequencyDays}d</td><td>${lastW}</td><td>${nextW}</td><td>${p.health||''}</td></tr>`;
+    }).join('');
+
+    const html = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<title>Plant Care Schedule</title>
+<style>body{font-family:system-ui,sans-serif;font-size:13px;color:#111;margin:24px}
+h1{font-size:20px;margin-bottom:4px}p.sub{color:#666;font-size:11px;margin-bottom:16px}
+table{width:100%;border-collapse:collapse}th{background:#f0f0f0;text-align:left;padding:6px 8px;font-size:11px;text-transform:uppercase;letter-spacing:.05em}
+td{padding:5px 8px;border-bottom:1px solid #e5e5e5}@media print{body{margin:0}}</style>
+</head><body>
+<h1>Plant Care Schedule</h1>
+<p class="sub">Generated ${today} &mdash; ${plants.length} plant${plants.length!==1?'s':''}</p>
+<table><thead><tr><th>Name</th><th>Species</th><th>Room</th><th>Water every</th><th>Last watered</th><th>Next due</th><th>Health</th></tr></thead>
+<tbody>${rows}</tbody></table></body></html>`;
+
+    const filename = `plant-tracker-schedule-${new Date().toISOString().slice(0, 10)}.html`;
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    if (req.query.format === 'html') {
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    }
+    res.status(200).send(html);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 functions.http('plantsApi', app);

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -3706,3 +3706,101 @@ describe('DELETE /propagations/:id', () => {
     expect(res.status).toBe(404);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Export routes
+// ---------------------------------------------------------------------------
+
+describe('GET /export/plants', () => {
+  beforeEach(() => {
+    store[plantPath('e1')] = { name: 'Basil', species: 'Ocimum basilicum', room: 'Kitchen', health: 'good', frequencyDays: 3, lastWatered: '2026-04-18' };
+    store[plantPath('e2')] = { name: 'Fern, "Boston"', species: 'Nephrolepis', room: 'Bathroom', health: 'fair', frequencyDays: 7, lastWatered: '2026-04-10' };
+  });
+
+  it('returns JSON list of plants without format param', async () => {
+    const res = await request(app).get('/export/plants').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(2);
+  });
+
+  it('returns CSV with correct Content-Type for ?format=csv', async () => {
+    const res = await request(app).get('/export/plants?format=csv').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/csv/);
+  });
+
+  it('CSV escapes commas and quotes in field values', async () => {
+    const res = await request(app).get('/export/plants?format=csv').set('Authorization', authHeader());
+    expect(res.text).toContain('"Fern, ""Boston"""');
+  });
+
+  it('CSV includes all plants as rows (header + 2 data rows)', async () => {
+    const res = await request(app).get('/export/plants?format=csv').set('Authorization', authHeader());
+    const lines = res.text.trim().split('\n');
+    expect(lines.length).toBe(3);
+  });
+});
+
+describe('GET /export/watering-history', () => {
+  beforeEach(() => {
+    store[plantPath('w1')] = {
+      name: 'Aloe', species: 'Aloe vera', room: 'Living Room',
+      wateringLog: [
+        { date: '2026-04-15', method: 'bottom', amount: '200ml', notes: '' },
+        { date: '2026-04-08', method: 'top',    amount: '150ml', notes: 'extra' },
+      ],
+    };
+    store[plantPath('w2')] = {
+      name: 'Cactus', species: 'Cactaceae', room: 'Study',
+      wateringLog: [
+        { date: '2026-04-12', method: 'top', amount: '50ml', notes: '' },
+      ],
+    };
+  });
+
+  it('returns JSON array of watering rows', async () => {
+    const res = await request(app).get('/export/watering-history').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(3);
+  });
+
+  it('CSV rows are sorted by date ascending', async () => {
+    const res = await request(app).get('/export/watering-history?format=csv').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    const lines = res.text.trim().split('\n');
+    expect(lines[1]).toContain('2026-04-08');
+    expect(lines[3]).toContain('2026-04-15');
+  });
+
+  it('filters rows by ?from date', async () => {
+    const res = await request(app).get('/export/watering-history?from=2026-04-12').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(2);
+    expect(res.body.every(r => r.date >= '2026-04-12')).toBe(true);
+  });
+});
+
+describe('GET /export/care-schedule', () => {
+  beforeEach(() => {
+    store[plantPath('c1')] = { name: 'Mint', species: 'Mentha', room: 'Kitchen', frequencyDays: 2, lastWatered: '2026-04-19', health: 'good' };
+    store[plantPath('c2')] = { name: 'Snake Plant', species: 'Sansevieria', room: 'Bedroom', frequencyDays: 14, lastWatered: '2026-04-01', health: 'excellent' };
+  });
+
+  it('returns HTML with a care-schedule table', async () => {
+    const res = await request(app).get('/export/care-schedule').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/html/);
+    expect(res.text).toContain('<table>');
+    expect(res.text).toContain('Mint');
+    expect(res.text).toContain('Snake Plant');
+  });
+
+  it('sets Content-Disposition attachment header when ?format=html', async () => {
+    const res = await request(app).get('/export/care-schedule?format=html').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition']).toMatch(/attachment/);
+    expect(res.headers['content-disposition']).toMatch(/\.html/);
+  });
+});

--- a/src/__tests__/SettingsPage.test.jsx
+++ b/src/__tests__/SettingsPage.test.jsx
@@ -149,7 +149,7 @@ describe('SettingsPage Data tab', () => {
     })
 
     renderAt('/settings/data')
-    fireEvent.click(screen.getByRole('button', { name: /export my data/i }))
+    fireEvent.click(screen.getByRole('button', { name: /all data \(json\)/i }))
 
     await waitFor(() => expect(accountApi.exportData).toHaveBeenCalledTimes(1))
     expect(createObjectURL).toHaveBeenCalledTimes(1)

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -250,6 +250,52 @@ export const billingApi = {
   }),
 }
 
+function downloadHeaders() {
+  const h = { 'x-api-key': API_KEY }
+  if (_credential) h['Authorization'] = `Bearer ${_credential}`
+  return h
+}
+
+async function fetchBlob(path) {
+  const res = await fetch(`${BASE_URL}${path}`, { headers: downloadHeaders() })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(text || `HTTP ${res.status}`)
+  }
+  const blob = await res.blob()
+  const disposition = res.headers.get('Content-Disposition') || ''
+  const match = disposition.match(/filename="([^"]+)"/)
+  const filename = match ? match[1] : 'export'
+  return { blob, filename }
+}
+
+function triggerDownload(blob, filename) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+export const exportApi = {
+  async downloadPlants(format = 'csv') {
+    const { blob, filename } = await fetchBlob(`/export/plants?format=${format}`)
+    triggerDownload(blob, filename)
+  },
+  async downloadWateringHistory(format = 'csv', { from, to } = {}) {
+    let path = `/export/watering-history?format=${format}`
+    if (from) path += `&from=${from}`
+    if (to) path += `&to=${to}`
+    const { blob, filename } = await fetchBlob(path)
+    triggerDownload(blob, filename)
+  },
+  async downloadCareSchedule() {
+    const { blob, filename } = await fetchBlob('/export/care-schedule?format=html')
+    triggerDownload(blob, filename)
+  },
+}
+
 export const imagesApi = {
   async upload(file, prefix = 'plants') {
     const ext = file.name.split('.').pop()

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -7,7 +7,7 @@ import { useAuth } from '../contexts/AuthContext.jsx'
 import HelpTooltip from '../components/HelpTooltip.jsx'
 import LeafletFloorplan from '../components/LeafletFloorplan.jsx'
 import { YARD_AREAS } from '../utils/watering.js'
-import { accountApi } from '../api/plants.js'
+import { accountApi, exportApi } from '../api/plants.js'
 
 const TABS = [
   { id: 'property', label: 'Property', icon: 'layers', tags: 'floors zones floorplan rooms upload property' },
@@ -449,14 +449,14 @@ function PreferencesTab({ search }) {
 
 function DataTab({ search }) {
   const { logout } = useAuth()
-  const [exportLoading, setExportLoading] = useState(false)
+  const [exportLoading, setExportLoading] = useState(null)
   const [exportError, setExportError] = useState(null)
   const [deletePhase, setDeletePhase] = useState(0)
   const [deleteInput, setDeleteInput] = useState('')
   const [deleteError, setDeleteError] = useState(null)
 
   const handleExport = async () => {
-    setExportLoading(true)
+    setExportLoading('json')
     setExportError(null)
     try {
       const data = await accountApi.exportData()
@@ -470,7 +470,21 @@ function DataTab({ search }) {
     } catch (err) {
       setExportError(err.message)
     } finally {
-      setExportLoading(false)
+      setExportLoading(null)
+    }
+  }
+
+  const handleCsvExport = async (type) => {
+    setExportLoading(type)
+    setExportError(null)
+    try {
+      if (type === 'plants-csv') await exportApi.downloadPlants('csv')
+      else if (type === 'watering-csv') await exportApi.downloadWateringHistory('csv')
+      else if (type === 'schedule-html') await exportApi.downloadCareSchedule()
+    } catch (err) {
+      setExportError(err.message)
+    } finally {
+      setExportLoading(null)
     }
   }
 
@@ -490,15 +504,36 @@ function DataTab({ search }) {
     <>
       <SettingSection id="export" title="Data export" icon="download" search={search}>
         <p className="text-muted mb-3">
-          Download all your plant data as a JSON file, including care history, measurements, and journal entries.
+          Download your plant data in multiple formats. CSV files open in Excel or any spreadsheet app.
+          The care schedule exports as a printable HTML page — open it in your browser and use File → Print to save as PDF.
         </p>
         {exportError && <div className="alert alert-danger py-2 mb-3">{exportError}</div>}
-        <Button variant="outline-primary" onClick={handleExport} disabled={exportLoading}>
-          <svg className="sa-icon me-2" style={{ width: 14, height: 14 }} aria-hidden="true">
-            <use href="/icons/sprite.svg#download"></use>
-          </svg>
-          {exportLoading ? 'Exporting…' : 'Export my data (JSON)'}
-        </Button>
+        <div className="d-flex flex-wrap gap-2">
+          <Button variant="outline-primary" onClick={handleExport} disabled={exportLoading !== null}>
+            <svg className="sa-icon me-2" style={{ width: 14, height: 14 }} aria-hidden="true">
+              <use href="/icons/sprite.svg#download"></use>
+            </svg>
+            {exportLoading === 'json' ? 'Exporting…' : 'All data (JSON)'}
+          </Button>
+          <Button variant="outline-secondary" onClick={() => handleCsvExport('plants-csv')} disabled={exportLoading !== null}>
+            <svg className="sa-icon me-2" style={{ width: 14, height: 14 }} aria-hidden="true">
+              <use href="/icons/sprite.svg#file-text"></use>
+            </svg>
+            {exportLoading === 'plants-csv' ? 'Exporting…' : 'Plant inventory (CSV)'}
+          </Button>
+          <Button variant="outline-secondary" onClick={() => handleCsvExport('watering-csv')} disabled={exportLoading !== null}>
+            <svg className="sa-icon me-2" style={{ width: 14, height: 14 }} aria-hidden="true">
+              <use href="/icons/sprite.svg#droplets"></use>
+            </svg>
+            {exportLoading === 'watering-csv' ? 'Exporting…' : 'Watering history (CSV)'}
+          </Button>
+          <Button variant="outline-secondary" onClick={() => handleCsvExport('schedule-html')} disabled={exportLoading !== null}>
+            <svg className="sa-icon me-2" style={{ width: 14, height: 14 }} aria-hidden="true">
+              <use href="/icons/sprite.svg#calendar"></use>
+            </svg>
+            {exportLoading === 'schedule-html' ? 'Exporting…' : 'Care schedule (printable)'}
+          </Button>
+        </div>
       </SettingSection>
 
       <SettingSection id="account-delete" title="Delete account" icon="trash-2" search={search}>


### PR DESCRIPTION
## Summary

Closes #165

- **Backend**: inline `csvEscape`/`toCsv` helpers (no new dependency); three new tier-gated export endpoints (`GET /export/plants`, `GET /export/watering-history`, `GET /export/care-schedule`) all behind `requireTier('home_pro')` — no-ops in dev since `BILLING_ENABLED !== 'true'`
- **Care schedule PDF**: exported as a print-ready HTML file; user opens in browser and uses File → Print → Save as PDF (no Puppeteer required)
- **Frontend `exportApi`**: blob-download helpers (`downloadPlants`, `downloadWateringHistory`, `downloadCareSchedule`) that read `Content-Disposition` filename from the response
- **Settings → Data tab**: 4 export buttons alongside the existing JSON export — Plant inventory (CSV), Watering history (CSV), Care schedule (printable HTML)

## Test plan

- [ ] 9 new backend tests: JSON list, CSV Content-Type, CSV comma/quote escaping, row count, date-sorted watering history, `?from` date filter, HTML care schedule body, Content-Disposition attachment header
- [ ] Existing SettingsPage test updated to match renamed "All data (JSON)" button label
- [ ] `npm run test:coverage` (frontend): 625 tests pass, all thresholds green
- [ ] `cd api/plants && npm run test:coverage` (backend): 402 tests pass, 84% statements / 72% branches

https://claude.ai/code/session_01LJtkErcU1Ga97NMekh2NpY