### PR TITLE
feat(#230): unit system preference — metric/imperial for measurements & display

### DIFF
--- a/src/__tests__/PlantModal.test.jsx
+++ b/src/__tests__/PlantModal.test.jsx
@@ -686,14 +686,14 @@ describe('PlantModal', () => {
     renderModal()
     selectMode('manual')
     // Initially no pot size visible (plantedIn not set to pot)
-    expect(screen.queryByRole('option', { name: 'Small (< 15cm)' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Small (< 15 cm)' })).not.toBeInTheDocument()
 
     // Select Pot
     const plantedInSelect = screen.getByRole('option', { name: 'Pot' }).closest('select')
     fireEvent.change(plantedInSelect, { target: { value: 'pot' } })
 
     // Now pot size and soil type should be visible
-    expect(screen.getByRole('option', { name: 'Small (< 15cm)' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Small (< 15 cm)' })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'Standard potting mix' })).toBeInTheDocument()
   })
 
@@ -704,11 +704,11 @@ describe('PlantModal', () => {
 
     // Select Pot first
     fireEvent.change(plantedInSelect, { target: { value: 'pot' } })
-    expect(screen.getByRole('option', { name: 'Small (< 15cm)' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Small (< 15 cm)' })).toBeInTheDocument()
 
     // Switch to In the Ground
     fireEvent.change(plantedInSelect, { target: { value: 'ground' } })
-    expect(screen.queryByRole('option', { name: 'Small (< 15cm)' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Small (< 15 cm)' })).not.toBeInTheDocument()
   })
 
   it('calls recommendApi.getWatering and shows results on Watering tab', async () => {

--- a/src/__tests__/units.test.js
+++ b/src/__tests__/units.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { formatLength, formatTemperatureC, POT_SIZES, unitSystemLabel } from '../utils/units.js'
+
+describe('formatLength', () => {
+  it('returns cm for metric', () => {
+    expect(formatLength(30, 'metric')).toBe('30 cm')
+  })
+
+  it('converts to inches for imperial', () => {
+    expect(formatLength(25.4, 'imperial')).toBe('10 in')
+  })
+
+  it('rounds to 1 decimal for non-integer inches', () => {
+    expect(formatLength(15, 'imperial')).toBe('5.9 in')
+  })
+
+  it('defaults to metric when system is undefined', () => {
+    expect(formatLength(10, undefined)).toBe('10 cm')
+  })
+})
+
+describe('formatTemperatureC', () => {
+  it('displays Celsius for celsius unit', () => {
+    expect(formatTemperatureC(30, 'celsius')).toBe('30°C')
+  })
+
+  it('converts to Fahrenheit for fahrenheit unit', () => {
+    expect(formatTemperatureC(0, 'fahrenheit')).toBe('32°F')
+    expect(formatTemperatureC(100, 'fahrenheit')).toBe('212°F')
+  })
+
+  it('rounds to nearest integer', () => {
+    expect(formatTemperatureC(36.6, 'celsius')).toBe('37°C')
+    expect(formatTemperatureC(37, 'fahrenheit')).toBe('99°F')
+  })
+
+  it('handles the forecast thresholds (30°C = 86°F, 10°C = 50°F)', () => {
+    expect(formatTemperatureC(30, 'fahrenheit')).toBe('86°F')
+    expect(formatTemperatureC(10, 'fahrenheit')).toBe('50°F')
+  })
+})
+
+describe('POT_SIZES', () => {
+  it('metric sizes contain cm units', () => {
+    expect(POT_SIZES.metric.every(s => s.label.includes('cm'))).toBe(true)
+  })
+
+  it('imperial sizes contain in units', () => {
+    expect(POT_SIZES.imperial.every(s => s.label.includes('in'))).toBe(true)
+  })
+
+  it('both systems have the same value keys', () => {
+    const metricValues = POT_SIZES.metric.map(s => s.value)
+    const imperialValues = POT_SIZES.imperial.map(s => s.value)
+    expect(metricValues).toEqual(imperialValues)
+  })
+})
+
+describe('unitSystemLabel', () => {
+  it('returns label for metric', () => {
+    expect(unitSystemLabel('metric')).toContain('Metric')
+  })
+
+  it('returns label for imperial', () => {
+    expect(unitSystemLabel('imperial')).toContain('Imperial')
+  })
+})

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -9,6 +9,7 @@ import { analyseWateringPattern, getPatternMeta } from '../utils/wateringPattern
 import { derivePlantName } from '../utils/plantName.js'
 import { getPlantEmoji, PLANT_EMOJI_GROUPS } from '../utils/plantEmoji.js'
 import { PlantContext } from '../context/PlantContext.jsx'
+import { POT_SIZES, formatLength } from '../utils/units.js'
 import { friendlyErrorMessage } from '../utils/errorMessages.js'
 
 // Max recommendation entries retained per plant. Older entries are trimmed
@@ -83,12 +84,7 @@ const SUN_EXPOSURE_OPTIONS = [
   { value: 'part-sun', label: 'Part Sun' },
   { value: 'shade', label: 'Shade' },
 ]
-const POT_SIZE_OPTIONS = [
-  { value: 'small', label: 'Small (< 15cm)' },
-  { value: 'medium', label: 'Medium (15–25cm)' },
-  { value: 'large', label: 'Large (25–40cm)' },
-  { value: 'xlarge', label: 'X-Large (> 40cm)' },
-]
+// POT_SIZE_OPTIONS is derived at render time from POT_SIZES[unitSystem]
 const SOIL_TYPE_OPTIONS = [
   { value: 'standard', label: 'Standard potting mix' },
   { value: 'well-draining', label: 'Well-draining (perlite/sand)' },
@@ -311,6 +307,8 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   const plantCtx = useContext(PlantContext)
   const updatePlantsLocally = plantCtx?.updatePlantsLocally
   const contextIsGuest = plantCtx?.isGuest ?? false
+  const unitSystem = plantCtx?.unitSystem?.system ?? 'metric'
+  const potSizeOptions = POT_SIZES[unitSystem] ?? POT_SIZES.metric
 
   // Persist recommendation history on the plant doc. Guest plants stay local
   // (their IDs aren't in Firestore). Failures are swallowed — the UI already
@@ -518,8 +516,9 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   const handleAddMeasurement = useCallback(async () => {
     const { height_cm, width_cm, leafCount, stemCount, notes } = newMeasurement
     const payload = {}
-    if (height_cm !== '') payload.height_cm = Number(height_cm)
-    if (width_cm  !== '') payload.width_cm  = Number(width_cm)
+    const inToCm = unitSystem === 'imperial' ? (v) => parseFloat((v * 2.54).toFixed(1)) : (v) => v
+    if (height_cm !== '') payload.height_cm = inToCm(Number(height_cm))
+    if (width_cm  !== '') payload.width_cm  = inToCm(Number(width_cm))
     if (leafCount  !== '') payload.leafCount  = Number(leafCount)
     if (stemCount  !== '') payload.stemCount  = Number(stemCount)
     if (Object.keys(payload).length === 0) {
@@ -1040,7 +1039,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
                           <Form.Label>Pot Size</Form.Label>
                           <Form.Select value={form.potSize || ''} onChange={(e) => update('potSize', e.target.value || null)}>
                             <option value="">— Select —</option>
-                            {POT_SIZE_OPTIONS.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
+                            {potSizeOptions.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
                           </Form.Select>
                         </Form.Group>
                       </Col>
@@ -1572,13 +1571,18 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
                 options={{
                   chart: { type: 'line', toolbar: { show: false }, background: 'transparent' },
                   xaxis: { categories: measurements.filter(m => m.height_cm != null).map(m => m.date.slice(0, 10)), type: 'category' },
-                  yaxis: { title: { text: 'cm' }, min: 0 },
+                  yaxis: { title: { text: unitSystem === 'imperial' ? 'in' : 'cm' }, min: 0 },
                   stroke: { curve: 'smooth', width: 2 },
                   markers: { size: 4 },
                   tooltip: { x: { show: true } },
                   grid: { borderColor: 'rgba(128,128,128,0.15)' },
                 }}
-                series={[{ name: 'Height (cm)', data: measurements.filter(m => m.height_cm != null).map(m => m.height_cm) }]}
+                series={[{
+                  name: unitSystem === 'imperial' ? 'Height (in)' : 'Height (cm)',
+                  data: measurements.filter(m => m.height_cm != null).map(m =>
+                    unitSystem === 'imperial' ? parseFloat((m.height_cm / 2.54).toFixed(1)) : m.height_cm
+                  ),
+                }]}
               />
             </div>
           )}
@@ -1588,8 +1592,9 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
             <Row className="g-2">
               <Col xs={6}>
                 <Form.Group controlId="growth-height-cm">
-                  <Form.Label className="fs-xs">Height (cm)</Form.Label>
-                  <Form.Control type="number" min="0" step="0.1" placeholder="e.g. 45"
+                  <Form.Label className="fs-xs">{unitSystem === 'imperial' ? 'Height (in)' : 'Height (cm)'}</Form.Label>
+                  <Form.Control type="number" min="0" step="0.1"
+                    placeholder={unitSystem === 'imperial' ? 'e.g. 18' : 'e.g. 45'}
                     value={newMeasurement.height_cm}
                     onChange={e => setNewMeasurement(prev => ({ ...prev, height_cm: e.target.value }))}
                   />
@@ -1597,8 +1602,9 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
               </Col>
               <Col xs={6}>
                 <Form.Group controlId="growth-width-cm">
-                  <Form.Label className="fs-xs">Width (cm)</Form.Label>
-                  <Form.Control type="number" min="0" step="0.1" placeholder="e.g. 30"
+                  <Form.Label className="fs-xs">{unitSystem === 'imperial' ? 'Width (in)' : 'Width (cm)'}</Form.Label>
+                  <Form.Control type="number" min="0" step="0.1"
+                    placeholder={unitSystem === 'imperial' ? 'e.g. 12' : 'e.g. 30'}
                     value={newMeasurement.width_cm}
                     onChange={e => setNewMeasurement(prev => ({ ...prev, width_cm: e.target.value }))}
                   />

--- a/src/context/PlantContext.jsx
+++ b/src/context/PlantContext.jsx
@@ -4,6 +4,7 @@ import { plantsApi, imagesApi, floorsApi, analyseApi, flushOfflineMutations, Off
 import { subscribe as subscribeOfflineQueue, size as offlineQueueSize } from '../utils/offlineQueue.js'
 import { useWeather } from '../hooks/useWeather.js'
 import { useTempUnit } from '../hooks/useTempUnit.js'
+import { useUnitSystem } from '../hooks/useUnitSystem.js'
 import { getWateringStatus, isOutdoor } from '../utils/watering.js'
 import { GUEST_PLANTS, GUEST_FLOORS } from '../data/guestData.js'
 import { toFriendlyError } from '../utils/errorMessages.js'
@@ -21,6 +22,7 @@ export function usePlantContext() {
 export function PlantProvider({ children }) {
   const { isAuthenticated, isGuest, logout } = useAuth()
   const tempUnit = useTempUnit()
+  const unitSystem = useUnitSystem()
   const { weather, locationDenied, location, setLocation } = useWeather(tempUnit.unit)
 
   const [plants, setPlants] = useState([])
@@ -400,7 +402,7 @@ export function PlantProvider({ children }) {
   const value = useMemo(() => ({
     plants, plantsLoading, plantsError, reloadPlants,
     floors, activeFloorId, setActiveFloorId,
-    weather, locationDenied, location, setLocation, tempUnit,
+    weather, locationDenied, location, setLocation, tempUnit, unitSystem,
     overdueCount, isAnalysingFloorplan,
     isGuest,
     isOnline, pendingSyncCount,
@@ -411,7 +413,7 @@ export function PlantProvider({ children }) {
     updatePlantsLocally,
   }), [
     plants, plantsLoading, plantsError, reloadPlants, floors, activeFloorId,
-    weather, locationDenied, location, setLocation, tempUnit, overdueCount, isAnalysingFloorplan, isGuest,
+    weather, locationDenied, location, setLocation, tempUnit, unitSystem, overdueCount, isAnalysingFloorplan, isGuest,
     isOnline, pendingSyncCount,
     handleSavePlant, handleWaterPlant, handleMoisturePlant, handleBatchWater,
     handleFertilisePlant,

--- a/src/hooks/useUnitSystem.js
+++ b/src/hooks/useUnitSystem.js
@@ -1,0 +1,34 @@
+import { useState, useCallback } from 'react'
+
+const STORAGE_KEY = 'plantTracker_unitSystem'
+
+function detectDefault() {
+  try {
+    const lang = navigator.language || ''
+    if (lang.startsWith('en-US') || lang === 'en-LR' || lang === 'my') return 'imperial'
+  } catch {}
+  return 'metric'
+}
+
+function readStored() {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    if (v === 'metric' || v === 'imperial') return v
+  } catch {}
+  return null
+}
+
+export function useUnitSystem() {
+  const [system, setSystemState] = useState(() => readStored() || detectDefault())
+
+  const setSystem = useCallback((s) => {
+    setSystemState(s)
+    try { localStorage.setItem(STORAGE_KEY, s) } catch {}
+  }, [])
+
+  const toggle = useCallback(() => {
+    setSystem(system === 'metric' ? 'imperial' : 'metric')
+  }, [system, setSystem])
+
+  return { system, setSystem, toggle }
+}

--- a/src/pages/ForecastPage.jsx
+++ b/src/pages/ForecastPage.jsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { Row, Col, Badge } from 'react-bootstrap'
 import { usePlantContext } from '../context/PlantContext.jsx'
 import { isOutdoor } from '../utils/watering.js'
+import { formatTemperatureC } from '../utils/units.js'
 import SeasonBadge from '../components/SeasonBadge.jsx'
 import EmptyState from '../components/EmptyState.jsx'
 
@@ -12,7 +13,7 @@ function dayLabel(dateStr, index) {
 }
 
 export default function ForecastPage() {
-  const { weather, plants, floors, location } = usePlantContext()
+  const { weather, plants, floors, location, tempUnit } = usePlantContext()
 
   const outdoorPlants = useMemo(
     () => plants.filter((p) => isOutdoor(p, floors)),
@@ -124,7 +125,7 @@ export default function ForecastPage() {
                       <div className="d-flex align-items-center gap-2 p-2 rounded bg-warning bg-opacity-10">
                         <svg className="sa-icon text-warning" style={{ width: 16, height: 16 }}><use href="/icons/sprite.svg#sun"></use></svg>
                         <span className="fs-sm">
-                          <strong>{hotDays.length} hot day{hotDays.length !== 1 ? 's' : ''}</strong> — water amounts increased by 25-50%
+                          <strong>{hotDays.length} hot day{hotDays.length !== 1 ? 's' : ''}</strong> (≥{formatTemperatureC(30, tempUnit?.unit)}) — water amounts increased by 25-50%
                         </span>
                       </div>
                     )}
@@ -132,7 +133,7 @@ export default function ForecastPage() {
                       <div className="d-flex align-items-center gap-2 p-2 rounded bg-primary bg-opacity-10">
                         <svg className="sa-icon text-primary" style={{ width: 16, height: 16 }}><use href="/icons/sprite.svg#thermometer"></use></svg>
                         <span className="fs-sm">
-                          <strong>{coldDays.length} cold day{coldDays.length !== 1 ? 's' : ''}</strong> — water amounts reduced by 25%
+                          <strong>{coldDays.length} cold day{coldDays.length !== 1 ? 's' : ''}</strong> (≤{formatTemperatureC(10, tempUnit?.unit)}) — water amounts reduced by 25%
                         </span>
                       </div>
                     )}

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -11,7 +11,7 @@ import { accountApi, exportApi } from '../api/plants.js'
 
 const TABS = [
   { id: 'property', label: 'Property', icon: 'layers', tags: 'floors zones floorplan rooms upload property' },
-  { id: 'preferences', label: 'Preferences', icon: 'sliders', tags: 'theme dark mode light temperature celsius fahrenheit location city weather' },
+  { id: 'preferences', label: 'Preferences', icon: 'sliders', tags: 'theme dark mode light temperature celsius fahrenheit metric imperial units location city weather' },
   { id: 'data', label: 'Data & export', icon: 'download', tags: 'export csv download backup data' },
   { id: 'advanced', label: 'Advanced', icon: 'tool', tags: 'reset onboarding developer version advanced' },
 ]
@@ -320,7 +320,7 @@ function PropertyTab({ search }) {
 }
 
 function PreferencesTab({ search }) {
-  const { tempUnit, location, setLocation } = usePlantContext()
+  const { tempUnit, unitSystem, location, setLocation } = usePlantContext()
   const { themeMode, changeThemeMode } = useLayoutContext()
   const [locationSearch, setLocationSearch] = useState('')
   const [locationResults, setLocationResults] = useState([])
@@ -360,17 +360,30 @@ function PreferencesTab({ search }) {
         </div>
       </SettingSection>
 
-      {tempUnit && (
+      {(tempUnit || unitSystem) && (
         <SettingSection id="units" title="Units" icon="thermometer" search={search}>
-          <div className="d-flex align-items-center justify-content-between">
-            <span className="d-flex align-items-center gap-1">
-              Temperature
-              <HelpTooltip articleId="temperature-units" label="What does temperature unit affect?" />
-            </span>
-            <Button variant="outline-default" size="sm" onClick={tempUnit.toggle}>
-              <svg className="sa-icon me-1" aria-hidden="true"><use href="/icons/sprite.svg#thermometer"></use></svg>
-              {tempUnit.unit === 'celsius' ? '°C → °F' : '°F → °C'}
-            </Button>
+          <div className="d-flex flex-column gap-3">
+            {tempUnit && (
+              <div className="d-flex align-items-center justify-content-between">
+                <span className="d-flex align-items-center gap-1">
+                  Temperature
+                  <HelpTooltip articleId="temperature-units" label="What does temperature unit affect?" />
+                </span>
+                <Button variant="outline-default" size="sm" onClick={tempUnit.toggle}>
+                  <svg className="sa-icon me-1" aria-hidden="true"><use href="/icons/sprite.svg#thermometer"></use></svg>
+                  {tempUnit.unit === 'celsius' ? '°C → °F' : '°F → °C'}
+                </Button>
+              </div>
+            )}
+            {unitSystem && (
+              <div className="d-flex align-items-center justify-content-between">
+                <span>Measurements</span>
+                <Button variant="outline-default" size="sm" onClick={unitSystem.toggle}>
+                  <svg className="sa-icon me-1" aria-hidden="true"><use href="/icons/sprite.svg#ruler"></use></svg>
+                  {unitSystem.system === 'metric' ? 'Metric → Imperial' : 'Imperial → Metric'}
+                </Button>
+              </div>
+            )}
           </div>
         </SettingSection>
       )}

--- a/src/utils/units.js
+++ b/src/utils/units.js
@@ -1,0 +1,33 @@
+// Unit conversion helpers — all store SI/metric internally, convert for display
+
+export const POT_SIZES = {
+  metric: [
+    { value: 'small',  label: 'Small (< 15 cm)' },
+    { value: 'medium', label: 'Medium (15–25 cm)' },
+    { value: 'large',  label: 'Large (25–40 cm)' },
+    { value: 'xlarge', label: 'X-Large (> 40 cm)' },
+  ],
+  imperial: [
+    { value: 'small',  label: 'Small (< 6 in)' },
+    { value: 'medium', label: 'Medium (6–10 in)' },
+    { value: 'large',  label: 'Large (10–16 in)' },
+    { value: 'xlarge', label: 'X-Large (> 16 in)' },
+  ],
+}
+
+export function formatLength(cm, unitSystem) {
+  if (unitSystem === 'imperial') {
+    const inches = cm / 2.54
+    return `${inches % 1 === 0 ? inches : inches.toFixed(1)} in`
+  }
+  return `${cm} cm`
+}
+
+export function formatTemperatureC(tempC, tempUnit) {
+  if (tempUnit === 'fahrenheit') return `${Math.round(tempC * 9 / 5 + 32)}°F`
+  return `${Math.round(tempC)}°C`
+}
+
+export function unitSystemLabel(system) {
+  return system === 'imperial' ? 'Imperial (in, fl oz)' : 'Metric (cm, ml)'
+}


### PR DESCRIPTION
## Summary

Closes #230

- **`useUnitSystem` hook**: auto-detects metric vs imperial from `navigator.language` (US/Liberia/Myanmar → imperial), persists in `localStorage`
- **`src/utils/units.js`**: `formatLength`, `formatTemperatureC`, `POT_SIZES` (per system), `unitSystemLabel`
- **PlantContext**: exposes `unitSystem` alongside existing `tempUnit`
- **Settings → Preferences → Units section**: new "Measurements" row with Metric ↔ Imperial toggle, sits below the existing Temperature toggle
- **PlantModal**: pot size dropdown labels reflect system (cm vs in); height/width form labels, input placeholders, and growth chart y-axis all update immediately; entering measurements in imperial converts to cm before saving (backend always stores SI)
- **ForecastPage**: hot/cold threshold messages show user's preferred unit (30°C or 86°F, 10°C or 50°F)
- **13 new tests** in `units.test.js` covering all helpers and `POT_SIZES` invariants

## Test plan

- [ ] `npx vitest run`: 652 tests pass
- [ ] `npm run test:coverage`: all thresholds green (45% statements, 44% branches)
- [ ] Settings → Preferences: toggle "Measurements" between Metric and Imperial; pot size dropdown in plant modal updates labels immediately
- [ ] ForecastPage outdoor impact section shows °C or °F threshold matching chosen unit

https://claude.ai/code/session_01LJtkErcU1Ga97NMekh2NpY