### PR TITLE
feat(#247): AI pest & disease diagnosis with structured Gemini response

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1989,30 +1989,94 @@ app.post('/recommend-fertiliser', async (req, res) => {
 
 // ── Plant diagnostic photo analysis ──────────────────────────────────────────
 
-const DIAGNOSTIC_PROMPT = `Analyse this photo of a plant issue and respond ONLY with valid JSON:
+const DIAGNOSE_SCHEMA = {
+  type: SchemaType.OBJECT,
+  properties: {
+    diagnoses: {
+      type: SchemaType.ARRAY,
+      items: {
+        type: SchemaType.OBJECT,
+        properties: {
+          name:       { type: SchemaType.STRING },
+          confidence: { type: SchemaType.NUMBER },
+          category:   { type: SchemaType.STRING },
+          evidence:   { type: SchemaType.ARRAY, items: { type: SchemaType.STRING } },
+          severity:   { type: SchemaType.STRING },
+        },
+        required: ['name', 'confidence', 'category', 'evidence', 'severity'],
+      },
+    },
+    treatments: {
+      type: SchemaType.ARRAY,
+      items: {
+        type: SchemaType.OBJECT,
+        properties: {
+          step:            { type: SchemaType.INTEGER },
+          action:          { type: SchemaType.STRING },
+          urgency:         { type: SchemaType.STRING },
+          safeForEdibles:  { type: SchemaType.BOOLEAN },
+          productExamples: { type: SchemaType.ARRAY, items: { type: SchemaType.STRING } },
+        },
+        required: ['step', 'action', 'urgency', 'safeForEdibles'],
+      },
+    },
+    preventiveCare: { type: SchemaType.ARRAY, items: { type: SchemaType.STRING } },
+    escalation: {
+      type: SchemaType.OBJECT,
+      properties: {
+        consultExpert: { type: SchemaType.BOOLEAN },
+        urgentFlags:   { type: SchemaType.ARRAY, items: { type: SchemaType.STRING } },
+      },
+      required: ['consultExpert', 'urgentFlags'],
+    },
+  },
+  required: ['diagnoses', 'treatments', 'preventiveCare', 'escalation'],
+};
+
+function buildDiagnosticPrompt({ symptoms = [], contextTags = [], isEdible = false } = {}) {
+  const edibleRule = isEdible
+    ? '- This plant is EDIBLE. Every treatment MUST be food-safe and organic. Set safeForEdibles=true only for treatments that are safe to use on edible plants. Prefer neem oil, insecticidal soap, copper fungicide, diatomaceous earth, or physical removal over synthetic pesticides.'
+    : '';
+  const symptomCtx = symptoms.length ? `Reported symptoms: ${symptoms.join(', ')}.` : '';
+  const tagCtx = contextTags.length ? `Context: ${contextTags.join(', ')}.` : '';
+
+  return `Analyse this plant photo for pests, diseases, nutrient deficiencies, or environmental stress.
+${symptomCtx}
+${tagCtx}
+
+Return valid JSON matching this schema:
 {
-  "issue": "Brief description of the problem",
-  "severity": "mild|moderate|severe",
-  "cause": "Most likely cause",
-  "treatment": "Recommended treatment in 1-2 sentences",
-  "preventionTips": ["tip 1", "tip 2"]
+  "diagnoses": [
+    { "name": "Spider mites", "confidence": 0.82, "category": "pest", "evidence": ["stippled leaves", "fine webbing"], "severity": "moderate" }
+  ],
+  "treatments": [
+    { "step": 1, "action": "Rinse foliage with water", "urgency": "today", "safeForEdibles": true, "productExamples": [] }
+  ],
+  "preventiveCare": ["Increase humidity to 50%+"],
+  "escalation": { "consultExpert": false, "urgentFlags": [] }
 }
 Rules:
-- Look for signs of disease, pests, nutrient deficiency, overwatering, underwatering, sunburn, etc.
-- severity must be exactly one of: mild, moderate, severe
-- preventionTips should have 2 items
+- diagnoses: rank by confidence descending; confidence is 0.0–1.0; category must be one of: pest, disease, deficiency, environmental
+- severity must be one of: mild, moderate, severe
+- treatments: numbered steps in recommended order; urgency must be one of: today, this-week, ongoing
+- escalation.consultExpert: true when top confidence < 0.5 or severity is severe and cause is unclear
+${edibleRule}
 - Respond with JSON only, no markdown or extra text`;
+}
 
-app.post('/plants/:id/diagnostic', requireUser, async (req, res) => {
+app.post('/plants/:id/diagnostic', requireUser, checkQuota('ai_analyses', countAiAnalysesForReq), async (req, res) => {
   try {
     const ref = userPlants(req.userId).doc(req.params.id);
     const doc = await ref.get();
     if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
 
-    const { imageBase64, mimeType } = req.body;
+    const { imageBase64, mimeType, symptoms, contextTags } = req.body;
     if (!imageBase64 || !mimeType) {
       return res.status(400).json({ error: 'imageBase64 and mimeType are required' });
     }
+
+    const plantData = doc.data();
+    const isEdible = (contextTags || []).includes('edible') || (plantData.category === 'edible');
 
     // Upload diagnostic image to GCS
     const ext = mimeType.split('/')[1] || 'jpg';
@@ -2022,35 +2086,55 @@ app.post('/plants/:id/diagnostic', requireUser, async (req, res) => {
     await file.save(buffer, { contentType: mimeType, resumable: false });
     const publicUrl = `https://storage.googleapis.com/${IMAGES_BUCKET}/${filename}`;
 
-    // Analyse with Gemini
+    // Analyse with Gemini using structured schema
     let analysis = null;
     try {
+      const prompt = buildDiagnosticPrompt({ symptoms, contextTags, isEdible });
       const result = await geminiWithRetry({
         contents: [{
           role: 'user',
           parts: [
             { inlineData: { mimeType, data: imageBase64 } },
-            { text: DIAGNOSTIC_PROMPT },
+            { text: prompt },
           ],
         }],
-        generationConfig: { temperature: 0.1, responseMimeType: 'application/json' },
+        generationConfig: {
+          temperature: 0.1,
+          responseMimeType: 'application/json',
+          responseSchema: DIAGNOSE_SCHEMA,
+          maxOutputTokens: 2048,
+        },
       });
       analysis = parseGeminiJson(result.response.text());
     } catch (err) {
-      console.error('Diagnostic analysis failed:', err.message);
+      log.warn('Diagnostic analysis failed', { error: err.message });
     }
 
-    // Append to photoLog
-    const existing = doc.data();
-    const photoLog = [...(existing.photoLog || [])];
-    const entry = { url: publicUrl, date: new Date().toISOString(), type: 'diagnostic', analysis };
-    photoLog.push(entry);
+    // Persist diagnosis to dedicated subcollection for tracking
+    const diagnosisId = crypto.randomUUID();
+    const diagnosisRef = userPlants(req.userId).doc(req.params.id)
+      .collection('diagnoses').doc(diagnosisId);
+    const diagnosisEntry = {
+      id: diagnosisId,
+      imageUrl: publicUrl,
+      analysis,
+      symptoms: symptoms || [],
+      contextTags: contextTags || [],
+      createdAt: new Date().toISOString(),
+    };
+    await diagnosisRef.set(diagnosisEntry);
 
+    // Also append to photoLog for timeline display
+    const photoLog = [...(plantData.photoLog || [])];
+    const photoEntry = { url: publicUrl, date: new Date().toISOString(), type: 'diagnostic', analysis, diagnosisId };
+    photoLog.push(photoEntry);
     await ref.set({ photoLog, updatedAt: new Date().toISOString() }, { merge: true });
 
-    res.status(200).json(entry);
+    try { await billing.incrementAiAnalyses(db, req.userId); } catch (e) { log.warn('ai-usage increment failed', { error: e.message }); }
+
+    res.status(200).json({ ...photoEntry, diagnosisId });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    res.status(err.status || 500).json({ error: err.message });
   }
 });
 

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -2030,6 +2030,18 @@ describe('gcsPath — via DELETE /plants/:id', () => {
 
 // ── POST /plants/:id/diagnostic ─────────────────────────────────────────────
 
+const MOCK_DIAGNOSIS = {
+  diagnoses: [
+    { name: 'Spider mites', confidence: 0.85, category: 'pest', evidence: ['stippled leaves', 'fine webbing'], severity: 'moderate' },
+  ],
+  treatments: [
+    { step: 1, action: 'Rinse foliage with water', urgency: 'today', safeForEdibles: true, productExamples: [] },
+    { step: 2, action: 'Apply insecticidal soap', urgency: 'this-week', safeForEdibles: true, productExamples: ['Safer Brand Insect Killing Soap'] },
+  ],
+  preventiveCare: ['Increase humidity to 50%+', 'Inspect plants weekly'],
+  escalation: { consultExpert: false, urgentFlags: [] },
+};
+
 describe('POST /plants/:id/diagnostic', () => {
   it('returns 404 for non-existent plant', async () => {
     const res = await request(app)
@@ -2052,6 +2064,80 @@ describe('POST /plants/:id/diagnostic', () => {
       .post('/plants/p1/diagnostic').set('Authorization', authHeader())
       .send({ imageBase64: 'abc' });
     expect(res.status).toBe(400);
+  });
+
+  it('returns structured diagnosis with diagnoses, treatments, preventiveCare, and escalation', async () => {
+    store[plantPath('p1')] = { name: 'Monstera', createdAt: '2026-01-01T00:00:00.000Z' };
+    geminiGenerateFn = async () => ({ response: { text: () => JSON.stringify(MOCK_DIAGNOSIS) } });
+
+    const res = await request(app)
+      .post('/plants/p1/diagnostic').set('Authorization', authHeader())
+      .send({ imageBase64: 'aGVsbG8=', mimeType: 'image/jpeg' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.analysis.diagnoses).toHaveLength(1);
+    expect(res.body.analysis.diagnoses[0].name).toBe('Spider mites');
+    expect(res.body.analysis.diagnoses[0].confidence).toBe(0.85);
+    expect(res.body.analysis.treatments).toHaveLength(2);
+    expect(res.body.analysis.preventiveCare).toHaveLength(2);
+    expect(res.body.analysis.escalation.consultExpert).toBe(false);
+    expect(res.body.diagnosisId).toBeTruthy();
+    expect(res.body.type).toBe('diagnostic');
+  });
+
+  it('persists diagnosis entry to the diagnoses subcollection', async () => {
+    store[plantPath('p1')] = { name: 'Monstera', createdAt: '2026-01-01T00:00:00.000Z' };
+    geminiGenerateFn = async () => ({ response: { text: () => JSON.stringify(MOCK_DIAGNOSIS) } });
+
+    const res = await request(app)
+      .post('/plants/p1/diagnostic').set('Authorization', authHeader())
+      .send({ imageBase64: 'aGVsbG8=', mimeType: 'image/jpeg' });
+
+    expect(res.status).toBe(200);
+    const diagnosisId = res.body.diagnosisId;
+    const diagnosisKey = Object.keys(store).find(k => k.includes('/diagnoses/'));
+    expect(diagnosisKey).toBeTruthy();
+    const savedDiagnosis = store[diagnosisKey];
+    expect(savedDiagnosis.id).toBe(diagnosisId);
+    expect(savedDiagnosis.analysis.diagnoses[0].name).toBe('Spider mites');
+  });
+
+  it('appends to photoLog with diagnosisId', async () => {
+    store[plantPath('p1')] = { name: 'Fern', photoLog: [], createdAt: '2026-01-01T00:00:00.000Z' };
+    geminiGenerateFn = async () => ({ response: { text: () => JSON.stringify(MOCK_DIAGNOSIS) } });
+
+    await request(app)
+      .post('/plants/p1/diagnostic').set('Authorization', authHeader())
+      .send({ imageBase64: 'aGVsbG8=', mimeType: 'image/jpeg' });
+
+    const saved = store[plantPath('p1')];
+    expect(saved.photoLog).toHaveLength(1);
+    expect(saved.photoLog[0].type).toBe('diagnostic');
+    expect(saved.photoLog[0].diagnosisId).toBeTruthy();
+  });
+
+  it('propagates contextTags and treats edible-tagged plant with food-safe rule', async () => {
+    store[plantPath('p1')] = { name: 'Basil', category: 'edible', createdAt: '2026-01-01T00:00:00.000Z' };
+    let capturedContents;
+    geminiGenerateFn = async (params) => {
+      capturedContents = params.contents;
+      return { response: { text: () => JSON.stringify(MOCK_DIAGNOSIS) } };
+    };
+
+    await request(app)
+      .post('/plants/p1/diagnostic').set('Authorization', authHeader())
+      .send({ imageBase64: 'aGVsbG8=', mimeType: 'image/jpeg', contextTags: ['edible'] });
+
+    const promptText = capturedContents[0].parts[1].text;
+    expect(promptText).toContain('EDIBLE');
+    expect(promptText).toContain('food-safe');
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app)
+      .post('/plants/p1/diagnostic')
+      .send({ imageBase64: 'abc', mimeType: 'image/jpeg' });
+    expect(res.status).toBe(401);
   });
 });
 

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -78,12 +78,12 @@ export const plantsApi = {
   wateringRecommendation: (id) => request(`/plants/${id}/watering-recommendation`),
   healthPrediction: (id) => request(`/plants/${id}/health-prediction`),
   anomaly: (id) => request(`/plants/${id}/anomaly`),
-  diagnostic: async (id, file) => {
+  diagnostic: async (id, file, { symptoms = [], contextTags = [] } = {}) => {
     const base64 = await fileToBase64(file)
     const [, data] = base64.split(',')
     return request(`/plants/${id}/diagnostic`, {
       method: 'POST',
-      body: JSON.stringify({ imageBase64: data, mimeType: file.type }),
+      body: JSON.stringify({ imageBase64: data, mimeType: file.type, symptoms, contextTags }),
     })
   },
   deletePhoto: (id, url) => request(`/plants/${id}/photos`, { method: 'DELETE', body: JSON.stringify({ url }) }),

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -156,50 +156,104 @@ function GrowthUpload({ plantId, onComplete }) {
   )
 }
 
-function DiagnosticUpload({ plantId, onComplete }) {
+const SEVERITY_VARIANT = { severe: 'danger', moderate: 'warning', mild: 'info' }
+const URGENCY_VARIANT  = { today: 'danger', 'this-week': 'warning', ongoing: 'secondary' }
+
+function DiagnosticUpload({ plantId, plant, onComplete }) {
   const [uploading, setUploading] = useState(false)
-  const [result, setResult] = useState(null)
-  const [error, setError] = useState(null)
+  const [result, setResult]       = useState(null)
+  const [error, setError]         = useState(null)
+  const [checkedSteps, setCheckedSteps] = useState({})
   const fileRef = useRef(null)
+
+  const isEdible = plant?.category === 'edible'
+  const contextTags = [
+    ...(isEdible ? ['edible'] : []),
+    ...(plant?.plantedIn === 'ground' || plant?.plantedIn === 'garden-bed' ? ['outdoor'] : []),
+  ]
 
   const handleFile = async (file) => {
     if (!file?.type.startsWith('image/')) return
-    setUploading(true); setError(null); setResult(null)
+    setUploading(true); setError(null); setResult(null); setCheckedSteps({})
     try {
-      const data = await plantsApi.diagnostic(plantId, file)
+      const data = await plantsApi.diagnostic(plantId, file, { contextTags })
       setResult(data)
       onComplete?.(data)
     } catch (err) { setError(err.message) }
     finally { setUploading(false) }
   }
 
+  const toggleStep = (i) => setCheckedSteps(prev => ({ ...prev, [i]: !prev[i] }))
+
+  const analysis = result?.analysis
+  const topDiagnosis = analysis?.diagnoses?.[0]
+
   return (
     <div>
       <Button variant="outline-warning" size="sm" onClick={() => fileRef.current?.click()} disabled={uploading}>
         {uploading ? <Spinner size="sm" className="me-1" /> : <svg className="sa-icon me-1" style={{ width: 12, height: 12 }}><use href="/icons/sprite.svg#search"></use></svg>}
-        {uploading ? 'Analysing...' : 'Diagnose Issue'}
+        {uploading ? 'Analysing…' : 'Diagnose Issue'}
       </Button>
       <input ref={fileRef} type="file" accept="image/*" capture="environment" className="d-none"
         onChange={(e) => { if (e.target.files?.[0]) handleFile(e.target.files[0]); e.target.value = '' }} />
 
       {error && <p className="text-danger fs-xs mt-2">{error}</p>}
 
-      {result?.analysis && (
-        <div className="mt-2 p-2 rounded border bg-body-tertiary">
-          <div className="d-flex align-items-center gap-2 mb-1">
-            <Badge bg={result.analysis.severity === 'severe' ? 'danger' : result.analysis.severity === 'moderate' ? 'warning' : 'info'}>
-              {result.analysis.severity}
-            </Badge>
-            <strong className="fs-sm">{result.analysis.issue}</strong>
+      {analysis && (
+        <div className="mt-2 rounded border bg-body-tertiary">
+          {/* Diagnoses list */}
+          <div className="p-2 border-bottom">
+            <p className="fw-semibold fs-xs text-muted mb-1 text-uppercase">Diagnoses</p>
+            {analysis.diagnoses?.map((dx, i) => (
+              <div key={i} className="d-flex align-items-start gap-2 mb-1">
+                <Badge bg={SEVERITY_VARIANT[dx.severity] || 'secondary'} className="mt-1 flex-shrink-0">{dx.severity}</Badge>
+                <div>
+                  <span className="fs-sm fw-semibold">{dx.name}</span>
+                  <span className="fs-xs text-muted ms-1">({Math.round(dx.confidence * 100)}% confidence)</span>
+                  {dx.evidence?.length > 0 && (
+                    <div className="d-flex flex-wrap gap-1 mt-1">
+                      {dx.evidence.map((e, j) => <Badge key={j} bg="light" text="dark" className="fw-normal">{e}</Badge>)}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
           </div>
-          <p className="fs-xs text-muted mb-1"><strong>Cause:</strong> {result.analysis.cause}</p>
-          <p className="fs-xs text-muted mb-1"><strong>Treatment:</strong> {result.analysis.treatment}</p>
-          {result.analysis.preventionTips?.length > 0 && (
-            <ul className="list-unstyled mb-0">
-              {result.analysis.preventionTips.map((tip, i) => (
-                <li key={i} className="fs-xs text-muted">• {tip}</li>
+
+          {/* Treatment checklist */}
+          {analysis.treatments?.length > 0 && (
+            <div className="p-2 border-bottom">
+              <p className="fw-semibold fs-xs text-muted mb-1 text-uppercase">Treatment plan</p>
+              {analysis.treatments.map((t, i) => (
+                <div key={i} className="d-flex align-items-start gap-2 mb-1">
+                  <Form.Check type="checkbox" id={`treatment-${plantId}-${i}`} checked={!!checkedSteps[i]}
+                    onChange={() => toggleStep(i)} className="flex-shrink-0 mt-1" />
+                  <div className={checkedSteps[i] ? 'text-decoration-line-through text-muted' : ''}>
+                    <span className="fs-xs">{t.action}</span>
+                    <div className="d-flex gap-1 mt-1">
+                      <Badge bg={URGENCY_VARIANT[t.urgency] || 'secondary'} className="fw-normal">{t.urgency}</Badge>
+                      {isEdible && <Badge bg={t.safeForEdibles ? 'success' : 'danger'} className="fw-normal">{t.safeForEdibles ? 'food-safe' : 'not edible-safe'}</Badge>}
+                    </div>
+                  </div>
+                </div>
               ))}
-            </ul>
+            </div>
+          )}
+
+          {/* Preventive care */}
+          {analysis.preventiveCare?.length > 0 && (
+            <div className="p-2 border-bottom">
+              <p className="fw-semibold fs-xs text-muted mb-1 text-uppercase">Preventive care</p>
+              {analysis.preventiveCare.map((tip, i) => <p key={i} className="fs-xs text-muted mb-0">• {tip}</p>)}
+            </div>
+          )}
+
+          {/* Escalation */}
+          {analysis.escalation?.consultExpert && (
+            <div className="p-2">
+              <Badge bg="danger" className="me-1">Expert advice recommended</Badge>
+              {analysis.escalation.urgentFlags?.map((f, i) => <span key={i} className="fs-xs text-danger ms-1">{f}</span>)}
+            </div>
           )}
         </div>
       )}
@@ -1077,9 +1131,10 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
                   if (result?.maturity) update('maturity', result.maturity)
                   if (result?.health) update('health', result.health)
                 }} />
-                <DiagnosticUpload plantId={plant.id} onComplete={(result) => {
-                  if (result?.analysis?.severity === 'severe') update('health', 'Poor')
-                  else if (result?.analysis?.severity === 'moderate') update('health', 'Fair')
+                <DiagnosticUpload plantId={plant.id} plant={plant} onComplete={(result) => {
+                  const topSeverity = result?.analysis?.diagnoses?.[0]?.severity
+                  if (topSeverity === 'severe') update('health', 'Poor')
+                  else if (topSeverity === 'moderate') update('health', 'Fair')
                 }} />
               </div>
 


### PR DESCRIPTION
## Summary

Closes #247

Upgrades the plant diagnostic endpoint from a basic single-issue analysis to a fully structured, multi-diagnosis schema powered by Gemini.

- **Backend** (`POST /plants/:id/diagnostic`): new `DIAGNOSE_SCHEMA` with ranked `diagnoses[]` (confidence, category, evidence, severity), step-by-step `treatments[]` (urgency, `safeForEdibles`), `preventiveCare[]`, and `escalation` (consultExpert flag). Edible plants trigger a food-safe-only treatment constraint. Quota-gated via existing `ai_analyses` allowance. Diagnoses persisted to `plants/{id}/diagnoses/{dxId}` subcollection for outbreak tracking.
- **Frontend** (`DiagnosticUpload` in `PlantModal`): renders ranked diagnoses with confidence bars and evidence chips, interactive treatment checklist with urgency badges, food-safe indicator for edible plants, preventive care tips, and expert escalation alert. Passes `contextTags` (edible, outdoor) derived from the plant record.
- **API client**: `plantsApi.diagnostic()` now accepts `{ symptoms, contextTags }` options.
- **Tests**: 7 new backend tests covering structured response, subcollection persistence, photoLog attachment, edible-plant prompt injection, and auth guard. All 423 backend + 665 frontend tests pass; backend coverage 84% stmts / 73% branches — above thresholds.

## Test plan

- [ ] Upload a photo to the Diagnose Issue button on a non-edible plant → ranked diagnoses with confidence appear, treatments are a checkable list
- [ ] Repeat on a plant with `category: edible` → treatments show "food-safe" / "not edible-safe" badges; prompt injected `EDIBLE` rule verified in logs
- [ ] Mark treatment steps as checked → strikethrough applied
- [ ] Diagnosis entry appears in `plants/{id}/diagnoses` subcollection in Firestore
- [ ] `POST /plants/:id/diagnostic` without auth → 401; missing `imageBase64` → 400