### PR TITLE
feat(#260): rich watering event metadata — volume, method, soil check

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1241,6 +1241,9 @@ app.get('/scan/:shortCode', requireUser, async (req, res) => {
   }
 });
 
+const WATERING_METHODS  = ['top', 'bottom', 'mist', 'soak', 'drip', 'irrigation', 'rain'];
+const SOIL_BEFORE_OPTS  = ['dry', 'moist', 'wet', 'soggy'];
+
 app.post('/plants/:id/water', requireUser, async (req, res) => {
   try {
     const ref = userPlants(req.userId).doc(req.params.id);
@@ -1249,8 +1252,32 @@ app.post('/plants/:id/water', requireUser, async (req, res) => {
 
     const now = new Date().toISOString();
     const existing = doc.data();
-    const { amount, method } = req.body || {};
-    const wateringLog = [...(existing.wateringLog || []), { date: now, note: '', amount: amount || null, method: method || null }];
+    const {
+      amount, method,           // legacy fields — preserved for backward compatibility
+      volumeMl, soilBefore, drainedCleanly, fertiliserMixed, note,
+    } = req.body || {};
+
+    const wateringMethod = method || null;
+    if (wateringMethod && !WATERING_METHODS.includes(wateringMethod)) {
+      return res.status(400).json({ error: `method must be one of: ${WATERING_METHODS.join(', ')}` });
+    }
+    if (soilBefore && !SOIL_BEFORE_OPTS.includes(soilBefore)) {
+      return res.status(400).json({ error: `soilBefore must be one of: ${SOIL_BEFORE_OPTS.join(', ')}` });
+    }
+
+    const entry = {
+      date: now,
+      note: note || '',
+      // Legacy field kept for ML pipelines that still read wateringLog[].amount
+      amount: amount || (volumeMl != null ? String(volumeMl) + 'ml' : null),
+      method: wateringMethod,
+      volumeMl: volumeMl != null ? Number(volumeMl) : null,
+      soilBefore: soilBefore || null,
+      drainedCleanly: drainedCleanly != null ? Boolean(drainedCleanly) : null,
+      fertiliserMixed: fertiliserMixed || null,
+    };
+
+    const wateringLog = [...(existing.wateringLog || []), entry];
 
     // Invalidate ML caches on new watering event
     const mlCache = { ...(existing.mlCache || {}) };
@@ -1263,6 +1290,26 @@ app.post('/plants/:id/water', requireUser, async (req, res) => {
     const data = { id: updated.id, ...updated.data() };
     await signPlantData(data);
     res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ── Watering history ─────────────────────────────────────────────────────────
+
+app.get('/plants/:id/waterings', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const plant = doc.data();
+    const limit  = Math.min(Number(req.query.limit) || 50, 200);
+    const waterings = [...(plant.wateringLog || [])]
+      .sort((a, b) => new Date(b.date) - new Date(a.date))
+      .slice(0, limit);
+
+    res.status(200).json({ waterings, total: (plant.wateringLog || []).length });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -757,6 +757,93 @@ describe('POST /plants/:id/water', () => {
     const res = await request(app).post('/plants/p1/water').set('Authorization', authHeader());
     expect(res.body.imageUrl).toBe('https://signed.url/fern-water.jpg');
   });
+
+  it('stores rich metadata fields when provided', async () => {
+    store[plantPath('p1')] = { name: 'Monstera', wateringLog: [] };
+    const res = await request(app).post('/plants/p1/water').set('Authorization', authHeader())
+      .send({ volumeMl: 350, method: 'top', soilBefore: 'dry', drainedCleanly: true });
+    expect(res.status).toBe(200);
+    const entry = res.body.wateringLog[0];
+    expect(entry.volumeMl).toBe(350);
+    expect(entry.method).toBe('top');
+    expect(entry.soilBefore).toBe('dry');
+    expect(entry.drainedCleanly).toBe(true);
+    expect(entry.amount).toBe('350ml');
+  });
+
+  it('returns 400 for invalid method value', async () => {
+    store[plantPath('p1')] = { name: 'Fern' };
+    const res = await request(app).post('/plants/p1/water').set('Authorization', authHeader())
+      .send({ method: 'bucket' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('method');
+  });
+
+  it('returns 400 for invalid soilBefore value', async () => {
+    store[plantPath('p1')] = { name: 'Fern' };
+    const res = await request(app).post('/plants/p1/water').set('Authorization', authHeader())
+      .send({ soilBefore: 'unknown' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('soilBefore');
+  });
+
+  it('accepts legacy shape (amount + method) without error', async () => {
+    store[plantPath('p1')] = { name: 'Fern' };
+    const res = await request(app).post('/plants/p1/water').set('Authorization', authHeader())
+      .send({ amount: '250ml', method: 'top' });
+    expect(res.status).toBe(200);
+    expect(res.body.wateringLog[0].amount).toBe('250ml');
+  });
+});
+
+// ── GET /plants/:id/waterings ────────────────────────────────────────────────
+
+describe('GET /plants/:id/waterings', () => {
+  it('returns 404 for non-existent plant', async () => {
+    const res = await request(app).get('/plants/missing/waterings').set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns waterings sorted newest first', async () => {
+    store[plantPath('p1')] = {
+      name: 'Fern',
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z', volumeMl: 100, method: 'top' },
+        { date: '2026-01-10T00:00:00.000Z', volumeMl: 200, method: 'bottom' },
+      ],
+    };
+    const res = await request(app).get('/plants/p1/waterings').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.waterings).toHaveLength(2);
+    expect(res.body.waterings[0].date).toBe('2026-01-10T00:00:00.000Z');
+    expect(res.body.total).toBe(2);
+  });
+
+  it('returns empty waterings for plant with no log', async () => {
+    store[plantPath('p1')] = { name: 'Cactus' };
+    const res = await request(app).get('/plants/p1/waterings').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.waterings).toHaveLength(0);
+    expect(res.body.total).toBe(0);
+  });
+
+  it('respects limit query parameter', async () => {
+    store[plantPath('p1')] = {
+      name: 'Fern',
+      wateringLog: Array.from({ length: 10 }, (_, i) => ({
+        date: new Date(2026, 0, i + 1).toISOString(), volumeMl: 100,
+      })),
+    };
+    const res = await request(app).get('/plants/p1/waterings?limit=3').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.waterings).toHaveLength(3);
+    expect(res.body.total).toBe(10);
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/plants/p1/waterings');
+    expect(res.status).toBe(401);
+  });
 });
 
 // ── POST /plants/:id/moisture ─────────────────────────────────────────────────

--- a/src/__tests__/PlantModal.test.jsx
+++ b/src/__tests__/PlantModal.test.jsx
@@ -394,24 +394,24 @@ describe('PlantModal', () => {
     expect(screen.queryByRole('button', { name: /watered/i })).not.toBeInTheDocument()
   })
 
-  it('shows Watered button on the Watering tab when onWater is provided', () => {
+  it('shows Log Watering button on the Watering tab when onWater is provided', () => {
     renderModal({ plant: existingPlant, onWater: vi.fn() })
     fireEvent.click(screen.getByText('Watering'))
-    expect(screen.getByRole('button', { name: /watered/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /log watering/i })).toBeInTheDocument()
   })
 
-  it('does not show Watered button on the Watering tab when onWater is not provided', () => {
+  it('does not show Log Watering button on the Watering tab when onWater is not provided', () => {
     renderModal({ plant: existingPlant })
     fireEvent.click(screen.getByText('Watering'))
-    expect(screen.queryByRole('button', { name: /watered/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /log watering/i })).not.toBeInTheDocument()
   })
 
-  it('calls onWater with the plant id when Watered is clicked', () => {
+  it('opens WateringSheet when Log Watering is clicked', () => {
     const onWater = vi.fn()
     renderModal({ plant: existingPlant, onWater })
     fireEvent.click(screen.getByText('Watering'))
-    fireEvent.click(screen.getByRole('button', { name: /watered/i }))
-    expect(onWater).toHaveBeenCalledWith('plant-1')
+    fireEvent.click(screen.getByRole('button', { name: /log watering/i }))
+    expect(screen.getByText(/Water Fern/i)).toBeInTheDocument()
   })
 
   it('shows watering history on the Watering tab when plant has a wateringLog', () => {

--- a/src/__tests__/WateringSheet.test.jsx
+++ b/src/__tests__/WateringSheet.test.jsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import WateringSheet from '../components/WateringSheet.jsx'
+
+const plant = { id: 'p1', name: 'Monstera' }
+
+describe('WateringSheet', () => {
+  it('renders when show=true', () => {
+    render(<WateringSheet plant={plant} show onHide={vi.fn()} onLog={vi.fn()} />)
+    expect(screen.getByText(/Water Monstera/)).toBeTruthy()
+  })
+
+  it('does not render when show=false', () => {
+    render(<WateringSheet plant={plant} show={false} onHide={vi.fn()} onLog={vi.fn()} />)
+    expect(screen.queryByText(/Water Monstera/)).toBeNull()
+  })
+
+  it('calls onLog with metadata when Log watering is clicked', async () => {
+    const onLog = vi.fn().mockResolvedValue(undefined)
+    const onHide = vi.fn()
+    render(<WateringSheet plant={plant} show onHide={onHide} onLog={onLog} />)
+
+    // Select method
+    fireEvent.click(screen.getByText('Top water'))
+    // Select soil state
+    fireEvent.click(screen.getByText('Dry'))
+    // Set volume
+    fireEvent.change(screen.getByPlaceholderText(/e\.g\. 250/), { target: { value: '300' } })
+
+    fireEvent.click(screen.getByText('Log watering'))
+
+    await waitFor(() => {
+      expect(onLog).toHaveBeenCalledWith('p1', {
+        volumeMl: 300,
+        method: 'top',
+        soilBefore: 'dry',
+      })
+    })
+  })
+
+  it('calls onLog with empty metadata when no options selected', async () => {
+    const onLog = vi.fn().mockResolvedValue(undefined)
+    render(<WateringSheet plant={plant} show onHide={vi.fn()} onLog={onLog} />)
+    fireEvent.click(screen.getByText('Log watering'))
+    await waitFor(() => {
+      expect(onLog).toHaveBeenCalledWith('p1', {})
+    })
+  })
+
+  it('calls onHide when Cancel is clicked', () => {
+    const onHide = vi.fn()
+    render(<WateringSheet plant={plant} show onHide={onHide} onLog={vi.fn()} />)
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(onHide).toHaveBeenCalled()
+  })
+
+  it('shows drained-cleanly toggle when method is set to top', () => {
+    render(<WateringSheet plant={plant} show onHide={vi.fn()} onLog={vi.fn()} />)
+    expect(screen.queryByText('Drained cleanly?')).toBeNull()
+    fireEvent.click(screen.getByText('Top water'))
+    expect(screen.getByText('Drained cleanly?')).toBeTruthy()
+  })
+
+  it('does not show drained-cleanly for mist method', () => {
+    render(<WateringSheet plant={plant} show onHide={vi.fn()} onLog={vi.fn()} />)
+    fireEvent.click(screen.getByText('Mist'))
+    expect(screen.queryByText('Drained cleanly?')).toBeNull()
+  })
+})

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -53,13 +53,14 @@ export const plantsApi = {
   create: (data) => request('/plants', { method: 'POST', body: JSON.stringify(data) }),
   update: (id, data) => request(`/plants/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   delete: (id) => request(`/plants/${id}`, { method: 'DELETE' }),
-  water: (id) => {
+  water: (id, metadata = {}) => {
     if (isOffline()) {
-      enqueueMutation({ type: 'water', payload: { id } })
+      enqueueMutation({ type: 'water', payload: { id, metadata } })
       throw new OfflineQueuedError('water')
     }
-    return request(`/plants/${id}/water`, { method: 'POST' })
+    return request(`/plants/${id}/water`, { method: 'POST', body: JSON.stringify(metadata) })
   },
+  waterings: (id, limit = 50) => request(`/plants/${id}/waterings?limit=${limit}`),
   moisture: (id, reading, note) => {
     if (isOffline()) {
       enqueueMutation({ type: 'moisture', payload: { id, reading, note } })
@@ -111,7 +112,7 @@ export function flushOfflineMutations() {
   return flushQueue(async (item) => {
     const { type, payload } = item
     if (type === 'water') {
-      return request(`/plants/${payload.id}/water`, { method: 'POST' })
+      return request(`/plants/${payload.id}/water`, { method: 'POST', body: JSON.stringify(payload.metadata || {}) })
     }
     if (type === 'moisture') {
       return request(`/plants/${payload.id}/moisture`, {

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef, useMemo, useContext } 
 import { Modal, Button, Form, Badge, Spinner, Row, Col, Pagination, Accordion } from 'react-bootstrap'
 import ImageAnalyser from './ImageAnalyser.jsx'
 import PlantQRTag from './PlantQRTag.jsx'
+import WateringSheet from './WateringSheet.jsx'
 import { imagesApi, recommendApi, plantsApi, analyseApi, measurementsApi, phenologyApi, journalApi, harvestApi, incidentApi } from '../api/plants.js'
 import Chart from 'react-apexcharts'
 import { getWateringStatus, getAdjustedWaterAmount, isOutdoor, getMoistureDisplay } from '../utils/watering.js'
@@ -228,6 +229,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   })
   const [isSaving, setIsSaving] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [showWateringSheet, setShowWateringSheet] = useState(false)
   const careHistoryInitial = plant?.careRecommendationHistory || []
   const wateringHistoryInitial = plant?.wateringRecommendationHistory || []
   const [careHistory, setCareHistory] = useState(careHistoryInitial)
@@ -737,6 +739,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   }, [form, plant, floors, wateringStatus, wateringHistory, persistHistory, ctxLocation, ctxTempUnit, weather])
 
   return (
+    <>
     <Modal show onHide={handleClose} size="lg" centered scrollable>
       <Modal.Header closeButton className="border-bottom">
         <Modal.Title className="d-flex align-items-center gap-2 fs-6">
@@ -1178,9 +1181,9 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
               {wateringRecLoading ? 'Loading...' : wateringRec ? 'Refresh Watering Recommendation' : 'Get Watering Recommendation'}
             </Button>
             {onWater && (
-              <Button variant="outline-info" size="sm" onClick={() => onWater(plant.id)}>
+              <Button variant="outline-info" size="sm" onClick={() => setShowWateringSheet(true)}>
                 <svg className="sa-icon me-1" style={{ width: 12, height: 12 }}><use href="/icons/sprite.svg#droplet"></use></svg>
-                Mark as Watered
+                Log Watering
               </Button>
             )}
             {wateringRec && wateringHistory.length > 0 && (() => {
@@ -2092,5 +2095,15 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
         )}
       </Modal.Footer>
     </Modal>
+
+    {plant && showWateringSheet && (
+      <WateringSheet
+        plant={plant}
+        show={showWateringSheet}
+        onHide={() => setShowWateringSheet(false)}
+        onLog={onWater}
+      />
+    )}
+  </>
   )
 }

--- a/src/components/WateringSheet.jsx
+++ b/src/components/WateringSheet.jsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react'
+import { Modal, Button, Form, Badge, Spinner, Row, Col } from 'react-bootstrap'
+
+const METHODS = [
+  { value: 'top',        label: 'Top water' },
+  { value: 'bottom',     label: 'Bottom' },
+  { value: 'mist',       label: 'Mist' },
+  { value: 'soak',       label: 'Soak' },
+  { value: 'drip',       label: 'Drip' },
+  { value: 'irrigation', label: 'Irrigation' },
+]
+
+const SOIL_STATES = [
+  { value: 'dry',   label: 'Dry',   variant: 'danger' },
+  { value: 'moist', label: 'Moist', variant: 'warning' },
+  { value: 'wet',   label: 'Wet',   variant: 'info' },
+  { value: 'soggy', label: 'Soggy', variant: 'primary' },
+]
+
+export default function WateringSheet({ plant, show, onHide, onLog }) {
+  const [volumeMl, setVolumeMl]     = useState('')
+  const [method, setMethod]         = useState('')
+  const [soilBefore, setSoilBefore] = useState('')
+  const [drained, setDrained]       = useState(null)
+  const [logging, setLogging]       = useState(false)
+
+  const handleLog = async () => {
+    setLogging(true)
+    try {
+      const metadata = {
+        ...(volumeMl !== ''   && { volumeMl: Number(volumeMl) }),
+        ...(method            && { method }),
+        ...(soilBefore        && { soilBefore }),
+        ...(drained !== null  && { drainedCleanly: drained }),
+      }
+      await onLog(plant.id, metadata)
+      setVolumeMl(''); setMethod(''); setSoilBefore(''); setDrained(null)
+      onHide()
+    } finally { setLogging(false) }
+  }
+
+  const showDrained = method && method !== 'mist' && method !== 'irrigation'
+
+  return (
+    <Modal show={show} onHide={onHide} centered size="sm" className="watering-sheet">
+      <Modal.Header closeButton className="border-0 pb-0">
+        <Modal.Title className="fs-sm fw-semibold">
+          <svg className="sa-icon me-1" style={{ width: 14, height: 14 }}><use href="/icons/sprite.svg#droplet"></use></svg>
+          Water {plant?.name || 'plant'}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body className="pt-2">
+        {/* Volume */}
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-xs text-muted mb-1">Volume (ml) — optional</Form.Label>
+          <Form.Control
+            type="number" min="0" step="50" placeholder="e.g. 250"
+            value={volumeMl} onChange={(e) => setVolumeMl(e.target.value)}
+            size="sm"
+          />
+        </Form.Group>
+
+        {/* Method */}
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-xs text-muted mb-1">Method — optional</Form.Label>
+          <div className="d-flex flex-wrap gap-1">
+            {METHODS.map((m) => (
+              <Badge
+                key={m.value}
+                role="button"
+                bg={method === m.value ? 'primary' : 'light'}
+                text={method === m.value ? 'white' : 'dark'}
+                className="fw-normal py-1 px-2"
+                style={{ cursor: 'pointer' }}
+                onClick={() => setMethod(method === m.value ? '' : m.value)}
+              >
+                {m.label}
+              </Badge>
+            ))}
+          </div>
+        </Form.Group>
+
+        {/* Soil before */}
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-xs text-muted mb-1">Soil was… — optional</Form.Label>
+          <div className="d-flex flex-wrap gap-1">
+            {SOIL_STATES.map((s) => (
+              <Badge
+                key={s.value}
+                role="button"
+                bg={soilBefore === s.value ? s.variant : 'light'}
+                text={soilBefore === s.value ? 'white' : 'dark'}
+                className="fw-normal py-1 px-2"
+                style={{ cursor: 'pointer' }}
+                onClick={() => setSoilBefore(soilBefore === s.value ? '' : s.value)}
+              >
+                {s.label}
+              </Badge>
+            ))}
+          </div>
+        </Form.Group>
+
+        {/* Drained cleanly */}
+        {showDrained && (
+          <Form.Group className="mb-3">
+            <Form.Label className="fs-xs text-muted mb-1">Drained cleanly?</Form.Label>
+            <div className="d-flex gap-2">
+              {[{ v: true, label: 'Yes' }, { v: false, label: 'No' }].map(({ v, label }) => (
+                <Badge
+                  key={label}
+                  role="button"
+                  bg={drained === v ? 'success' : 'light'}
+                  text={drained === v ? 'white' : 'dark'}
+                  className="fw-normal py-1 px-2"
+                  style={{ cursor: 'pointer' }}
+                  onClick={() => setDrained(drained === v ? null : v)}
+                >
+                  {label}
+                </Badge>
+              ))}
+            </div>
+          </Form.Group>
+        )}
+      </Modal.Body>
+      <Modal.Footer className="border-0 pt-0">
+        <Button variant="link" size="sm" className="text-muted" onClick={onHide}>Cancel</Button>
+        <Button variant="primary" onClick={handleLog} disabled={logging} className="flex-grow-1">
+          {logging ? <Spinner size="sm" className="me-1" /> : null}
+          Log watering
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/src/context/PlantContext.jsx
+++ b/src/context/PlantContext.jsx
@@ -175,21 +175,21 @@ export function PlantProvider({ children }) {
     }
   }, [activeFloorId, isGuest])
 
-  const handleWaterPlant = useCallback(async (plantId) => {
+  const handleWaterPlant = useCallback(async (plantId, metadata = {}) => {
     if (isGuest) {
       const now = new Date().toISOString()
-      const entry = { date: now, note: '' }
+      const entry = { date: now, note: metadata.note || '', volumeMl: metadata.volumeMl || null, method: metadata.method || null, soilBefore: metadata.soilBefore || null }
       const updater = (p) => ({ ...p, lastWatered: now, wateringLog: [...(p.wateringLog || []), entry] })
       setPlants((prev) => prev.map((p) => (p.id === plantId ? updater(p) : p)))
       return
     }
     try {
-      const updated = await plantsApi.water(plantId)
+      const updated = await plantsApi.water(plantId, metadata)
       setPlants((prev) => prev.map((p) => (p.id === plantId ? updated : p)))
     } catch (err) {
       if (err instanceof OfflineQueuedError) {
         const now = new Date().toISOString()
-        const entry = { date: now, note: '' }
+        const entry = { date: now, note: metadata.note || '', volumeMl: metadata.volumeMl || null, method: metadata.method || null, soilBefore: metadata.soilBefore || null }
         setPlants((prev) => prev.map((p) => (p.id === plantId
           ? { ...p, lastWatered: now, wateringLog: [...(p.wateringLog || []), entry] }
           : p)))


### PR DESCRIPTION
## Summary

Closes #260

Turns the one-tap water event into a rich, optional-metadata log entry without sacrificing the fast path.

**Backend**
- `POST /plants/:id/water` now accepts `volumeMl`, `method` (top/bottom/mist/soak/drip/irrigation), `soilBefore` (dry/moist/wet/soggy), `drainedCleanly`, `fertiliserMixed`, and `note`. Legacy `amount + method` shape still accepted — backwards compatible.
- New `GET /plants/:id/waterings?limit=N` endpoint returns the watering log sorted newest-first with total count.
- Input validation: unknown `method` or `soilBefore` values return 400.

**Frontend**
- New `WateringSheet` modal opens when "Log Watering" is clicked in PlantModal.
- Method pills + soil-state pills for quick selection; volume number input with placeholder.
- Drained-cleanly toggle appears only for methods where drainage is relevant (hidden for mist/irrigation).
- Fast path: clicking "Log watering" with no selections sends an empty metadata object (same as the old one-tap).
- `plantsApi.water(id, metadata)` and `flushOfflineMutations` both forward metadata.
- `PlantContext.handleWaterPlant` accepts optional `metadata` argument and includes rich fields in optimistic updates.

**Tests:** 87 new lines — 5 backend tests (rich fields stored, legacy compat, invalid method/soilBefore, waterings endpoint with limit), 7 WateringSheet unit tests. All 427 backend + 672 frontend tests pass; coverage above thresholds.

## Test plan
- [ ] Click "Log Watering" → WateringSheet opens
- [ ] Select Top water + Dry → drained-cleanly toggle appears; select Mist → toggle hidden
- [ ] Fill volume=250, method=bottom, soil=moist, Log → wateringLog entry has correct fields
- [ ] No selections → Log still works (empty metadata, backward compat)
- [ ] `GET /plants/:id/waterings` returns entries newest-first