### PR TITLE
feat(#255): data-viz redesign — color-blind safe palettes + ChartFrame wrapper

### DIFF
--- a/src/__tests__/ChartFrame.test.jsx
+++ b/src/__tests__/ChartFrame.test.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import ChartFrame from '../components/ChartFrame.jsx'
+
+describe('ChartFrame', () => {
+  it('renders title', () => {
+    render(<ChartFrame title="Test Chart"><div>chart</div></ChartFrame>)
+    expect(screen.getByText('Test Chart')).toBeTruthy()
+  })
+
+  it('renders unit badge when unit is provided', () => {
+    render(<ChartFrame title="T" unit="plants"><div /></ChartFrame>)
+    expect(screen.getByText('plants')).toBeTruthy()
+  })
+
+  it('renders children when not loading or empty', () => {
+    render(<ChartFrame title="T"><div data-testid="chart-content">chart</div></ChartFrame>)
+    expect(screen.getByTestId('chart-content')).toBeTruthy()
+  })
+
+  it('renders skeleton when loading=true', () => {
+    render(<ChartFrame title="T" loading><div data-testid="c">content</div></ChartFrame>)
+    expect(screen.queryByTestId('c')).toBeNull()
+  })
+
+  it('renders empty state when empty=true', () => {
+    render(<ChartFrame title="T" empty emptyText="Nothing here yet."><div>content</div></ChartFrame>)
+    expect(screen.getByText('Nothing here yet.')).toBeTruthy()
+    expect(screen.queryByText('content')).toBeNull()
+  })
+
+  it('uses default empty text when emptyText is not provided', () => {
+    render(<ChartFrame title="T" empty><div>content</div></ChartFrame>)
+    expect(screen.getByText(/No data yet/)).toBeTruthy()
+  })
+
+  it('renders help node in panel header', () => {
+    render(
+      <ChartFrame title="T" help={<span data-testid="help-node">Help</span>}>
+        <div />
+      </ChartFrame>
+    )
+    expect(screen.getByTestId('help-node')).toBeTruthy()
+  })
+
+  it('has aria-label from title for screen reader landmark', () => {
+    const { container } = render(<ChartFrame title="My Chart"><div /></ChartFrame>)
+    expect(container.querySelector('[aria-label="My Chart"]')).toBeTruthy()
+  })
+})

--- a/src/__tests__/ChartTheme.test.js
+++ b/src/__tests__/ChartTheme.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import {
+  OKABE_ITO,
+  HEALTH_COLORS,
+  getApexTheme,
+  getApexAxisDefaults,
+  heatmapColor,
+  categoricalColor,
+  divergingColor,
+} from '../charts/theme.js'
+
+describe('OKABE_ITO palette', () => {
+  it('has 7 entries', () => {
+    expect(OKABE_ITO).toHaveLength(7)
+  })
+
+  it('contains hex color strings', () => {
+    OKABE_ITO.forEach((c) => expect(c).toMatch(/^#[0-9A-Fa-f]{6}$/))
+  })
+})
+
+describe('HEALTH_COLORS', () => {
+  it('maps all four health states', () => {
+    expect(HEALTH_COLORS.Excellent).toBeTruthy()
+    expect(HEALTH_COLORS.Good).toBeTruthy()
+    expect(HEALTH_COLORS.Fair).toBeTruthy()
+    expect(HEALTH_COLORS.Poor).toBeTruthy()
+  })
+})
+
+describe('getApexTheme', () => {
+  it('returns dark mode when mode is dark', () => {
+    const t = getApexTheme('dark')
+    expect(t.mode).toBe('dark')
+  })
+
+  it('returns light mode by default', () => {
+    const t = getApexTheme('light')
+    expect(t.mode).toBe('light')
+  })
+})
+
+describe('getApexAxisDefaults', () => {
+  it('returns tooltip theme dark when mode is dark', () => {
+    const d = getApexAxisDefaults('dark')
+    expect(d.tooltip.theme).toBe('dark')
+  })
+
+  it('returns tooltip theme light for light mode', () => {
+    const d = getApexAxisDefaults('light')
+    expect(d.tooltip.theme).toBe('light')
+  })
+
+  it('includes xaxis and yaxis label styles', () => {
+    const d = getApexAxisDefaults('light')
+    expect(d.xaxis.labels.style.colors).toBeTruthy()
+    expect(d.yaxis.labels.style.colors).toBeTruthy()
+  })
+})
+
+describe('heatmapColor', () => {
+  it('returns css variable for count 0', () => {
+    expect(heatmapColor(0)).toContain('var(')
+  })
+
+  it('returns a hex color for count > 0', () => {
+    expect(heatmapColor(1)).toMatch(/^#/)
+    expect(heatmapColor(3)).toMatch(/^#/)
+  })
+
+  it('max count returns the darkest stop', () => {
+    const maxColor = heatmapColor(100, 100)
+    const twoColor = heatmapColor(1, 100)
+    expect(maxColor).not.toBe(twoColor)
+  })
+})
+
+describe('categoricalColor', () => {
+  it('returns first palette color at index 0', () => {
+    expect(categoricalColor(0)).toBe(OKABE_ITO[0])
+  })
+
+  it('wraps around for index >= 7', () => {
+    expect(categoricalColor(7)).toBe(OKABE_ITO[0])
+  })
+})
+
+describe('divergingColor', () => {
+  it('returns positive color for positive values above threshold', () => {
+    expect(divergingColor(2)).toMatch(/^#/)
+  })
+
+  it('returns negative color for negative values below threshold', () => {
+    const neg = divergingColor(-2)
+    const pos = divergingColor(2)
+    expect(neg).not.toBe(pos)
+  })
+
+  it('returns neutral color near zero', () => {
+    expect(divergingColor(0)).toMatch(/^#/)
+  })
+})

--- a/src/charts/theme.js
+++ b/src/charts/theme.js
@@ -1,0 +1,94 @@
+// Color-blind safe palettes for all charts.
+// Okabe-Ito (categorical, 7 stops) — safe across deuteranopia, protanopia, tritanopia.
+export const OKABE_ITO = ['#E69F00', '#56B4E9', '#009E73', '#F0E442', '#0072B2', '#D55E00', '#CC79A7']
+
+// Sequential palette (cividis-inspired, 5 stops) — safe blue→yellow, suitable for
+// heatmaps where saturation encodes magnitude.
+export const SEQUENTIAL = ['#F0E442', '#56B4E9', '#0072B2', '#004C9B', '#00305E']
+
+// Diverging palette (orange ↔ teal around zero) — for deviation charts.
+export const DIVERGING = {
+  negative: '#D55E00',
+  neutral:  '#CCCCCC',
+  positive: '#009E73',
+}
+
+// Health-specific palette (still color-blind friendly via shape/label redundancy).
+export const HEALTH_COLORS = {
+  Excellent: '#009E73',
+  Good:      '#56B4E9',
+  Fair:      '#E69F00',
+  Poor:      '#D55E00',
+  Unknown:   '#CCCCCC',
+}
+
+/**
+ * Builds an ApexCharts-compatible theme object for a given app theme mode and
+ * optional base color. Call this inside the `options` prop of react-apexcharts.
+ *
+ * @param {'light'|'dark'} mode   - from LayoutContext
+ * @returns {object}              - ApexCharts theme config
+ */
+export function getApexTheme(mode = 'light') {
+  const isDark = mode === 'dark'
+  return {
+    mode: isDark ? 'dark' : 'light',
+    monochrome: { enabled: false },
+    palette: 'palette1',
+  }
+}
+
+/**
+ * Shared ApexCharts axis/grid defaults that keep AA contrast in both modes.
+ *
+ * @param {'light'|'dark'} mode
+ */
+export function getApexAxisDefaults(mode = 'light') {
+  const isDark = mode === 'dark'
+  const labelColor  = isDark ? '#c9d1d9' : '#374151'
+  const gridColor   = isDark ? '#374151' : '#e5e7eb'
+  return {
+    xaxis: {
+      labels: { style: { colors: labelColor, fontSize: '11px' } },
+      axisBorder: { color: gridColor },
+      axisTicks: { color: gridColor },
+    },
+    yaxis: {
+      labels: { style: { colors: labelColor, fontSize: '11px' } },
+    },
+    grid: {
+      borderColor: gridColor,
+    },
+    tooltip: {
+      theme: isDark ? 'dark' : 'light',
+      style: { fontSize: '12px' },
+    },
+  }
+}
+
+/**
+ * Returns a single color from the Okabe-Ito palette by index (wraps around).
+ */
+export function categoricalColor(index) {
+  return OKABE_ITO[index % OKABE_ITO.length]
+}
+
+/**
+ * Maps a deviation value to a diverging color.
+ * Positive deviations → teal (good), negative → orange (concern), near-zero → grey.
+ */
+export function divergingColor(value, threshold = 0.5) {
+  if (value > threshold) return DIVERGING.positive
+  if (value < -threshold) return DIVERGING.negative
+  return DIVERGING.neutral
+}
+
+/**
+ * Maps an intensity value 0..max to a sequential heatmap color (5 stops).
+ * Returns the appropriate stop from SEQUENTIAL.
+ */
+export function heatmapColor(count, max = 3) {
+  if (count === 0) return 'var(--bs-tertiary-bg)'
+  const idx = Math.min(Math.floor((count / Math.max(max, 1)) * (SEQUENTIAL.length - 1)), SEQUENTIAL.length - 1)
+  return SEQUENTIAL[idx]
+}

--- a/src/components/ChartFrame.jsx
+++ b/src/components/ChartFrame.jsx
@@ -1,0 +1,83 @@
+import React from 'react'
+
+/**
+ * Consistent wrapper for all charts in the app.
+ * Handles empty state, loading skeleton, title/unit props, and ARIA.
+ *
+ * Props:
+ *   title       string   Panel header text
+ *   unit        string   Y-axis unit shown in the panel header badge (e.g. "days", "plants")
+ *   loading     bool     Show skeleton while data loads
+ *   empty       bool     Show empty state when no data
+ *   emptyText   string   Custom empty state copy
+ *   children    node     The <Chart /> (react-apexcharts) element
+ *   className   string   Additional classes on the panel root
+ *   help        node     Optional HelpTooltip element placed in panel header
+ */
+export default function ChartFrame({
+  title,
+  unit,
+  loading = false,
+  empty = false,
+  emptyText = 'No data yet — add plants and log care events to see charts.',
+  children,
+  className = '',
+  help,
+}) {
+  return (
+    <div className={`panel panel-icon ${className}`} role="region" aria-label={title}>
+      <div className="panel-hdr">
+        <span className="d-flex align-items-center gap-2">
+          {title}
+          {unit && (
+            <span className="badge bg-light text-muted fw-normal fs-xs border">{unit}</span>
+          )}
+        </span>
+        {help && <span className="ms-auto">{help}</span>}
+      </div>
+      <div className="panel-container">
+        <div className="panel-content">
+          {loading ? (
+            <ChartSkeleton />
+          ) : empty ? (
+            <ChartEmptyState text={emptyText} />
+          ) : (
+            children
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ChartSkeleton() {
+  return (
+    <div aria-hidden="true" className="chart-skeleton">
+      <div className="skeleton-bar-group d-flex align-items-end gap-1" style={{ height: 160 }}>
+        {[60, 90, 45, 120, 75, 100, 55, 80, 65, 110, 70, 95].map((h, i) => (
+          <div
+            key={i}
+            className="flex-grow-1 rounded-top"
+            style={{
+              height: `${h}px`,
+              background: 'var(--bs-tertiary-bg)',
+              animation: 'pulse 1.4s ease-in-out infinite',
+              animationDelay: `${i * 0.08}s`,
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ChartEmptyState({ text }) {
+  return (
+    <div className="d-flex flex-column align-items-center justify-content-center py-4 text-muted">
+      <svg style={{ width: 40, height: 40, opacity: 0.35, marginBottom: 8 }}>
+        <use href="/icons/sprite.svg#bar-chart-2" />
+      </svg>
+      <p className="fs-sm mb-0 text-center" style={{ maxWidth: 260 }}>{text}</p>
+    </div>
+  )
+}

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -5,9 +5,12 @@ import { usePlantContext } from '../context/PlantContext.jsx'
 import { useLayoutContext } from '../context/LayoutContext.jsx'
 import { analyseWateringPattern, getPatternMeta } from '../utils/wateringPattern.js'
 import HelpTooltip from '../components/HelpTooltip.jsx'
+import ChartFrame from '../components/ChartFrame.jsx'
 import { formatDate } from '../utils/format.js'
+import { HEALTH_COLORS as CB_HEALTH, getApexTheme, getApexAxisDefaults, heatmapColor, OKABE_ITO } from '../charts/theme.js'
 
-const HEALTH_COLORS = { Excellent: '#10b981', Good: '#22c55e', Fair: '#f59e0b', Poor: '#ef4444' }
+// Color-blind safe health palette (Okabe-Ito based).
+const HEALTH_COLORS = CB_HEALTH
 const HEALTH_ORDER = ['Excellent', 'Good', 'Fair', 'Poor']
 const HEALTH_VALUE = { Excellent: 4, Good: 3, Fair: 2, Poor: 1 }
 
@@ -44,11 +47,9 @@ function buildHeatmap(plants) {
   })
 }
 
+// Use color-blind safe sequential palette from charts/theme for the heatmap.
 function heatColor(count) {
-  if (count === 0) return 'var(--bs-tertiary-bg)'
-  if (count === 1) return 'var(--bs-success)'
-  if (count === 2) return '#059669'
-  return '#047857'
+  return heatmapColor(count, 3)
 }
 
 function incidentStats(plants) {
@@ -94,14 +95,19 @@ function OverviewTab({ plants, theme }) {
 
   const heatmapDays = useMemo(() => buildHeatmap(plants), [plants])
 
+  const axisDefaults = getApexAxisDefaults(theme)
   const healthChartOpts = {
     chart: { type: 'donut', background: 'transparent' },
-    theme: { mode: theme },
+    theme: getApexTheme(theme),
     labels: healthData.map((d) => d.name),
     colors: healthData.map((d) => d.color),
-    legend: { position: 'right', fontSize: '13px' },
+    legend: { position: 'right', fontSize: '13px', ...axisDefaults.legend },
     plotOptions: { pie: { donut: { size: '65%' } } },
     dataLabels: { enabled: false },
+    tooltip: {
+      ...axisDefaults.tooltip,
+      y: { formatter: (val, { seriesIndex, w }) => `${val} plant${val !== 1 ? 's' : ''} (${Math.round((val / plants.length) * 100)}%)` },
+    },
     responsive: [
       {
         breakpoint: 480,
@@ -117,28 +123,25 @@ function OverviewTab({ plants, theme }) {
     <div>
       <Row className="mb-4">
         <Col md={6}>
-          <div className="panel panel-icon">
-            <div className="panel-hdr">
-              <span>Health Distribution</span>
-              <HelpTooltip articleId="analytics" label="Explain health distribution chart" className="ms-2" />
-            </div>
-            <div className="panel-container"><div className="panel-content">
-              {plants.length === 0 ? <p className="text-muted">No plants yet.</p> : (
-                <>
-                  <Chart options={healthChartOpts} series={healthData.map((d) => d.value)} type="donut" height={200} />
-                  <table className="visually-hidden">
-                    <caption>Health distribution of tracked plants</caption>
-                    <thead><tr><th scope="col">Health</th><th scope="col">Plants</th></tr></thead>
-                    <tbody>
-                      {healthData.map((d) => (
-                        <tr key={d.name}><td>{d.name}</td><td>{d.value}</td></tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </>
-              )}
-            </div></div>
-          </div>
+          <ChartFrame
+            title="Health Distribution"
+            unit="plants"
+            empty={plants.length === 0}
+            help={<HelpTooltip articleId="analytics" label="Explain health distribution chart" />}
+          >
+            <>
+              <Chart options={healthChartOpts} series={healthData.map((d) => d.value)} type="donut" height={200} />
+              <table className="visually-hidden">
+                <caption>Health distribution of tracked plants</caption>
+                <thead><tr><th scope="col">Health</th><th scope="col">Plants</th></tr></thead>
+                <tbody>
+                  {healthData.map((d) => (
+                    <tr key={d.name}><td>{d.name}</td><td>{d.value}</td></tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          </ChartFrame>
         </Col>
         <Col md={6}>
           <div className="panel panel-icon">
@@ -175,12 +178,13 @@ function OverviewTab({ plants, theme }) {
       </Row>
 
       {/* Heatmap */}
-      <div className="panel panel-icon mb-4">
-        <div className="panel-hdr">
-          <span>Watering Activity — Last 12 Weeks</span>
-          <HelpTooltip articleId="analytics" label="Explain watering heatmap" className="ms-2" />
-        </div>
-        <div className="panel-container"><div className="panel-content">
+      <ChartFrame
+        title="Watering Activity — Last 12 Weeks"
+        className="mb-4"
+        empty={plants.length === 0}
+        help={<HelpTooltip articleId="analytics" label="Explain watering heatmap" />}
+      >
+        <>
           <div className="d-flex gap-1 flex-wrap" role="img" aria-label="Watering activity heatmap, last 12 weeks">
             {heatmapDays.map((day) => (
               <div
@@ -191,9 +195,9 @@ function OverviewTab({ plants, theme }) {
             ))}
           </div>
           <div className="d-flex align-items-center gap-1 mt-2 tx-muted">
-            <span>Less</span>
+            <span className="fs-xs">Less</span>
             {[0, 1, 2, 3].map((n) => <div key={n} style={{ width: 12, height: 12, borderRadius: 2, background: heatColor(n) }} />)}
-            <span>More</span>
+            <span className="fs-xs">More</span>
           </div>
           <table className="visually-hidden">
             <caption>Days where at least one plant was watered, last 12 weeks</caption>
@@ -204,13 +208,12 @@ function OverviewTab({ plants, theme }) {
               ))}
             </tbody>
           </table>
-        </div></div>
-      </div>
+        </>
+      </ChartFrame>
 
       {/* Pest & Disease */}
-      <div className="panel panel-icon">
-        <div className="panel-hdr"><span>Pest &amp; Disease</span></div>
-        <div className="panel-container"><div className="panel-content">
+      <ChartFrame title="Pest &amp; Disease" empty={plants.length === 0}>
+        <>
           <Row>
             <Col xs={6} md={3} className="mb-3 text-center">
               <div className="fs-3 fw-600 text-danger">{pestStats.activeCount}</div>
@@ -237,8 +240,8 @@ function OverviewTab({ plants, theme }) {
               }
             </Col>
           </Row>
-        </div></div>
-      </div>
+        </>
+      </ChartFrame>
     </div>
   )
 }
@@ -257,15 +260,19 @@ function PerPlantTab({ plants, theme }) {
 
   if (!plant) return <p className="text-muted">No plants yet.</p>
 
+  const axisDefaults = getApexAxisDefaults(theme)
   const barOpts = {
     chart: { type: 'bar', toolbar: { show: false }, background: 'transparent' },
-    theme: { mode: theme },
-    xaxis: { categories: weeklyData.map((w) => w.week) },
-    colors: ['var(--bs-primary, #10b981)'],
+    theme: getApexTheme(theme),
+    xaxis: { categories: weeklyData.map((w) => w.week), ...axisDefaults.xaxis },
+    yaxis: { ...axisDefaults.yaxis, title: { text: 'waterings', style: { color: axisDefaults.yaxis.labels.style.colors } } },
+    colors: [OKABE_ITO[1]],
     plotOptions: { bar: { borderRadius: 3, columnWidth: '60%' } },
     dataLabels: { enabled: false },
+    grid: axisDefaults.grid,
+    tooltip: { ...axisDefaults.tooltip, y: { formatter: (val) => `${val} watering${val !== 1 ? 's' : ''}` } },
     annotations: plant.frequencyDays ? {
-      yaxis: [{ y: +(7 / plant.frequencyDays).toFixed(2), borderColor: '#f59e0b', strokeDashArray: 4, label: { text: 'Target', style: { color: '#f59e0b', background: 'transparent' } } }]
+      yaxis: [{ y: +(7 / plant.frequencyDays).toFixed(2), borderColor: '#E69F00', strokeDashArray: 4, label: { text: 'Target', style: { color: '#E69F00', background: 'transparent' } } }]
     } : {},
     responsive: [
       {
@@ -280,10 +287,10 @@ function PerPlantTab({ plants, theme }) {
 
   const radialOpts = {
     chart: { type: 'radialBar', background: 'transparent' },
-    theme: { mode: theme },
+    theme: getApexTheme(theme),
     plotOptions: { radialBar: { hollow: { size: '65%' }, dataLabels: { name: { show: true, fontSize: '12px' }, value: { show: true, fontSize: '24px', fontWeight: 700 } } } },
     labels: [score !== null ? (score >= 80 ? 'Consistent' : score >= 60 ? 'Moderate' : 'Irregular') : 'No data'],
-    colors: [score !== null ? (score >= 80 ? '#10b981' : score >= 60 ? '#f59e0b' : '#ef4444') : '#6b7280'],
+    colors: [score !== null ? (score >= 80 ? '#009E73' : score >= 60 ? '#E69F00' : '#D55E00') : '#6b7280'],
     responsive: [
       {
         breakpoint: 480,
@@ -310,69 +317,61 @@ function PerPlantTab({ plants, theme }) {
 
       <Row className="mb-4">
         <Col md={6}>
-          <div className="panel panel-icon">
-            <div className="panel-hdr">
-              <span>Consistency Score</span>
-              <HelpTooltip articleId="analytics" label="What is the consistency score?" className="ms-2" />
-            </div>
-            <div className="panel-container"><div className="panel-content text-center">
-              {score === null ? <p className="text-muted fs-sm py-3">Need at least 2 watering events.</p> : (
-                <>
-                  <Chart options={radialOpts} series={[score]} type="radialBar" height={200} />
-                  <p className="visually-hidden">
-                    Consistency score {score} out of 100 — {radialOpts.labels[0]}.
-                  </p>
-                </>
-              )}
-            </div></div>
-          </div>
+          <ChartFrame
+            title="Consistency Score"
+            empty={score === null}
+            emptyText="Need at least 2 watering events to compute score."
+            help={<HelpTooltip articleId="analytics" label="What is the consistency score?" />}
+          >
+            <>
+              <div className="text-center">
+                <Chart options={radialOpts} series={[score]} type="radialBar" height={200} />
+              </div>
+              <p className="visually-hidden">
+                Consistency score {score} out of 100 — {radialOpts.labels[0]}.
+              </p>
+            </>
+          </ChartFrame>
         </Col>
         <Col md={6}>
-          <div className="panel panel-icon">
-            <div className="panel-hdr"><span>Last Watered</span></div>
-            <div className="panel-container"><div className="panel-content">
-              {daysSinceLast === null ? <p className="text-muted fs-sm">No watering recorded.</p> : (
-                <>
-                  <div className="d-flex align-items-baseline gap-1 mb-3">
-                    <span className="display-6 fw-bold">{daysSinceLast}</span>
-                    <span className="text-muted">days ago</span>
-                  </div>
-                  {plant.frequencyDays && (
-                    <p className="fs-xs text-muted">
-                      Recommended every <strong>{plant.frequencyDays}d</strong>
-                      {daysSinceLast > plant.frequencyDays
-                        ? <span className="text-danger ms-1">· {daysSinceLast - plant.frequencyDays}d overdue</span>
-                        : <span className="text-success ms-1">· {plant.frequencyDays - daysSinceLast}d remaining</span>}
-                    </p>
-                  )}
-                </>
+          <ChartFrame title="Last Watered" unit="days" empty={daysSinceLast === null} emptyText="No watering recorded yet.">
+            <>
+              <div className="d-flex align-items-baseline gap-1 mb-3">
+                <span className="display-6 fw-bold">{daysSinceLast}</span>
+                <span className="text-muted">days ago</span>
+              </div>
+              {plant.frequencyDays && (
+                <p className="fs-xs text-muted">
+                  Recommended every <strong>{plant.frequencyDays}d</strong>
+                  {daysSinceLast > plant.frequencyDays
+                    ? <span className="text-danger ms-1">· {daysSinceLast - plant.frequencyDays}d overdue</span>
+                    : <span className="text-success ms-1">· {plant.frequencyDays - daysSinceLast}d remaining</span>}
+                </p>
               )}
-            </div></div>
-          </div>
+            </>
+          </ChartFrame>
         </Col>
       </Row>
 
-      <div className="panel panel-icon">
-        <div className="panel-hdr"><span>Watering Timeline — Last 12 Weeks</span></div>
-        <div className="panel-container"><div className="panel-content">
-          {weeklyData.every((w) => w.count === 0) ? (
-            <p className="text-muted fs-sm">No watering events in the last 12 weeks.</p>
-          ) : (
-            <>
-              <Chart options={barOpts} series={[{ name: 'Waterings', data: weeklyData.map((w) => w.count) }]} type="bar" height={200} />
-              <table className="visually-hidden">
-                <caption>Weekly watering count, last 12 weeks</caption>
-                <thead><tr><th scope="col">Week starting</th><th scope="col">Waterings</th></tr></thead>
-                <tbody>
-                  {weeklyData.map((w) => (
-                    <tr key={w.week}><td>{w.week}</td><td>{w.count}</td></tr>
-                  ))}
-                </tbody>
-              </table>
-            </>
-          )}
-        </div></div>
-      </div>
+      <ChartFrame
+        title="Watering Timeline — Last 12 Weeks"
+        unit="waterings"
+        empty={weeklyData.every((w) => w.count === 0)}
+        emptyText="No watering events in the last 12 weeks."
+      >
+        <>
+          <Chart options={barOpts} series={[{ name: 'Waterings', data: weeklyData.map((w) => w.count) }]} type="bar" height={200} />
+          <table className="visually-hidden">
+            <caption>Weekly watering count, last 12 weeks</caption>
+            <thead><tr><th scope="col">Week starting</th><th scope="col">Waterings</th></tr></thead>
+            <tbody>
+              {weeklyData.map((w) => (
+                <tr key={w.week}><td>{w.week}</td><td>{w.count}</td></tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      </ChartFrame>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Introduces `src/charts/theme.js` with Okabe-Ito color-blind safe palette (`OKABE_ITO`, `SEQUENTIAL`, `DIVERGING`, `HEALTH_COLORS`) and utility functions (`getApexTheme`, `getApexAxisDefaults`, `heatmapColor`, `categoricalColor`, `divergingColor`)
- Adds `src/components/ChartFrame.jsx` — shared panel wrapper for all ApexCharts instances with loading skeleton (animated bars), empty state (SVG icon + copy), `role="region"` + `aria-label` ARIA, unit badge, and optional help tooltip slot
- Rewires `AnalyticsPage.jsx` to use color-blind safe colors throughout (health donut, watering heatmap, consistency radial) and wraps all chart panels in `ChartFrame`

## Test plan

- [ ] `npm test` passes (ChartFrame and ChartTheme suites: 22 new tests)
- [ ] AnalyticsPage renders correctly in both light and dark mode
- [ ] Health distribution donut uses Okabe-Ito/HEALTH_COLORS (no red/green-only distinction)
- [ ] Watering heatmap uses sequential blue palette
- [ ] ChartFrame shows skeleton while loading, empty state when no data
- [ ] ARIA landmark `role="region"` with `aria-label` present on each chart panel

Closes #255

https://claude.ai/code/session_01N62KrHp25dEi4P3syqgH7V