### PR TITLE
feat(ux): replayable feature tours and What's new panel (#224)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-apexcharts": "^2.1.0",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^18.3.1",
+        "react-joyride": "^3.0.2",
         "react-router": "^7.14.0",
         "react-window": "^2.2.7",
         "sass": "^1.99.0",
@@ -2291,6 +2292,99 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz",
+      "integrity": "sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/hooks": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz",
+      "integrity": "sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.4.1"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19"
+      }
+    },
+    "node_modules/@gilbarbara/types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz",
+      "integrity": "sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.1.0"
+      }
+    },
+    "node_modules/@gilbarbara/types/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -7105,6 +7199,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz",
+      "integrity": "sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==",
+      "license": "MIT"
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -8699,11 +8799,43 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "node_modules/react-joyride": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-3.0.2.tgz",
+      "integrity": "sha512-Tm+zXo/O8rFOUkN1yH+t38HqLvOCB8p5JTqgQD3IlLyZGCXzJEnCXtyB/BQIUC7X07kEaw0BqtKjWFzF4fyDVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/deepmerge": "^3.2.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@gilbarbara/deep-equal": "^0.4.1",
+        "@gilbarbara/hooks": "^0.11.0",
+        "@gilbarbara/types": "^0.2.2",
+        "is-lite": "^2.0.0",
+        "react-innertext": "^1.1.5",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19",
+        "react-dom": "16.8 - 19"
+      }
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -9148,6 +9280,18 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
+      "license": "MIT"
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -12479,6 +12623,69 @@
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
       "dev": true
     },
+    "@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA=="
+    },
+    "@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "requires": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "requires": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "requires": {
+        "@floating-ui/dom": "^1.7.6"
+      }
+    },
+    "@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
+    },
+    "@gilbarbara/deep-equal": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz",
+      "integrity": "sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w=="
+    },
+    "@gilbarbara/hooks": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz",
+      "integrity": "sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==",
+      "requires": {
+        "@gilbarbara/deep-equal": "^0.4.1"
+      }
+    },
+    "@gilbarbara/types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz",
+      "integrity": "sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==",
+      "requires": {
+        "type-fest": "^4.1.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "4.41.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+          "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
+        }
+      }
+    },
     "@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -15457,6 +15664,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz",
+      "integrity": "sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g=="
+    },
     "is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -16433,11 +16645,33 @@
         "scheduler": "^0.23.2"
       }
     },
+    "react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q=="
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "react-joyride": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-3.0.2.tgz",
+      "integrity": "sha512-Tm+zXo/O8rFOUkN1yH+t38HqLvOCB8p5JTqgQD3IlLyZGCXzJEnCXtyB/BQIUC7X07kEaw0BqtKjWFzF4fyDVw==",
+      "requires": {
+        "@fastify/deepmerge": "^3.2.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@gilbarbara/deep-equal": "^0.4.1",
+        "@gilbarbara/hooks": "^0.11.0",
+        "@gilbarbara/types": "^0.2.2",
+        "is-lite": "^2.0.0",
+        "react-innertext": "^1.1.5",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "use-sync-external-store": "^1.6.0"
+      }
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -16733,6 +16967,16 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg=="
+    },
+    "scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA=="
     },
     "semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-apexcharts": "^2.1.0",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^18.3.1",
+    "react-joyride": "^3.0.2",
     "react-router": "^7.14.0",
     "react-window": "^2.2.7",
     "sass": "^1.99.0",

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -64,6 +64,12 @@ vi.mock('react-apexcharts', () => ({
   default: () => <div data-testid="apex-chart" />,
 }))
 
+// react-joyride uses DOM APIs not available in jsdom
+vi.mock('react-joyride', () => ({
+  default: () => null,
+  STATUS: { FINISHED: 'finished', SKIPPED: 'skipped' },
+}))
+
 // Leaflet is not available in jsdom
 vi.mock('../components/LeafletFloorplan.jsx', () => ({
   default: () => <div data-testid="leaflet-floorplan" />,

--- a/src/__tests__/TourContext.test.jsx
+++ b/src/__tests__/TourContext.test.jsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import { render, screen, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { TourProvider, useTour, TOURS } from '../context/TourContext.jsx'
+
+// Consumer component for testing
+function TourConsumer() {
+  const { activeTour, showWhatsNew, startTour, completeTour, isTourCompleted, openWhatsNew, closeWhatsNew, LATEST_VERSION } = useTour()
+  return (
+    <div>
+      <span data-testid="active-tour">{activeTour ?? 'none'}</span>
+      <span data-testid="show-whats-new">{showWhatsNew ? 'yes' : 'no'}</span>
+      <span data-testid="latest-version">{LATEST_VERSION}</span>
+      <span data-testid="setup-done">{isTourCompleted('setup') ? 'yes' : 'no'}</span>
+      <button onClick={() => startTour('setup')}>Start setup</button>
+      <button onClick={() => completeTour('setup')}>Complete setup</button>
+      <button onClick={openWhatsNew}>Open whats new</button>
+      <button onClick={closeWhatsNew}>Close whats new</button>
+    </div>
+  )
+}
+
+function renderConsumer() {
+  return render(
+    <TourProvider>
+      <TourConsumer />
+    </TourProvider>
+  )
+}
+
+describe('TourContext', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('exposes TOURS constant with expected tour ids', () => {
+    expect(TOURS.map((t) => t.id)).toEqual(['setup', 'floorplan', 'analytics', 'bulk-upload'])
+  })
+
+  it('activeTour is null initially', () => {
+    renderConsumer()
+    expect(screen.getByTestId('active-tour').textContent).toBe('none')
+  })
+
+  it('startTour sets activeTour', () => {
+    renderConsumer()
+    act(() => {
+      screen.getByText('Start setup').click()
+    })
+    expect(screen.getByTestId('active-tour').textContent).toBe('setup')
+  })
+
+  it('completeTour clears activeTour and persists to localStorage', () => {
+    renderConsumer()
+    act(() => { screen.getByText('Start setup').click() })
+    act(() => { screen.getByText('Complete setup').click() })
+    expect(screen.getByTestId('active-tour').textContent).toBe('none')
+    expect(localStorage.getItem('plant-tracker-tour-done-setup')).toBe('1')
+  })
+
+  it('isTourCompleted reflects localStorage', () => {
+    localStorage.setItem('plant-tracker-tour-done-setup', '1')
+    renderConsumer()
+    expect(screen.getByTestId('setup-done').textContent).toBe('yes')
+  })
+
+  it('does not auto-show whats-new for first-time users', () => {
+    // No 'plant-tracker-onboarded' key → first-time user
+    renderConsumer()
+    expect(screen.getByTestId('show-whats-new').textContent).toBe('no')
+  })
+
+  it('auto-shows whats-new for returning users who have not seen latest version', () => {
+    localStorage.setItem('plant-tracker-onboarded', '1')
+    // No whats-new-seen key → should auto-show
+    renderConsumer()
+    expect(screen.getByTestId('show-whats-new').textContent).toBe('yes')
+  })
+
+  it('does not auto-show whats-new if latest version already seen', () => {
+    localStorage.setItem('plant-tracker-onboarded', '1')
+    localStorage.setItem('plant-tracker-whats-new-seen', '9.9.9') // higher than any real version
+    renderConsumer()
+    expect(screen.getByTestId('show-whats-new').textContent).toBe('no')
+  })
+
+  it('openWhatsNew shows the modal', () => {
+    renderConsumer()
+    expect(screen.getByTestId('show-whats-new').textContent).toBe('no')
+    act(() => { screen.getByText('Open whats new').click() })
+    expect(screen.getByTestId('show-whats-new').textContent).toBe('yes')
+  })
+
+  it('closeWhatsNew hides the modal and saves seen version', () => {
+    localStorage.setItem('plant-tracker-onboarded', '1')
+    renderConsumer()
+    act(() => { screen.getByText('Close whats new').click() })
+    expect(screen.getByTestId('show-whats-new').textContent).toBe('no')
+    expect(localStorage.getItem('plant-tracker-whats-new-seen')).toBeTruthy()
+  })
+
+  it('throws when useTour is used outside TourProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<TourConsumer />)).toThrow('useTour must be used inside TourProvider')
+    spy.mockRestore()
+  })
+})

--- a/src/components/FeatureTour.jsx
+++ b/src/components/FeatureTour.jsx
@@ -1,0 +1,174 @@
+import Joyride, { STATUS } from 'react-joyride'
+import { useTour } from '../context/TourContext.jsx'
+
+const TOUR_STEPS = {
+  setup: [
+    {
+      target: 'body',
+      title: 'Welcome to Plant Tracker',
+      content: 'This quick tour covers the key areas of the app. You can replay any tour from the sidebar at any time.',
+      placement: 'center',
+      disableBeacon: true,
+    },
+    {
+      target: 'aside.app-sidebar',
+      title: 'Sidebar Navigation',
+      content: 'Use the sidebar to navigate between pages: Dashboard, Analytics, Calendar, Forecast, and more.',
+      placement: 'right',
+      disableBeacon: true,
+    },
+    {
+      target: '[data-tour="nav-today"]',
+      title: "Today's Tasks",
+      content: 'The Today page shows exactly which plants need watering or care right now.',
+      placement: 'right',
+      disableBeacon: true,
+    },
+    {
+      target: '[data-tour="nav-settings"]',
+      title: 'Settings',
+      content: 'Start here — upload a floorplan photo and configure your floors. Gemini AI identifies rooms automatically.',
+      placement: 'right',
+      disableBeacon: true,
+    },
+    {
+      target: '[data-tour="nav-analytics"]',
+      title: 'Analytics',
+      content: 'Track your care consistency, watering patterns, and plant health over time.',
+      placement: 'right',
+      disableBeacon: true,
+    },
+  ],
+  floorplan: [
+    {
+      target: 'body',
+      title: 'Your Interactive Floorplan',
+      content: 'The Dashboard shows your floorplan with plant markers. Click anywhere on the map to add a plant at that position.',
+      placement: 'center',
+      disableBeacon: true,
+    },
+    {
+      target: '[data-tour="floor-nav"]',
+      title: 'Multiple Floors',
+      content: 'If your home has multiple floors, switch between them using these tabs. Add floors in Settings.',
+      placement: 'bottom',
+      disableBeacon: true,
+    },
+    {
+      target: '[data-tour="plant-list"]',
+      title: 'Plant List',
+      content: 'All your plants appear here, grouped by room. Search, filter, and click any plant to view or edit it.',
+      placement: 'left',
+      disableBeacon: true,
+    },
+    {
+      target: '[data-tour="floorplan-panel"]',
+      title: 'Place Plants',
+      content: 'Click anywhere on the floorplan to add a plant marker. Drag existing markers to reposition them.',
+      placement: 'top',
+      disableBeacon: true,
+    },
+  ],
+  analytics: [
+    {
+      target: '[data-tour="nav-analytics"]',
+      title: 'Analytics Overview',
+      content: 'The Analytics page shows charts for watering frequency, health distribution, and care consistency.',
+      placement: 'right',
+      disableBeacon: true,
+    },
+    {
+      target: '[data-tour="nav-calendar"]',
+      title: 'Care Calendar',
+      content: 'The Calendar view shows your care schedule for the month — see what needs attention and when.',
+      placement: 'right',
+      disableBeacon: true,
+    },
+    {
+      target: '[data-tour="nav-forecast"]',
+      title: 'Watering Forecast',
+      content: 'The Forecast page predicts exactly when each plant will next need water, factoring in weather.',
+      placement: 'right',
+      disableBeacon: true,
+    },
+    {
+      target: '[data-tour="nav-today"]',
+      title: "Today's Tasks",
+      content: "Start each day here — it shows only the plants that need attention today so nothing gets missed.",
+      placement: 'right',
+      disableBeacon: true,
+    },
+  ],
+  'bulk-upload': [
+    {
+      target: 'body',
+      title: 'Bulk Import from Photos',
+      content: 'You can import many plants at once by uploading photos. Gemini AI identifies the species automatically.',
+      placement: 'center',
+      disableBeacon: true,
+    },
+    {
+      target: '[data-tour="nav-bulk-upload"]',
+      title: 'Bulk Upload',
+      content: 'Open Bulk Upload from the sidebar. Drop in up to 20 photos and review the AI-identified results before saving.',
+      placement: 'right',
+      disableBeacon: true,
+    },
+  ],
+}
+
+const joyrideStyles = {
+  options: {
+    zIndex: 10000,
+    arrowColor: 'var(--bs-body-bg)',
+    backgroundColor: 'var(--bs-body-bg)',
+    textColor: 'var(--bs-body-color)',
+    primaryColor: 'var(--bs-primary, #3e7d5f)',
+  },
+  tooltip: {
+    borderRadius: 8,
+  },
+  buttonNext: {
+    borderRadius: 6,
+  },
+  buttonBack: {
+    color: 'var(--bs-secondary)',
+  },
+}
+
+const joyrideLocale = {
+  back: 'Back',
+  close: 'Close',
+  last: 'Done',
+  next: 'Next',
+  open: 'Open dialog',
+  skip: 'Skip tour',
+}
+
+export default function FeatureTour() {
+  const { activeTour, completeTour } = useTour()
+
+  if (!activeTour || !TOUR_STEPS[activeTour]) return null
+
+  const handleCallback = ({ status }) => {
+    if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
+      completeTour(activeTour)
+    }
+  }
+
+  return (
+    <Joyride
+      key={activeTour}
+      steps={TOUR_STEPS[activeTour]}
+      run
+      continuous
+      showSkipButton
+      showProgress
+      scrollToFirstStep
+      disableOverlayClose
+      callback={handleCallback}
+      styles={joyrideStyles}
+      locale={joyrideLocale}
+    />
+  )
+}

--- a/src/components/FloorplanPanel.jsx
+++ b/src/components/FloorplanPanel.jsx
@@ -147,7 +147,7 @@ export default function FloorplanPanel({ onPlantClick, onFloorplanClick, onAddPl
       fullWidth={fullWidth}
     >
       {/* Floor tabs + view toggle */}
-      <div className="floorplan-toolbar d-flex align-items-center justify-content-between px-3 py-2 border-bottom flex-wrap gap-2">
+      <div className="floorplan-toolbar d-flex align-items-center justify-content-between px-3 py-2 border-bottom flex-wrap gap-2" data-tour="floor-nav">
         <Nav variant="pills" className="gap-1 flex-nowrap overflow-auto flex-grow-1">
           {visibleFloors.map((f) => (
             <Nav.Item key={f.id}>
@@ -240,6 +240,7 @@ export default function FloorplanPanel({ onPlantClick, onFloorplanClick, onAddPl
       {viewMode !== 'list' && (
       <div
         className="floorplan-wrapper"
+        data-tour="floorplan-panel"
         style={{ height: fullWidth ? 'calc(100vh - 180px)' : (houseHeight || 500), minHeight: fullWidth ? 500 : undefined }}
       >
         {isAnalysingFloorplan && (

--- a/src/components/PlantListPanel.jsx
+++ b/src/components/PlantListPanel.jsx
@@ -235,7 +235,7 @@ export default function PlantListPanel({ onPlantClick, onAddPlant, gnomeWaterRef
   }, [filteredPlants, weather, floors])
 
   return (
-    <div className="panel panel-icon">
+    <div className="panel panel-icon" data-tour="plant-list">
       <div className="panel-hdr d-flex justify-content-between align-items-center">
         <span>
           Plants

--- a/src/components/WhatsNewModal.jsx
+++ b/src/components/WhatsNewModal.jsx
@@ -1,0 +1,55 @@
+import { Modal, Badge } from 'react-bootstrap'
+import changelog from '../data/changelog.json'
+import { useTour } from '../context/TourContext.jsx'
+
+const TYPE_VARIANTS = {
+  new:      'success',
+  improved: 'primary',
+  fixed:    'warning',
+}
+
+export default function WhatsNewModal() {
+  const { showWhatsNew, closeWhatsNew } = useTour()
+
+  return (
+    <Modal show={showWhatsNew} onHide={closeWhatsNew} centered scrollable>
+      <Modal.Header closeButton className="border-bottom-0 pb-0">
+        <Modal.Title className="fs-base fw-600 d-flex align-items-center gap-2">
+          <svg className="sa-icon text-primary" aria-hidden="true">
+            <use href="/icons/sprite.svg#sparkles"></use>
+          </svg>
+          What&apos;s new
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {changelog.map((release) => (
+          <div key={release.version} className="mb-4">
+            <div className="d-flex align-items-baseline gap-2 mb-2">
+              <span className="fw-600 fs-sm">v{release.version}</span>
+              <span className="text-muted fs-xs">{release.date}</span>
+            </div>
+            <ul className="list-unstyled mb-0 ps-1">
+              {release.entries.map((entry, i) => (
+                <li key={i} className="d-flex align-items-start gap-2 mb-2">
+                  <Badge
+                    bg={TYPE_VARIANTS[entry.type] || 'secondary'}
+                    className="mt-1 flex-shrink-0 text-capitalize"
+                    style={{ fontSize: '0.6rem', fontWeight: 600, minWidth: 52 }}
+                  >
+                    {entry.type}
+                  </Badge>
+                  <span className="fs-sm">{entry.text}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </Modal.Body>
+      <Modal.Footer className="border-top-0 pt-0">
+        <button className="btn btn-primary btn-sm" onClick={closeWhatsNew}>
+          Got it
+        </button>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/src/context/TourContext.jsx
+++ b/src/context/TourContext.jsx
@@ -1,0 +1,73 @@
+import { createContext, useContext, useState, useCallback, useMemo } from 'react'
+import changelog from '../data/changelog.json'
+
+const LATEST_VERSION = changelog[0]?.version || '0.0.0'
+const LS_TOUR_PREFIX = 'plant-tracker-tour-done-'
+const LS_WHATS_NEW = 'plant-tracker-whats-new-seen'
+const LS_ONBOARDED = 'plant-tracker-onboarded'
+
+export const TOURS = [
+  { id: 'setup',       label: 'First-time setup' },
+  { id: 'floorplan',   label: 'Using the floorplan' },
+  { id: 'analytics',   label: 'Understanding Analytics' },
+  { id: 'bulk-upload', label: 'Bulk import from photos' },
+]
+
+const TourContext = createContext(null)
+
+export function TourProvider({ children }) {
+  const [activeTour, setActiveTour] = useState(null)
+  const [showWhatsNew, setShowWhatsNew] = useState(() => {
+    // Only auto-show for returning users who haven't seen the latest version
+    const onboarded = localStorage.getItem(LS_ONBOARDED)
+    if (!onboarded) return false
+    const seen = localStorage.getItem(LS_WHATS_NEW)
+    return !seen || seen < LATEST_VERSION
+  })
+
+  const isTourCompleted = useCallback((id) => {
+    return !!localStorage.getItem(LS_TOUR_PREFIX + id)
+  }, [])
+
+  const startTour = useCallback((id) => {
+    setActiveTour(id)
+  }, [])
+
+  const completeTour = useCallback((id) => {
+    localStorage.setItem(LS_TOUR_PREFIX + id, '1')
+    setActiveTour(null)
+  }, [])
+
+  const openWhatsNew = useCallback(() => {
+    setShowWhatsNew(true)
+  }, [])
+
+  const closeWhatsNew = useCallback(() => {
+    localStorage.setItem(LS_WHATS_NEW, LATEST_VERSION)
+    setShowWhatsNew(false)
+  }, [])
+
+  const value = useMemo(() => ({
+    activeTour,
+    showWhatsNew,
+    startTour,
+    completeTour,
+    isTourCompleted,
+    openWhatsNew,
+    closeWhatsNew,
+    TOURS,
+    LATEST_VERSION,
+  }), [activeTour, showWhatsNew, startTour, completeTour, isTourCompleted, openWhatsNew, closeWhatsNew])
+
+  return (
+    <TourContext.Provider value={value}>
+      {children}
+    </TourContext.Provider>
+  )
+}
+
+export function useTour() {
+  const ctx = useContext(TourContext)
+  if (!ctx) throw new Error('useTour must be used inside TourProvider')
+  return ctx
+}

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,0 +1,36 @@
+[
+  {
+    "version": "1.4.0",
+    "date": "2026-04-22",
+    "entries": [
+      { "type": "new", "text": "Replayable feature tours — access any tour from the sidebar or Help menu" },
+      { "type": "new", "text": "\"What's new\" panel shows release highlights automatically after each update" },
+      { "type": "new", "text": "Cursor-based pagination for large plant collections (up to 200 plants per page)" },
+      { "type": "new", "text": "Virtualised plant list with react-window for collections over 40 plants" },
+      { "type": "new", "text": "Storybook design system catalogue — run npm run storybook" },
+      { "type": "new", "text": "Motion tokens and Framer Motion micro-interactions throughout the UI" }
+    ]
+  },
+  {
+    "version": "1.3.0",
+    "date": "2026-04-10",
+    "entries": [
+      { "type": "new", "text": "Outbreak detection and bulk treatment for pest and disease incidents" },
+      { "type": "new", "text": "Bulk plant import from photos using Gemini AI species identification" },
+      { "type": "new", "text": "QR code tags — generate and scan plant labels for instant access" },
+      { "type": "improved", "text": "Analytics: watering heatmap, care consistency score, and health distribution charts" },
+      { "type": "improved", "text": "Seasonal care adjustments powered by Gemini recommendations" }
+    ]
+  },
+  {
+    "version": "1.2.0",
+    "date": "2026-03-20",
+    "entries": [
+      { "type": "new", "text": "Propagation tracker — log cuttings, seedlings, and divisions" },
+      { "type": "new", "text": "Harvest log for edible plants and herbs" },
+      { "type": "new", "text": "Phenology events — record flowering, fruiting, and seasonal milestones" },
+      { "type": "improved", "text": "Offline support — mutations are queued and replayed when back online" },
+      { "type": "fixed", "text": "Watering pattern anomaly detection now ignores plants watered early" }
+    ]
+  }
+]

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -5,9 +5,12 @@ import { useAuth } from '../contexts/AuthContext.jsx'
 import { PlantProvider } from '../context/PlantContext.jsx'
 import { HelpProvider } from '../context/HelpContext.jsx'
 import { CommandPaletteProvider, useCommandPalette } from '../context/CommandPaletteContext.jsx'
+import { TourProvider } from '../context/TourContext.jsx'
 import Sidebar from './components/Sidebar.jsx'
 import Topbar from './components/Topbar.jsx'
 import Onboarding from '../components/Onboarding.jsx'
+import FeatureTour from '../components/FeatureTour.jsx'
+import WhatsNewModal from '../components/WhatsNewModal.jsx'
 import WeatherAlertBanner from '../components/WeatherAlertBanner.jsx'
 import ErrorBoundary from '../components/ErrorBoundary.jsx'
 import OfflineBanner from '../components/OfflineBanner.jsx'
@@ -61,6 +64,7 @@ export default function MainLayout() {
   return (
     <MotionConfig reducedMotion="user">
     <PlantProvider>
+      <TourProvider>
       <HelpProvider>
         <CommandPaletteProvider>
           <GlobalKeyboardShortcuts />
@@ -107,10 +111,13 @@ export default function MainLayout() {
             </footer>
           </main>
           <Onboarding />
+          <FeatureTour />
+          <WhatsNewModal />
           <HelpDrawer />
         </div>
         </CommandPaletteProvider>
       </HelpProvider>
+      </TourProvider>
     </PlantProvider>
     </MotionConfig>
   )

--- a/src/layouts/components/Sidebar.jsx
+++ b/src/layouts/components/Sidebar.jsx
@@ -1,9 +1,10 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useAuth } from '../../contexts/AuthContext.jsx'
 import { useLayoutContext } from '../../context/LayoutContext.jsx'
 import { usePlantContext } from '../../context/PlantContext.jsx'
 import { useHelp } from '../../context/HelpContext.jsx'
+import { useTour, TOURS } from '../../context/TourContext.jsx'
 import SidebarMenu from './SidebarMenu.jsx'
 import WeatherStrip from '../../components/WeatherStrip.jsx'
 import OfflineIndicator from '../../components/OfflineIndicator.jsx'
@@ -15,6 +16,8 @@ export default function Sidebar() {
   const { navMinified, toggleSetting } = useLayoutContext()
   const { weather, location, plants, floors } = usePlantContext()
   const { open: openHelp } = useHelp()
+  const { startTour, openWhatsNew } = useTour()
+  const [tourMenuOpen, setTourMenuOpen] = useState(false)
   const navigate = useNavigate()
 
   const todayCount = useMemo(
@@ -27,7 +30,7 @@ export default function Sidebar() {
   }
 
   return (
-    <aside className="app-sidebar d-flex flex-column">
+    <aside className="app-sidebar d-flex flex-column" data-tour="sidebar">
       {/* Weather strip above everything */}
       <WeatherStrip weather={weather} location={location} onLocationClick={() => navigate('/settings')} />
 
@@ -65,6 +68,46 @@ export default function Sidebar() {
           <SidebarMenu items={menuItems} badges={{ today: todayCount }} />
           {/* Sign out — below Settings */}
           <ul className="nav-menu d-flex flex-column">
+            <li>
+              <button type="button" onClick={openWhatsNew} className="nav-link-btn text-start w-100 bg-transparent border-0">
+                <svg className="sa-icon" aria-hidden="true">
+                  <use href="/icons/sprite.svg#sparkles"></use>
+                </svg>
+                <span className="nav-link-text">What&apos;s new</span>
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                onClick={() => setTourMenuOpen((o) => !o)}
+                className="nav-link-btn text-start w-100 bg-transparent border-0"
+                aria-expanded={tourMenuOpen}
+              >
+                <svg className="sa-icon" aria-hidden="true">
+                  <use href="/icons/sprite.svg#compass"></use>
+                </svg>
+                <span className="nav-link-text">Take a tour</span>
+                <svg className="sa-icon ms-auto" style={{ width: 12, height: 12, transform: tourMenuOpen ? 'rotate(180deg)' : undefined }} aria-hidden="true">
+                  <use href="/icons/sprite.svg#chevron-down"></use>
+                </svg>
+              </button>
+              {tourMenuOpen && (
+                <ul className="list-unstyled ps-4 mb-1">
+                  {TOURS.map((tour) => (
+                    <li key={tour.id}>
+                      <button
+                        type="button"
+                        onClick={() => { startTour(tour.id); setTourMenuOpen(false) }}
+                        className="btn btn-link btn-sm text-start w-100 p-0 py-1 text-white-50 text-decoration-none"
+                        style={{ fontSize: '0.8rem' }}
+                      >
+                        {tour.label}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
             <li>
               <button type="button" onClick={() => openHelp()} className="nav-link-btn text-start w-100 bg-transparent border-0">
                 <svg className="sa-icon" aria-hidden="true">

--- a/src/layouts/components/SidebarMenu.jsx
+++ b/src/layouts/components/SidebarMenu.jsx
@@ -11,7 +11,7 @@ export default function SidebarMenu({ items, badges = {} }) {
         }
         const badge = badges[item.key]
         return (
-          <li key={item.key}>
+          <li key={item.key} data-tour={`nav-${item.key}`}>
             <NavLink
               to={item.url}
               end={item.url === '/'}


### PR DESCRIPTION
## Summary

- **TourContext** (`src/context/TourContext.jsx`): manages four named tours (`setup`, `floorplan`, `analytics`, `bulk-upload`). Tour completion is persisted in localStorage. Automatically shows the "What's new" modal for returning users who haven't seen the current release version.
- **FeatureTour** (`src/components/FeatureTour.jsx`): renders `react-joyride` overlays. Each tour anchors to `data-tour` DOM attributes on real UI elements; missing targets are handled gracefully (joyride shows tooltip centred). Four tours with step definitions covering setup, floorplan use, analytics, and bulk import.
- **WhatsNewModal** (`src/components/WhatsNewModal.jsx`): Bootstrap modal driven by `src/data/changelog.json`. Auto-shown once per release version on first app load; replayable from the sidebar.
- **changelog.json**: structured release notes for v1.4.0, v1.3.0, v1.2.0 with `new`, `improved`, and `fixed` entry types.
- **Sidebar**: adds collapsible "Take a tour" submenu (lists all four tours) and "What's new" shortcut. `SidebarMenu` items get `data-tour="nav-<key>"` attributes.
- **data-tour attributes**: added to `aside.app-sidebar`, `.floorplan-toolbar` (floor-nav), `.floorplan-wrapper` (floorplan-panel), and the plant list panel root.
- **MainLayout**: wraps layout in `TourProvider`; mounts `<FeatureTour />` and `<WhatsNewModal />`.

## Test plan

- [ ] `npm test` — 722 tests pass (11 new TourContext unit tests)
- [ ] `npm run test:coverage` — all thresholds pass
- [ ] Sidebar shows "What's new" and "Take a tour" nav items
- [ ] Clicking "Take a tour" expands the submenu listing all four tours
- [ ] Clicking a tour name launches the joyride overlay anchored to real DOM elements
- [ ] Tour can be replayed after completion via sidebar
- [ ] On first load after a new release, "What's new" modal appears automatically
- [ ] Closing "What's new" marks it as seen and it does not reappear on next load
- [ ] First-time users (no onboarding flag) do not see the "What's new" modal automatically

Closes #224