### PR TITLE
feat(ux): timezone preference for schedules, overdue badges, and calendar (#231)

### DIFF
--- a/src/__tests__/useTimezone.test.js
+++ b/src/__tests__/useTimezone.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTimezone, TIMEZONE_GROUPS } from '../hooks/useTimezone.js'
+
+describe('useTimezone', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('defaults to the browser IANA timezone when no preference is stored', () => {
+    const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone
+    const { result } = renderHook(() => useTimezone())
+    expect(result.current.timezone).toBe(browserTz)
+  })
+
+  it('reads a previously stored timezone from localStorage', () => {
+    localStorage.setItem('plantTracker_timezone', 'Europe/Berlin')
+    const { result } = renderHook(() => useTimezone())
+    expect(result.current.timezone).toBe('Europe/Berlin')
+  })
+
+  it('setTimezone updates the state and persists to localStorage', () => {
+    const { result } = renderHook(() => useTimezone())
+    act(() => {
+      result.current.setTimezone('Asia/Tokyo')
+    })
+    expect(result.current.timezone).toBe('Asia/Tokyo')
+    expect(localStorage.getItem('plantTracker_timezone')).toBe('Asia/Tokyo')
+  })
+})
+
+describe('TIMEZONE_GROUPS', () => {
+  it('includes a UTC group', () => {
+    const utcGroup = TIMEZONE_GROUPS.find((g) => g.label === 'UTC')
+    expect(utcGroup).toBeDefined()
+    expect(utcGroup.zones).toContain('UTC')
+  })
+
+  it('includes common timezones in each region', () => {
+    const labels = TIMEZONE_GROUPS.map((g) => g.label)
+    expect(labels).toContain('Americas')
+    expect(labels).toContain('Europe')
+    expect(labels).toContain('Asia')
+    expect(labels).toContain('Pacific')
+  })
+
+  it('every zone string is non-empty', () => {
+    for (const group of TIMEZONE_GROUPS) {
+      for (const tz of group.zones) {
+        expect(tz.length).toBeGreaterThan(0)
+      }
+    }
+  })
+})

--- a/src/__tests__/watering.test.js
+++ b/src/__tests__/watering.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getWateringStatus, getAdjustedWaterAmount, isOutdoor, urgencyColor, urgencyLabel, OUTDOOR_ROOMS, getSeason, SEASONAL_MULTIPLIERS, getPlantAttributeMultiplier, getSuggestedFrequency, getMoistureStatusAdjustment, getMoistureFrequencySuggestion, getMoistureDisplay, computeRainCredit } from '../utils/watering.js'
+import { getWateringStatus, getAdjustedWaterAmount, isOutdoor, urgencyColor, urgencyLabel, OUTDOOR_ROOMS, getSeason, SEASONAL_MULTIPLIERS, getPlantAttributeMultiplier, getSuggestedFrequency, getMoistureStatusAdjustment, getMoistureFrequencySuggestion, getMoistureDisplay, computeRainCredit, localDateStr } from '../utils/watering.js'
 
 function makePlant(overrides = {}) {
   return {
@@ -948,5 +948,50 @@ describe('computeRainCredit', () => {
   it('clamps rainSkipMultiplier to [0, 1]', () => {
     const result = computeRainCredit({ frequencyDays: 7, rainSkipMultiplier: 2 }, { recentMm: 20 })
     expect(result.advanceByDays).toBe(7) // clamped to 1.0 × 7
+  })
+})
+
+// ── localDateStr ─────────────────────────────────────────────────────────────
+
+describe('localDateStr', () => {
+  it('returns YYYY-MM-DD string for UTC', () => {
+    const d = new Date('2026-04-22T12:00:00Z')
+    expect(localDateStr(d, 'UTC')).toBe('2026-04-22')
+  })
+
+  it('returns correct date for UTC+9 (Tokyo) when time is just past midnight UTC', () => {
+    // 2026-04-22T00:30:00Z is still April 22 in UTC and April 22 in Tokyo (+9)
+    const d = new Date('2026-04-22T00:30:00Z')
+    expect(localDateStr(d, 'Asia/Tokyo')).toBe('2026-04-22')
+  })
+
+  it('returns next day for UTC+14 timezone', () => {
+    // 2026-04-22T23:00:00Z is April 23 in UTC+14
+    const d = new Date('2026-04-22T23:00:00Z')
+    expect(localDateStr(d, 'Pacific/Kiritimati')).toBe('2026-04-23')
+  })
+
+  it('accepts ISO string in place of Date object', () => {
+    expect(localDateStr('2026-06-15T10:00:00Z', 'UTC')).toBe('2026-06-15')
+  })
+})
+
+// ── getWateringStatus timezone ───────────────────────────────────────────────
+
+describe('getWateringStatus timezone', () => {
+  it('accepts a timezone parameter without throwing', () => {
+    const plant = makePlant({ lastWatered: new Date(Date.now() - 3 * 86400000).toISOString(), frequencyDays: 7 })
+    expect(() => getWateringStatus(plant, null, [], 'America/New_York')).not.toThrow()
+  })
+
+  it('daysUntil is an integer (no fractional days from TZ offset)', () => {
+    const plant = makePlant({ lastWatered: new Date(Date.now() - 3 * 86400000).toISOString(), frequencyDays: 7 })
+    const { daysUntil } = getWateringStatus(plant, null, [], 'Europe/London')
+    expect(Number.isInteger(daysUntil)).toBe(true)
+  })
+
+  it('defaults gracefully when timezone is null', () => {
+    const plant = makePlant()
+    expect(() => getWateringStatus(plant, null, [], null)).not.toThrow()
   })
 })

--- a/src/context/PlantContext.jsx
+++ b/src/context/PlantContext.jsx
@@ -5,6 +5,7 @@ import { subscribe as subscribeOfflineQueue, size as offlineQueueSize } from '..
 import { useWeather } from '../hooks/useWeather.js'
 import { useTempUnit } from '../hooks/useTempUnit.js'
 import { useUnitSystem } from '../hooks/useUnitSystem.js'
+import { useTimezone } from '../hooks/useTimezone.js'
 import { getWateringStatus, isOutdoor } from '../utils/watering.js'
 import { GUEST_PLANTS, GUEST_FLOORS } from '../data/guestData.js'
 import { toFriendlyError } from '../utils/errorMessages.js'
@@ -23,6 +24,7 @@ export function PlantProvider({ children }) {
   const { isAuthenticated, isGuest, logout } = useAuth()
   const tempUnit = useTempUnit()
   const unitSystem = useUnitSystem()
+  const { timezone, setTimezone } = useTimezone()
   const { weather, locationDenied, location, setLocation } = useWeather(tempUnit.unit)
 
   const [plants, setPlants] = useState([])
@@ -40,8 +42,8 @@ export function PlantProvider({ children }) {
   const [isOnline, setIsOnline] = useState(() => typeof navigator === 'undefined' || navigator.onLine !== false)
 
   const overdueCount = useMemo(
-    () => plants.filter((p) => getWateringStatus(p, weather, floors).daysUntil < 0).length,
-    [plants, weather, floors],
+    () => plants.filter((p) => getWateringStatus(p, weather, floors, timezone).daysUntil < 0).length,
+    [plants, weather, floors, timezone],
   )
 
   // Track offline queue size so the UI can show a pending-sync badge.
@@ -432,6 +434,7 @@ export function PlantProvider({ children }) {
     plantsHasMore, plantsLoadingMore, loadMorePlants,
     floors, activeFloorId, setActiveFloorId,
     weather, locationDenied, location, setLocation, tempUnit, unitSystem,
+    timezone, setTimezone,
     overdueCount, isAnalysingFloorplan,
     isGuest,
     isOnline, pendingSyncCount,
@@ -442,7 +445,7 @@ export function PlantProvider({ children }) {
     updatePlantsLocally,
   }), [
     plants, plantsLoading, plantsError, reloadPlants, floors, activeFloorId,
-    weather, locationDenied, location, setLocation, tempUnit, unitSystem, overdueCount, isAnalysingFloorplan, isGuest,
+    weather, locationDenied, location, setLocation, tempUnit, unitSystem, timezone, setTimezone, overdueCount, isAnalysingFloorplan, isGuest,
     isOnline, pendingSyncCount,
     plantsHasMore, plantsLoadingMore, loadMorePlants,
     handleSavePlant, handleWaterPlant, handleMoisturePlant, handleBatchWater,

--- a/src/hooks/useTimezone.js
+++ b/src/hooks/useTimezone.js
@@ -1,0 +1,82 @@
+import { useState, useCallback } from 'react'
+
+const STORAGE_KEY = 'plantTracker_timezone'
+
+function detectDefault() {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  } catch {}
+  return 'UTC'
+}
+
+function readStored() {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    if (v) return v
+  } catch {}
+  return null
+}
+
+export function useTimezone() {
+  const [timezone, setTimezoneState] = useState(() => readStored() || detectDefault())
+
+  const setTimezone = useCallback((tz) => {
+    setTimezoneState(tz)
+    try { localStorage.setItem(STORAGE_KEY, tz) } catch {}
+  }, [])
+
+  return { timezone, setTimezone }
+}
+
+/**
+ * Groups of commonly used IANA timezone identifiers for display in a picker.
+ * Not exhaustive — covers ~95% of users worldwide.
+ */
+export const TIMEZONE_GROUPS = [
+  { label: 'UTC', zones: ['UTC'] },
+  {
+    label: 'Americas',
+    zones: [
+      'America/Anchorage', 'America/Argentina/Buenos_Aires', 'America/Bogota',
+      'America/Caracas', 'America/Chicago', 'America/Denver', 'America/Halifax',
+      'America/Lima', 'America/Los_Angeles', 'America/Mexico_City', 'America/New_York',
+      'America/Phoenix', 'America/Sao_Paulo', 'America/Santiago', 'America/Toronto',
+      'America/Vancouver', 'Pacific/Honolulu',
+    ],
+  },
+  {
+    label: 'Europe',
+    zones: [
+      'Europe/Amsterdam', 'Europe/Athens', 'Europe/Berlin', 'Europe/Brussels',
+      'Europe/Bucharest', 'Europe/Budapest', 'Europe/Copenhagen', 'Europe/Dublin',
+      'Europe/Helsinki', 'Europe/Istanbul', 'Europe/Kiev', 'Europe/Lisbon',
+      'Europe/London', 'Europe/Madrid', 'Europe/Moscow', 'Europe/Oslo',
+      'Europe/Paris', 'Europe/Prague', 'Europe/Rome', 'Europe/Stockholm',
+      'Europe/Vienna', 'Europe/Warsaw',
+    ],
+  },
+  {
+    label: 'Africa & Middle East',
+    zones: [
+      'Africa/Cairo', 'Africa/Johannesburg', 'Africa/Lagos', 'Africa/Nairobi',
+      'Asia/Dubai', 'Asia/Jerusalem', 'Asia/Riyadh', 'Asia/Tehran',
+    ],
+  },
+  {
+    label: 'Asia',
+    zones: [
+      'Asia/Bangkok', 'Asia/Colombo', 'Asia/Dhaka', 'Asia/Hong_Kong',
+      'Asia/Jakarta', 'Asia/Karachi', 'Asia/Kolkata', 'Asia/Kuala_Lumpur',
+      'Asia/Manila', 'Asia/Seoul', 'Asia/Shanghai', 'Asia/Singapore',
+      'Asia/Taipei', 'Asia/Tokyo', 'Asia/Yangon',
+    ],
+  },
+  {
+    label: 'Pacific',
+    zones: [
+      'Australia/Adelaide', 'Australia/Brisbane', 'Australia/Darwin',
+      'Australia/Melbourne', 'Australia/Perth', 'Australia/Sydney',
+      'Pacific/Auckland', 'Pacific/Fiji', 'Pacific/Guam',
+    ],
+  },
+]

--- a/src/pages/CalendarPage.jsx
+++ b/src/pages/CalendarPage.jsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react'
 import { Button, Badge } from 'react-bootstrap'
 import { usePlantContext } from '../context/PlantContext.jsx'
-import { getWateringStatus } from '../utils/watering.js'
+import { getWateringStatus, localDateStr } from '../utils/watering.js'
 import { getFeedingStatus } from '../utils/feeding.js'
 import EmptyState from '../components/EmptyState.jsx'
 
@@ -16,76 +16,79 @@ function eventBadgeColor(type) {
 }
 
 export default function CalendarPage() {
-  const { plants, weather, floors } = usePlantContext()
+  const { plants, weather, floors, timezone } = usePlantContext()
   const [monthOffset, setMonthOffset] = useState(0)
   const [selectedDay, setSelectedDay] = useState(null)
 
-  const now = new Date()
-  const viewDate = new Date(now.getFullYear(), now.getMonth() + monthOffset, 1)
-  const year = viewDate.getFullYear()
-  const month = viewDate.getMonth()
+  // Use the user's timezone for "today" and date boundary calculations
+  const todayStr = localDateStr(new Date(), timezone)
+  const [todayYear, todayMonth1, todayDay] = todayStr.split('-').map(Number)
+  const todayMonth = todayMonth1 - 1
+
+  const viewYear  = monthOffset === 0 ? todayYear  : (() => { const d = new Date(todayYear, todayMonth + monthOffset, 1); return d.getFullYear() })()
+  const viewMonth = monthOffset === 0 ? todayMonth : (() => { const d = new Date(todayYear, todayMonth + monthOffset, 1); return d.getMonth() })()
+  const year  = viewYear
+  const month = viewMonth
   const daysInMonth = new Date(year, month + 1, 0).getDate()
   const firstDay = (new Date(year, month, 1).getDay() + 6) % 7
-  const monthName = new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' }).format(viewDate)
+  const monthName = new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' }).format(new Date(year, month, 1))
 
-  const isToday = (day) => {
-    const t = new Date()
-    return day === t.getDate() && month === t.getMonth() && year === t.getFullYear()
-  }
+  const isToday = (day) => day === todayDay && month === todayMonth && year === todayYear
 
   const dayMap = useMemo(() => {
     const map = {}
-    const monthEnd = new Date(year, month + 1, 0)
+    const monthEndTs = new Date(year, month + 1, 0).getTime()
     for (const plant of plants) {
-      // Past waterings
+      // Past waterings — place on the day they occurred in the user's timezone
       for (const entry of plant.wateringLog || []) {
-        const d = new Date(entry.date)
-        if (d.getMonth() === month && d.getFullYear() === year) {
-          const day = d.getDate()
-          if (!map[day]) map[day] = []
-          map[day].push({ type: 'watered', plant })
+        const ds = localDateStr(new Date(entry.date), timezone)
+        const [eY, eM1, eD] = ds.split('-').map(Number)
+        if (eM1 - 1 === month && eY === year) {
+          if (!map[eD]) map[eD] = []
+          map[eD].push({ type: 'watered', plant })
         }
       }
       // Past fertilisings
       for (const entry of plant.fertiliserLog || []) {
-        const d = new Date(entry.date)
-        if (d.getMonth() === month && d.getFullYear() === year) {
-          const day = d.getDate()
-          if (!map[day]) map[day] = []
-          map[day].push({ type: 'fertilised', plant })
+        const ds = localDateStr(new Date(entry.date), timezone)
+        const [eY, eM1, eD] = ds.split('-').map(Number)
+        if (eM1 - 1 === month && eY === year) {
+          if (!map[eD]) map[eD] = []
+          map[eD].push({ type: 'fertilised', plant })
         }
       }
       // Future watering due dates
-      const status = getWateringStatus(plant, weather, floors)
       if (plant.lastWatered && plant.frequencyDays) {
         let nextDue = new Date(plant.lastWatered)
         for (let i = 0; i < 60; i++) {
           nextDue = new Date(nextDue.getTime() + plant.frequencyDays * 86400000)
-          if (nextDue.getMonth() === month && nextDue.getFullYear() === year) {
-            const day = nextDue.getDate()
-            if (!map[day]) map[day] = []
-            map[day].push({ type: 'due', plant })
+          const ds = localDateStr(nextDue, timezone)
+          const [eY, eM1, eD] = ds.split('-').map(Number)
+          if (eM1 - 1 === month && eY === year) {
+            if (!map[eD]) map[eD] = []
+            map[eD].push({ type: 'due', plant })
           }
-          if (nextDue > monthEnd) break
+          if (nextDue.getTime() > monthEndTs) break
         }
       }
-      // Future feeding due dates (based on schedule + lastFertilised)
+      // Future feeding due dates
       const feedStatus = getFeedingStatus(plant, weather)
       if (!feedStatus.skip && plant.lastFertilised && feedStatus.effectiveFrequencyDays) {
         let nextFeed = new Date(plant.lastFertilised)
         for (let i = 0; i < 24; i++) {
           nextFeed = new Date(nextFeed.getTime() + feedStatus.effectiveFrequencyDays * 86400000)
-          if (nextFeed.getMonth() === month && nextFeed.getFullYear() === year) {
-            const day = nextFeed.getDate()
-            if (!map[day]) map[day] = []
-            map[day].push({ type: 'feed-due', plant })
+          const ds = localDateStr(nextFeed, timezone)
+          const [eY, eM1, eD] = ds.split('-').map(Number)
+          if (eM1 - 1 === month && eY === year) {
+            if (!map[eD]) map[eD] = []
+            map[eD].push({ type: 'feed-due', plant })
           }
-          if (nextFeed > monthEnd) break
+          if (nextFeed.getTime() > monthEndTs) break
         }
       }
     }
     return map
-  }, [plants, weather, floors, month, year])
+  }, [plants, weather, floors, month, year, timezone])
 
   const selectedEvents = selectedDay ? dayMap[selectedDay] || [] : []
 

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -7,6 +7,7 @@ import { useAuth } from '../contexts/AuthContext.jsx'
 import HelpTooltip from '../components/HelpTooltip.jsx'
 import LeafletFloorplan from '../components/LeafletFloorplan.jsx'
 import { YARD_AREAS } from '../utils/watering.js'
+import { TIMEZONE_GROUPS } from '../hooks/useTimezone.js'
 import { accountApi, exportApi } from '../api/plants.js'
 
 const TABS = [
@@ -320,7 +321,7 @@ function PropertyTab({ search }) {
 }
 
 function PreferencesTab({ search }) {
-  const { tempUnit, unitSystem, location, setLocation } = usePlantContext()
+  const { tempUnit, unitSystem, location, setLocation, timezone, setTimezone } = usePlantContext()
   const { themeMode, changeThemeMode } = useLayoutContext()
   const [locationSearch, setLocationSearch] = useState('')
   const [locationResults, setLocationResults] = useState([])
@@ -455,6 +456,30 @@ function PreferencesTab({ search }) {
             ))}
           </div>
         )}
+      </SettingSection>
+
+      <SettingSection id="timezone" title="Timezone" icon="clock" search={search}>
+        <div className="d-flex align-items-center justify-content-between flex-wrap gap-2">
+          <div>
+            <div className="fw-500 fs-sm">Timezone</div>
+            <div className="text-muted fs-xs">Used for overdue badges, calendar days, and watering schedules</div>
+          </div>
+          <Form.Select
+            size="sm"
+            value={timezone}
+            onChange={(e) => setTimezone(e.target.value)}
+            style={{ maxWidth: 260 }}
+            aria-label="Select timezone"
+          >
+            {TIMEZONE_GROUPS.map((group) => (
+              <optgroup key={group.label} label={group.label}>
+                {group.zones.map((tz) => (
+                  <option key={tz} value={tz}>{tz.replace(/_/g, ' ')}</option>
+                ))}
+              </optgroup>
+            ))}
+          </Form.Select>
+        </div>
       </SettingSection>
     </>
   )

--- a/src/utils/watering.js
+++ b/src/utils/watering.js
@@ -1,6 +1,21 @@
 // Plants in these room names are treated as outdoor for weather-aware watering
 export const OUTDOOR_ROOMS = new Set(['Garden', 'Balcony', 'Outdoors', 'Patio', 'Terrace', 'Verandah', 'Veranda', 'Deck', 'Courtyard'])
 
+/**
+ * Returns "YYYY-MM-DD" for the given date in the specified IANA timezone.
+ * Falls back to local date if the timezone is invalid.
+ */
+export function localDateStr(date, timezone) {
+  try {
+    return new Intl.DateTimeFormat('en-CA', { timeZone: timezone }).format(
+      date instanceof Date ? date : new Date(date),
+    )
+  } catch {
+    const d = date instanceof Date ? date : new Date(date)
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  }
+}
+
 // Yard areas for outdoor zones — rendered around the house
 export const YARD_AREAS = [
   { id: 'frontyard', label: 'Front Yard' },
@@ -142,7 +157,8 @@ export function getPlantAttributeMultiplier(plant) {
  * @param {Array}       floors  - array of floor objects from floorsApi
  * @returns {{ daysUntil: number, color: string, label: string, note: string|null, skippedRain: boolean, season: string|null, seasonNote: string|null }}
  */
-export function getWateringStatus(plant, weather = null, floors = []) {
+export function getWateringStatus(plant, weather = null, floors = [], timezone = null) {
+  const tz = timezone || (typeof Intl !== 'undefined' ? Intl.DateTimeFormat().resolvedOptions().timeZone : 'UTC')
   const outdoor   = isOutdoor(plant, floors)
   const temp      = weather?.current?.temp ?? null
   const tempC     = temp !== null ? toC(temp, weather?.unit) : null
@@ -228,7 +244,10 @@ export function getWateringStatus(plant, weather = null, floors = []) {
 
   const last      = new Date(plant.lastWatered)
   const next      = new Date(last.getTime() + effective * 86400000)
-  const daysUntil = Math.ceil((next - new Date()) / 86400000)
+  // Compare as day strings in the user's timezone so the boundary doesn't shift with UTC offset
+  const todayStr  = localDateStr(new Date(), tz)
+  const nextStr   = localDateStr(next, tz)
+  const daysUntil = Math.round((new Date(nextStr) - new Date(todayStr)) / 86400000)
 
   // Note priority: heat > moisture meter > dry air > rain forecast > seasonal
   let note = heatNote(tempC)


### PR DESCRIPTION
## Summary

- **`useTimezone` hook** (`src/hooks/useTimezone.js`): reads/writes an IANA timezone string to localStorage; defaults to `Intl.DateTimeFormat().resolvedOptions().timeZone`. Exports `TIMEZONE_GROUPS` — a curated list of ~75 timezones grouped by region for use in the settings picker.
- **`localDateStr(date, timezone)`** added to `src/utils/watering.js`: returns `"YYYY-MM-DD"` for any date in the user's IANA timezone using `Intl.DateTimeFormat`, with a graceful fallback for invalid zones.
- **`getWateringStatus`** now accepts an optional `timezone` parameter. The `daysUntil` calculation compares day strings in the user's timezone (not UTC midnight), so overdue badges update correctly when the user changes timezone or travels.
- **`PlantContext`**: uses `useTimezone`, threads `timezone` through `overdueCount` and exposes `timezone`/`setTimezone` in context.
- **`CalendarPage`**: `isToday()` and all date-to-calendar-day mappings (waterings, fertilisings, due/feed dates) use `localDateStr` in the user's timezone. The "today" cell correctly tracks the user's chosen TZ without a reload.
- **Settings > Preferences**: new Timezone section with a grouped `<select>` of IANA zones.

## Test plan

- [ ] `npm test` — 735 tests pass (13 new: useTimezone hook, TIMEZONE_GROUPS, localDateStr, getWateringStatus timezone)
- [ ] Settings > Preferences shows a "Timezone" section with a grouped timezone picker
- [ ] Changing timezone in Settings immediately recomputes overdue badges (no reload required)
- [ ] Calendar "today" cell matches the selected timezone when it differs from the browser TZ
- [ ] Watering log dates in the Calendar are placed on the correct day in the user's timezone

Closes #231