### PR TITLE
feat(#167): white-label branding settings

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -931,6 +931,52 @@ app.put('/config/floorplan', requireUser, async (req, res) => {
   }
 });
 
+// ── Branding config ───────────────────────────────────────────────────────────
+
+const BRANDING_DEFAULTS = {
+  businessName: '',
+  primaryColor: '#2d5a1b',
+  contactPhone: '',
+  contactEmail: '',
+  contactWebsite: '',
+  logoUrl: null,
+};
+
+app.get('/config/branding', requireUser, async (req, res) => {
+  try {
+    const doc = await userConfig(req.userId).doc('branding').get();
+    const data = doc.exists ? { ...BRANDING_DEFAULTS, ...doc.data() } : { ...BRANDING_DEFAULTS };
+    if (data.logoUrl) data.logoUrl = await signReadUrl(data.logoUrl);
+    res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.put('/config/branding', requireUser, async (req, res) => {
+  try {
+    const { businessName, primaryColor, contactPhone, contactEmail, contactWebsite, logoUrl } = req.body;
+    if (primaryColor && !/^#[0-9a-fA-F]{6}$/.test(primaryColor)) {
+      return res.status(400).json({ error: 'primaryColor must be a valid hex colour (e.g. #2d5a1b)' });
+    }
+    const payload = {
+      businessName: businessName || '',
+      primaryColor: primaryColor || '#2d5a1b',
+      contactPhone: contactPhone || '',
+      contactEmail: contactEmail || '',
+      contactWebsite: contactWebsite || '',
+      logoUrl: logoUrl || null,
+      updatedAt: new Date().toISOString(),
+    };
+    await userConfig(req.userId).doc('branding').set(payload, { merge: true });
+    const result = { ...payload };
+    if (result.logoUrl) result.logoUrl = await signReadUrl(result.logoUrl);
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Plants CRUD ───────────────────────────────────────────────────────────────
 
 app.get('/plants', requireUser, async (req, res) => {

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -1294,6 +1294,72 @@ describe('PUT /config/floorplan', () => {
   });
 });
 
+// ── GET /config/branding ──────────────────────────────────────────────────────
+
+const brandingPath = () => `users/${USER_SUB}/config/branding`;
+
+describe('GET /config/branding', () => {
+  it('returns defaults when no branding config exists', async () => {
+    const res = await request(app).get('/config/branding').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.businessName).toBe('');
+    expect(res.body.primaryColor).toBe('#2d5a1b');
+    expect(res.body.logoUrl).toBeNull();
+  });
+
+  it('returns saved branding config', async () => {
+    store[brandingPath()] = { businessName: 'Green Thumb', primaryColor: '#006400', contactEmail: 'hi@gt.com', contactPhone: '', contactWebsite: '', logoUrl: null };
+    const res = await request(app).get('/config/branding').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.businessName).toBe('Green Thumb');
+    expect(res.body.primaryColor).toBe('#006400');
+  });
+
+  it('signs logoUrl when present', async () => {
+    store[brandingPath()] = { businessName: 'Acme', primaryColor: '#2d5a1b', logoUrl: 'branding/logo.png', contactPhone: '', contactEmail: '', contactWebsite: '' };
+    storageSignedUrlFn = async () => ['https://signed.url/logo.png'];
+    const res = await request(app).get('/config/branding').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.logoUrl).toBe('https://signed.url/logo.png');
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/config/branding');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── PUT /config/branding ──────────────────────────────────────────────────────
+
+describe('PUT /config/branding', () => {
+  it('saves and returns branding config', async () => {
+    const payload = { businessName: 'Leaf & Co', primaryColor: '#3a7d44', contactPhone: '555-1234', contactEmail: 'leaf@co.com', contactWebsite: 'https://leaf.co', logoUrl: null };
+    const res = await request(app).put('/config/branding').set('Authorization', authHeader()).send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.businessName).toBe('Leaf & Co');
+    expect(res.body.primaryColor).toBe('#3a7d44');
+  });
+
+  it('persists branding to Firestore', async () => {
+    await request(app).put('/config/branding').set('Authorization', authHeader())
+      .send({ businessName: 'Sprout', primaryColor: '#2d5a1b', contactPhone: '', contactEmail: '', contactWebsite: '', logoUrl: null });
+    expect(store[brandingPath()].businessName).toBe('Sprout');
+    expect(store[brandingPath()].updatedAt).toBeTruthy();
+  });
+
+  it('rejects invalid primaryColor', async () => {
+    const res = await request(app).put('/config/branding').set('Authorization', authHeader())
+      .send({ primaryColor: 'not-a-color' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/hex/i);
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app).put('/config/branding').send({ businessName: 'Test' });
+    expect(res.status).toBe(401);
+  });
+});
+
 // ── ML export endpoint ───────────────────────────────────────────────────────
 
 describe('GET /ml/export', () => {

--- a/src/__tests__/BrandingSettings.test.jsx
+++ b/src/__tests__/BrandingSettings.test.jsx
@@ -1,0 +1,117 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../api/plants.js', () => ({
+  brandingApi: {
+    get: vi.fn(),
+    save: vi.fn(),
+  },
+  imagesApi: {
+    upload: vi.fn(),
+  },
+  plantsApi: { list: vi.fn().mockResolvedValue([]) },
+  floorsApi: { get: vi.fn().mockResolvedValue({ floors: [] }), save: vi.fn() },
+  analyseApi: { analyseFloorplan: vi.fn(), analyse: vi.fn() },
+  setApiCredential: vi.fn(),
+  recommendApi: { get: vi.fn() },
+}))
+
+vi.mock('../context/PlantContext.jsx', () => ({
+  usePlantContext: () => ({
+    floors: [],
+    handleSaveFloors: vi.fn(),
+    handleFloorplanUpload: vi.fn(),
+    isAnalysingFloorplan: false,
+    tempUnit: null,
+    isGuest: false,
+    location: null,
+    setLocation: vi.fn(),
+  }),
+}))
+
+vi.mock('../context/LayoutContext.jsx', () => ({
+  useLayoutContext: () => ({ theme: 'light', changeTheme: vi.fn() }),
+}))
+
+vi.mock('../components/LeafletFloorplan.jsx', () => ({
+  default: () => <div data-testid="leaflet-floorplan" />,
+}))
+
+const { brandingApi } = await import('../api/plants.js')
+
+import SettingsPage from '../pages/SettingsPage.jsx'
+
+describe('BrandingSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    brandingApi.get.mockResolvedValue({
+      businessName: '',
+      primaryColor: '#2d5a1b',
+      contactPhone: '',
+      contactEmail: '',
+      contactWebsite: '',
+      logoUrl: null,
+    })
+  })
+
+  it('renders the Branding panel heading', async () => {
+    render(<SettingsPage />)
+    await waitFor(() => expect(screen.getByText('Branding')).toBeInTheDocument())
+  })
+
+  it('shows default branding values from API', async () => {
+    render(<SettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Business name')).toHaveValue('')
+      expect(screen.getByLabelText('Brand colour hex code')).toHaveValue('#2d5a1b')
+    })
+  })
+
+  it('pre-fills saved businessName from API', async () => {
+    brandingApi.get.mockResolvedValue({
+      businessName: 'Green Thumb Gardens',
+      primaryColor: '#006400',
+      contactPhone: '',
+      contactEmail: '',
+      contactWebsite: '',
+      logoUrl: null,
+    })
+    render(<SettingsPage />)
+    await waitFor(() =>
+      expect(screen.getByLabelText('Business name')).toHaveValue('Green Thumb Gardens'),
+    )
+  })
+
+  it('calls brandingApi.save on Save click', async () => {
+    brandingApi.save.mockResolvedValue({
+      businessName: 'Leaf Co',
+      primaryColor: '#2d5a1b',
+      contactPhone: '',
+      contactEmail: '',
+      contactWebsite: '',
+      logoUrl: null,
+    })
+    render(<SettingsPage />)
+    await waitFor(() => screen.getByLabelText('Save branding settings'))
+    const input = screen.getByLabelText('Business name')
+    fireEvent.change(input, { target: { value: 'Leaf Co' } })
+    fireEvent.click(screen.getByLabelText('Save branding settings'))
+    await waitFor(() => expect(brandingApi.save).toHaveBeenCalled())
+  })
+
+  it('shows Saved! feedback after successful save', async () => {
+    brandingApi.save.mockResolvedValue({
+      businessName: '',
+      primaryColor: '#2d5a1b',
+      contactPhone: '',
+      contactEmail: '',
+      contactWebsite: '',
+      logoUrl: null,
+    })
+    render(<SettingsPage />)
+    await waitFor(() => screen.getByLabelText('Save branding settings'))
+    fireEvent.click(screen.getByLabelText('Save branding settings'))
+    await waitFor(() => expect(screen.getByText('Saved!')).toBeInTheDocument())
+  })
+})

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -1,6 +1,10 @@
 import { vi } from 'vitest'
 import '@testing-library/jest-dom'
 
+// Build-time globals injected by Vite — stub for jsdom test environment
+globalThis.__APP_VERSION__ = 'test'
+globalThis.__BUILD_TIME__ = '2024-01-01T00:00:00.000Z'
+
 // jsdom doesn't implement pointer capture APIs used by PlantMarker drag logic
 Element.prototype.setPointerCapture = vi.fn()
 Element.prototype.releasePointerCapture = vi.fn()

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -135,3 +135,8 @@ export const imagesApi = {
     return publicUrl
   },
 }
+
+export const brandingApi = {
+  get: () => request('/config/branding'),
+  save: (data) => request('/config/branding', { method: 'PUT', body: JSON.stringify(data) }),
+}

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,9 +1,10 @@
-import { useState, useCallback, useRef } from 'react'
-import { Button, Form, Table, Badge } from 'react-bootstrap'
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { Button, Form, Table, Badge, Spinner } from 'react-bootstrap'
 import { usePlantContext } from '../context/PlantContext.jsx'
 import { useLayoutContext } from '../context/LayoutContext.jsx'
 import LeafletFloorplan from '../components/LeafletFloorplan.jsx'
 import { YARD_AREAS } from '../utils/watering.js'
+import { brandingApi, imagesApi } from '../api/plants.js'
 
 
 
@@ -179,6 +180,188 @@ function FloorRow({ floor, onChange, onDelete, expanded, onToggle }) {
         </tr>
       )}
     </>
+  )
+}
+
+function BrandingSection() {
+  const [branding, setBranding] = useState({
+    businessName: '', primaryColor: '#2d5a1b',
+    contactPhone: '', contactEmail: '', contactWebsite: '', logoUrl: null,
+  })
+  const [loading, setLoading] = useState(true)
+  const [saving, setBrandingSaving] = useState(false)
+  const [saved, setBrandingSaved] = useState(false)
+  const [logoUploading, setLogoUploading] = useState(false)
+  const logoInputRef = useRef(null)
+
+  useEffect(() => {
+    brandingApi.get()
+      .then((data) => setBranding(data))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  const handleChange = (field, value) => setBranding((prev) => ({ ...prev, [field]: value }))
+
+  const handleLogoUpload = async (file) => {
+    if (!file) return
+    setLogoUploading(true)
+    try {
+      const url = await imagesApi.upload(file, 'branding')
+      setBranding((prev) => ({ ...prev, logoUrl: url }))
+    } catch { /* ignore */ }
+    setLogoUploading(false)
+  }
+
+  const handleSave = async () => {
+    setBrandingSaving(true)
+    try {
+      const result = await brandingApi.save(branding)
+      setBranding(result)
+      setBrandingSaved(true)
+      setTimeout(() => setBrandingSaved(false), 2000)
+    } catch { /* ignore */ }
+    setBrandingSaving(false)
+  }
+
+  if (loading) return <div className="p-3"><Spinner size="sm" /></div>
+
+  return (
+    <div className="panel panel-icon mb-4">
+      <div className="panel-hdr">
+        <span>
+          <svg className="sa-icon me-2"><use href="/icons/sprite.svg#tag"></use></svg>
+          Branding
+        </span>
+      </div>
+      <div className="panel-container"><div className="panel-content">
+        <p className="text-muted fs-sm mb-3">
+          Customise your business identity for client-facing reports and portals.
+        </p>
+
+        <Form.Group className="mb-3">
+          <Form.Label>Business name</Form.Label>
+          <Form.Control
+            value={branding.businessName}
+            onChange={(e) => handleChange('businessName', e.target.value)}
+            placeholder="e.g. Green Thumb Gardens"
+            aria-label="Business name"
+          />
+        </Form.Group>
+
+        <Form.Group className="mb-3">
+          <Form.Label>Brand colour</Form.Label>
+          <div className="d-flex align-items-center gap-2">
+            <Form.Control
+              type="color"
+              value={branding.primaryColor}
+              onChange={(e) => handleChange('primaryColor', e.target.value)}
+              style={{ width: 48, height: 38, padding: 2 }}
+              aria-label="Brand colour picker"
+            />
+            <Form.Control
+              value={branding.primaryColor}
+              onChange={(e) => handleChange('primaryColor', e.target.value)}
+              placeholder="#2d5a1b"
+              pattern="^#[0-9a-fA-F]{6}$"
+              maxLength={7}
+              aria-label="Brand colour hex code"
+              style={{ maxWidth: 120 }}
+            />
+          </div>
+        </Form.Group>
+
+        <Form.Group className="mb-3">
+          <Form.Label>Logo</Form.Label>
+          <div className="d-flex align-items-center gap-3">
+            {branding.logoUrl && (
+              <img
+                src={branding.logoUrl}
+                alt="Business logo"
+                style={{ maxHeight: 60, maxWidth: 200, objectFit: 'contain', borderRadius: 4 }}
+              />
+            )}
+            <Button
+              variant="outline-primary"
+              size="sm"
+              onClick={() => logoInputRef.current?.click()}
+              disabled={logoUploading}
+              aria-label="Upload logo"
+            >
+              {logoUploading ? <Spinner size="sm" /> : (
+                <>
+                  <svg className="sa-icon me-1" style={{ width: 14, height: 14 }}>
+                    <use href="/icons/sprite.svg#upload"></use>
+                  </svg>
+                  {branding.logoUrl ? 'Replace logo' : 'Upload logo'}
+                </>
+              )}
+            </Button>
+            {branding.logoUrl && (
+              <Button
+                variant="link"
+                size="sm"
+                className="text-danger p-0"
+                onClick={() => handleChange('logoUrl', null)}
+                aria-label="Remove logo"
+              >
+                Remove
+              </Button>
+            )}
+          </div>
+          <small className="text-muted d-block mt-1">PNG, SVG or JPEG, max 2 MB. Displayed in reports and client portals.</small>
+          <input
+            ref={logoInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/svg+xml"
+            className="d-none"
+            onChange={(e) => { handleLogoUpload(e.target.files?.[0]); e.target.value = '' }}
+          />
+        </Form.Group>
+
+        <Form.Group className="mb-3">
+          <Form.Label>Contact phone</Form.Label>
+          <Form.Control
+            type="tel"
+            value={branding.contactPhone}
+            onChange={(e) => handleChange('contactPhone', e.target.value)}
+            placeholder="+1 555 000 1234"
+            aria-label="Contact phone"
+          />
+        </Form.Group>
+
+        <Form.Group className="mb-3">
+          <Form.Label>Contact email</Form.Label>
+          <Form.Control
+            type="email"
+            value={branding.contactEmail}
+            onChange={(e) => handleChange('contactEmail', e.target.value)}
+            placeholder="hello@example.com"
+            aria-label="Contact email"
+          />
+        </Form.Group>
+
+        <Form.Group className="mb-3">
+          <Form.Label>Website</Form.Label>
+          <Form.Control
+            type="url"
+            value={branding.contactWebsite}
+            onChange={(e) => handleChange('contactWebsite', e.target.value)}
+            placeholder="https://example.com"
+            aria-label="Contact website"
+          />
+        </Form.Group>
+
+        <Button
+          variant={saved ? 'success' : 'primary'}
+          onClick={handleSave}
+          disabled={saving}
+          aria-label="Save branding settings"
+        >
+          {saving ? <Spinner size="sm" /> : saved ? 'Saved!' : 'Save Branding'}
+        </Button>
+      </div></div>
+    </div>
   )
 }
 
@@ -396,6 +579,9 @@ export default function SettingsPage() {
             </div>
 
           </div>
+
+          {/* Branding */}
+          <BrandingSection />
 
         </div>
 


### PR DESCRIPTION
## Summary

Implements #167 — white-label branding settings for landscaper client portals.

- **Backend**: `GET /config/branding` and `PUT /config/branding` routes storing branding config in Firestore at `users/{userId}/config/branding`. Logo URLs are signed on read. Validates `primaryColor` as a hex string.
- **Frontend API**: `brandingApi.get()` / `brandingApi.save()` added to `src/api/plants.js`.
- **Settings UI**: New `BrandingSection` panel in SettingsPage with business name, brand colour (colour picker + hex input), logo upload (GCS), contact phone/email/website, and Save button with feedback.
- **Tests**: 4 backend route tests (defaults, save, logo signing, auth) + 5 frontend component tests.

## Test plan

- [ ] Backend: `npm test` in `api/plants/` — all tests pass including 4 new branding tests
- [ ] Frontend: coverage thresholds all pass (lines ≥ 35%, branches ≥ 35%, functions ≥ 30%)
- [ ] Branding panel appears in `/settings`
- [ ] Colour picker and hex input stay in sync
- [ ] Logo upload uses existing GCS signed-URL flow
- [ ] Save button shows "Saved!" feedback on success

Closes #167

https://claude.ai/code/session_01CY9bPiRfY8o7DB6RaUdCVf