### PR TITLE
feat(insights): surface anomaly detection, seasonal adjustments & species clustering in ML Insights

### DIFF
--- a/src/__tests__/InsightsPage.test.jsx
+++ b/src/__tests__/InsightsPage.test.jsx
@@ -1,0 +1,238 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('react-apexcharts', () => ({
+  default: ({ type }) => <div data-testid="apex-chart" data-type={type} />,
+}))
+
+vi.mock('../components/UpgradePrompt.jsx', () => ({
+  default: ({ children }) => <div data-testid="upgrade-prompt">{children}</div>,
+}))
+
+vi.mock('../components/EmptyState.jsx', () => ({
+  default: ({ title }) => <div data-testid="empty-state">{title}</div>,
+}))
+
+vi.mock('../components/Skeleton.jsx', () => ({
+  SkeletonCard: () => <div data-testid="skeleton-card" />,
+  SkeletonRect: () => <div data-testid="skeleton-rect" />,
+}))
+
+vi.mock('../context/PlantContext.jsx', () => ({
+  usePlantContext: vi.fn(),
+}))
+
+vi.mock('../context/LayoutContext.jsx', () => ({
+  useLayoutContext: vi.fn(),
+}))
+
+vi.mock('../api/plants.js', () => ({
+  plantsApi: {
+    careScores: vi.fn(),
+    wateringPattern: vi.fn(),
+    healthPrediction: vi.fn(),
+    anomaly: vi.fn(),
+    wateringRecommendation: vi.fn(),
+    seasonalAdjustment: vi.fn(),
+    speciesCluster: vi.fn(),
+  },
+}))
+
+import { usePlantContext } from '../context/PlantContext.jsx'
+import { useLayoutContext } from '../context/LayoutContext.jsx'
+import { plantsApi } from '../api/plants.js'
+import InsightsPage from '../pages/InsightsPage.jsx'
+
+const MOCK_CARE_SCORES = [
+  {
+    plantId: 'p1',
+    name: 'Monstera',
+    species: 'Monstera deliciosa',
+    score: 82,
+    grade: 'B',
+    dimensions: { consistency: 80, timing: 85, healthOutcome: 80, responsiveness: 70 },
+  },
+  {
+    plantId: 'p2',
+    name: 'Snake Plant',
+    species: 'Sansevieria',
+    score: 42,
+    grade: 'F',
+    dimensions: { consistency: 40, timing: 40, healthOutcome: 50, responsiveness: 35 },
+  },
+]
+
+const MOCK_ANOMALY_NORMAL = { isAnomaly: false, score: 0.1, flags: [], detectedAt: null }
+const MOCK_ANOMALY_DETECTED = {
+  isAnomaly: true,
+  score: 0.9,
+  flags: ['Longest gap was 25 days', 'High watering variability'],
+  detectedAt: '2026-01-01T00:00:00.000Z',
+}
+const MOCK_SEASONAL = {
+  season: 'winter',
+  multiplier: 0.75,
+  adjustedFrequencyDays: 11,
+  note: 'Reduce watering in winter',
+  source: 'heuristic',
+}
+const MOCK_CLUSTER = {
+  clusterId: 'forgiving_foliage',
+  clusterLabel: 'Forgiving Foliage',
+  similarSpecies: ['pothos', 'philodendron', 'rubber plant'],
+  clusterCareProfile: { avgFrequency: 8, droughtTolerance: 'medium', humidityNeed: 'medium' },
+  source: 'default',
+}
+
+function buildPlants(count, wateringsEach) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `p${i}`,
+    name: `Plant ${i}`,
+    wateringLog: Array.from({ length: wateringsEach }, (_, j) => ({
+      date: new Date(Date.now() - j * 86400000 * 7).toISOString(),
+    })),
+    fertiliserLog: [],
+  }))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  usePlantContext.mockReturnValue({ plants: buildPlants(5, 5) })
+  useLayoutContext.mockReturnValue({ theme: 'light' })
+
+  plantsApi.careScores.mockResolvedValue(MOCK_CARE_SCORES)
+  plantsApi.wateringPattern.mockResolvedValue({ pattern: 'optimal', contributingFactors: ['Consistent schedule'] })
+  plantsApi.healthPrediction.mockResolvedValue({ predictedHealth: 'good', trend: 'stable', keyRisks: [] })
+  plantsApi.anomaly.mockResolvedValue(MOCK_ANOMALY_NORMAL)
+  plantsApi.wateringRecommendation.mockResolvedValue({ recommendedFrequencyDays: 8, basis: 'Based on history', confidenceInterval: [7, 9] })
+  plantsApi.seasonalAdjustment.mockResolvedValue(MOCK_SEASONAL)
+  plantsApi.speciesCluster.mockResolvedValue(MOCK_CLUSTER)
+})
+
+describe('InsightsPage', () => {
+  it('shows not-enough-data empty state when fewer than 3 plants', () => {
+    usePlantContext.mockReturnValue({ plants: buildPlants(1, 3) })
+    render(<InsightsPage />)
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+    expect(screen.getByText('Not enough data yet')).toBeInTheDocument()
+  })
+
+  it('shows not-enough-data empty state when plants have fewer than 10 waterings total', () => {
+    usePlantContext.mockReturnValue({ plants: buildPlants(4, 1) })
+    render(<InsightsPage />)
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+  })
+
+  it('shows loading skeletons while fetching care scores', () => {
+    plantsApi.careScores.mockReturnValue(new Promise(() => {}))
+    render(<InsightsPage />)
+    expect(screen.getAllByTestId('skeleton-card').length).toBeGreaterThan(0)
+  })
+
+  it('renders collection overview with avg score and at-risk list after load', async () => {
+    render(<InsightsPage />)
+    await waitFor(() => expect(screen.getByText('Collection Health')).toBeInTheDocument())
+    // Average of 82 and 42 = 62
+    expect(screen.getByText('62')).toBeInTheDocument()
+    // At-risk section renders plant name with score < 60 (multiple matches are fine here)
+    expect(screen.getAllByText('Snake Plant').length).toBeGreaterThan(0)
+  })
+
+  it('renders plant score rows with grade badges', async () => {
+    render(<InsightsPage />)
+    await waitFor(() => expect(screen.getAllByText('Monstera').length).toBeGreaterThan(0))
+    expect(screen.getAllByText('B').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('F').length).toBeGreaterThan(0)
+  })
+
+  it('expanding a plant fetches and displays anomaly, seasonal, and cluster sections', async () => {
+    render(<InsightsPage />)
+    await waitFor(() => expect(screen.getByText('Monstera')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByLabelText('Monstera care score details'))
+
+    await waitFor(() => expect(screen.getByTestId('anomaly-section')).toBeInTheDocument())
+    expect(screen.getByTestId('seasonal-section')).toBeInTheDocument()
+    expect(screen.getByTestId('cluster-section')).toBeInTheDocument()
+
+    // Anomaly: normal
+    expect(screen.getByText('Normal behaviour')).toBeInTheDocument()
+
+    // Seasonal data
+    expect(screen.getByText('winter')).toBeInTheDocument()
+    expect(screen.getByText(/11/)).toBeInTheDocument()
+
+    // Cluster data
+    expect(screen.getByText('Forgiving Foliage')).toBeInTheDocument()
+  })
+
+  it('calls speciesCluster with the plant species name', async () => {
+    render(<InsightsPage />)
+    await waitFor(() => expect(screen.getByText('Monstera')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Monstera care score details'))
+    await waitFor(() => expect(plantsApi.speciesCluster).toHaveBeenCalledWith('Monstera deliciosa'))
+  })
+
+  it('shows anomaly-detected badge and flags when isAnomaly is true', async () => {
+    plantsApi.anomaly.mockResolvedValue(MOCK_ANOMALY_DETECTED)
+    render(<InsightsPage />)
+    await waitFor(() => expect(screen.getAllByText('Snake Plant').length).toBeGreaterThan(0))
+
+    fireEvent.click(screen.getByLabelText('Snake Plant care score details'))
+
+    await waitFor(() => expect(screen.getByTestId('anomaly-section')).toBeInTheDocument())
+    // Flags appear in both the card section and the top banner, so use getAllByText
+    expect(screen.getAllByText('⚠ Anomaly detected').length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Longest gap was 25 days/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/High watering variability/).length).toBeGreaterThan(0)
+  })
+
+  it('shows anomaly alert banner when an expanded plant has isAnomaly true', async () => {
+    plantsApi.anomaly.mockResolvedValue(MOCK_ANOMALY_DETECTED)
+    render(<InsightsPage />)
+    await waitFor(() => expect(screen.getByText('Monstera')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByLabelText('Monstera care score details'))
+
+    await waitFor(() => expect(screen.getByTestId('anomaly-alert-banner')).toBeInTheDocument())
+    expect(screen.getByText(/Watering anomalies detected/)).toBeInTheDocument()
+  })
+
+  it('shows no-cluster message when species is missing', async () => {
+    const scoresWithoutSpecies = [{ ...MOCK_CARE_SCORES[0], species: '' }]
+    plantsApi.careScores.mockResolvedValue(scoresWithoutSpecies)
+    render(<InsightsPage />)
+    await waitFor(() => expect(screen.getByText('Monstera')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Monstera care score details'))
+    await waitFor(() => expect(screen.getByTestId('cluster-section')).toBeInTheDocument())
+    expect(screen.getByText('Add a species to see cluster info.')).toBeInTheDocument()
+  })
+
+  it('renders seasonal note text', async () => {
+    render(<InsightsPage />)
+    await waitFor(() => expect(screen.getByText('Monstera')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Monstera care score details'))
+    await waitFor(() => expect(screen.getByText('Reduce watering in winter')).toBeInTheDocument())
+  })
+
+  it('renders score dimensions in expanded view', async () => {
+    render(<InsightsPage />)
+    await waitFor(() => expect(screen.getByText('Monstera')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Monstera care score details'))
+    await waitFor(() => expect(screen.getByText('Score Dimensions')).toBeInTheDocument())
+    expect(screen.getByText('Consistency:')).toBeInTheDocument()
+  })
+
+  it('collapses expanded plant when clicked again', async () => {
+    render(<InsightsPage />)
+    await waitFor(() => expect(screen.getByText('Monstera')).toBeInTheDocument())
+
+    const row = screen.getByLabelText('Monstera care score details')
+    fireEvent.click(row)
+    await waitFor(() => expect(screen.getByTestId('anomaly-section')).toBeInTheDocument())
+
+    fireEvent.click(row)
+    await waitFor(() => expect(screen.queryByTestId('anomaly-section')).not.toBeInTheDocument())
+  })
+})

--- a/src/pages/InsightsPage.jsx
+++ b/src/pages/InsightsPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
-import { Row, Col, Card, Badge, Spinner, Button, ProgressBar } from 'react-bootstrap'
+import { Row, Col, Card, Badge, Spinner, Button, Alert, ProgressBar } from 'react-bootstrap'
 import Chart from 'react-apexcharts'
 import { usePlantContext } from '../context/PlantContext.jsx'
 import { useLayoutContext } from '../context/LayoutContext.jsx'
@@ -12,6 +12,25 @@ const GRADE_COLORS = { A: '#10b981', B: '#22c55e', C: '#f59e0b', D: '#ef4444', F
 const PATTERN_COLORS = { optimal: '#10b981', over_watered: '#3b82f6', under_watered: '#ef4444', inconsistent: '#f59e0b', insufficient_data: '#9ca3af' }
 const PATTERN_LABELS = { optimal: 'Optimal', over_watered: 'Over-watered', under_watered: 'Under-watered', inconsistent: 'Inconsistent', insufficient_data: 'No Data' }
 
+const CLUSTER_ICONS = {
+  thirsty_tropicals: '🌿',
+  forgiving_foliage: '🍃',
+  drought_tolerant: '🌵',
+  seasonal_bloomers: '🌸',
+}
+
+function AnomalyBadge({ anomaly }) {
+  if (!anomaly) return null
+  if (!anomaly.isAnomaly) {
+    return <Badge bg="success" className="ms-2">Normal</Badge>
+  }
+  return (
+    <Badge bg="danger" className="ms-2" title={`Score: ${anomaly.score}`}>
+      ⚠ Anomaly
+    </Badge>
+  )
+}
+
 export default function InsightsPage() {
   const { plants } = usePlantContext()
   const { theme } = useLayoutContext()
@@ -20,7 +39,6 @@ export default function InsightsPage() {
   const [expandedPlant, setExpandedPlant] = useState(null)
   const [plantDetails, setPlantDetails] = useState({})
 
-  // Fetch aggregate care scores
   useEffect(() => {
     let cancelled = false
     async function load() {
@@ -34,39 +52,41 @@ export default function InsightsPage() {
     return () => { cancelled = true }
   }, [plants])
 
-  // Lazy-load individual plant ML details on expand
-  const loadPlantDetails = useCallback(async (plantId) => {
+  const loadPlantDetails = useCallback(async (plantId, species) => {
     if (plantDetails[plantId]) return
     try {
-      const [pattern, prediction, anomaly, recommendation] = await Promise.all([
+      const [pattern, prediction, anomaly, recommendation, seasonal, cluster] = await Promise.all([
         plantsApi.wateringPattern(plantId).catch(() => null),
         plantsApi.healthPrediction(plantId).catch(() => null),
         plantsApi.anomaly(plantId).catch(() => null),
         plantsApi.wateringRecommendation(plantId).catch(() => null),
+        plantsApi.seasonalAdjustment(plantId).catch(() => null),
+        species ? plantsApi.speciesCluster(species).catch(() => null) : Promise.resolve(null),
       ])
-      setPlantDetails(prev => ({ ...prev, [plantId]: { pattern, prediction, anomaly, recommendation } }))
+      setPlantDetails(prev => ({
+        ...prev,
+        [plantId]: { pattern, prediction, anomaly, recommendation, seasonal, cluster },
+      }))
     } catch { /* ignore */ }
   }, [plantDetails])
 
-  const handleExpand = useCallback((plantId) => {
+  const handleExpand = useCallback((score) => {
+    const plantId = score.plantId
     setExpandedPlant(prev => prev === plantId ? null : plantId)
-    loadPlantDetails(plantId)
+    loadPlantDetails(plantId, score.species)
   }, [loadPlantDetails])
 
-  // Collection overview stats
   const overview = useMemo(() => {
     if (!careScores || careScores.length === 0) return null
     const avgScore = Math.round(careScores.reduce((s, c) => s + c.score, 0) / careScores.length)
     const atRisk = careScores.filter(c => c.score < 60)
-    return { avgScore, atRisk, total: careScores.length }
-  }, [careScores])
+    const anomalyCount = Object.values(plantDetails).filter(d => d?.anomaly?.isAnomaly).length
+    return { avgScore, atRisk, total: careScores.length, anomalyCount }
+  }, [careScores, plantDetails])
 
-  // Watering pattern distribution for donut chart
   const patternDistribution = useMemo(() => {
     if (!careScores) return null
-    // Group by patterns from loaded details, or show placeholder
     const counts = { optimal: 0, over_watered: 0, under_watered: 0, inconsistent: 0, insufficient_data: 0 }
-    // Use grades as proxy: A/B likely optimal, C inconsistent, D/F problematic
     for (const score of careScores) {
       if (score.grade === 'A' || score.grade === 'B') counts.optimal++
       else if (score.grade === 'C') counts.inconsistent++
@@ -75,7 +95,14 @@ export default function InsightsPage() {
     return counts
   }, [careScores])
 
-  // Minimum data check
+  // Collect anomaly alerts across all loaded plant details
+  const anomalyAlerts = useMemo(() => {
+    if (!careScores) return []
+    return careScores
+      .filter(s => plantDetails[s.plantId]?.anomaly?.isAnomaly)
+      .map(s => ({ ...s, anomaly: plantDetails[s.plantId].anomaly }))
+  }, [careScores, plantDetails])
+
   const insufficientData = plants.length < 3 || (plants.reduce((sum, p) => sum + (p.wateringLog || []).length, 0) < 10)
 
   if (insufficientData) {
@@ -95,9 +122,7 @@ export default function InsightsPage() {
               icon="bar-chart-2"
               title="Not enough data yet"
               description={descParts.length > 0 ? `${descParts.join(' and ')} to unlock health predictions.` : 'Insights will appear as you log more plant care history.'}
-              actions={[
-                { label: 'Go to dashboard', icon: 'home', href: '/' },
-              ]}
+              actions={[{ label: 'Go to dashboard', icon: 'home', href: '/' }]}
             />
             <div className="px-4 pb-4" style={{ maxWidth: 340, margin: '0 auto' }}>
               <ProgressBar
@@ -122,6 +147,21 @@ export default function InsightsPage() {
         Full ML Insights are a Home Pro feature. Free-tier users see basic per-plant care scores but not aggregate predictions, anomaly detection, or watering-pattern analysis.
       </UpgradePrompt>
 
+      {/* Anomaly alerts — rendered once plants are expanded and anomaly data is loaded */}
+      {anomalyAlerts.length > 0 && (
+        <Alert variant="danger" className="mb-4" data-testid="anomaly-alert-banner">
+          <strong>⚠ Watering anomalies detected</strong> in {anomalyAlerts.length} plant{anomalyAlerts.length !== 1 ? 's' : ''}:
+          {anomalyAlerts.map(a => (
+            <div key={a.plantId} className="mt-1 ms-2">
+              <strong>{a.name}</strong>
+              {(a.anomaly.flags || []).map((f, i) => (
+                <span key={i} className="text-danger d-block ms-2 small">• {f}</span>
+              ))}
+            </div>
+          ))}
+        </Alert>
+      )}
+
       {loading ? (
         <div aria-label="Loading insights" aria-busy="true">
           <Row className="mb-4">
@@ -136,7 +176,6 @@ export default function InsightsPage() {
         </div>
       ) : (
         <>
-          {/* Collection Overview */}
           {overview && (
             <Row className="mb-4">
               <Col md={4}>
@@ -196,15 +235,14 @@ export default function InsightsPage() {
             </Row>
           )}
 
-          {/* Per-Plant Scores */}
           <h5 className="mb-3">Plant Scores</h5>
           {careScores && careScores.map(score => (
             <Card key={score.plantId} className="mb-2">
               <Card.Body
                 className="d-flex align-items-center justify-content-between"
                 style={{ cursor: 'pointer' }}
-                onClick={() => handleExpand(score.plantId)}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleExpand(score.plantId) } }}
+                onClick={() => handleExpand(score)}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleExpand(score) } }}
                 role="button"
                 tabIndex={0}
                 aria-expanded={expandedPlant === score.plantId}
@@ -219,6 +257,10 @@ export default function InsightsPage() {
                   <div>
                     <strong>{score.name}</strong>
                     {score.species && <small className="text-muted ms-2">{score.species}</small>}
+                    {/* Show anomaly badge if data already loaded */}
+                    {plantDetails[score.plantId]?.anomaly && (
+                      <AnomalyBadge anomaly={plantDetails[score.plantId].anomaly} />
+                    )}
                   </div>
                 </div>
                 <div className="d-flex align-items-center gap-3">
@@ -234,60 +276,140 @@ export default function InsightsPage() {
                   {!plantDetails[score.plantId] ? (
                     <div className="text-center p-3"><Spinner size="sm" /></div>
                   ) : (
-                    <Row>
-                      <Col md={3}>
-                        <h6>Dimensions</h6>
-                        {score.dimensions && (
-                          <ul className="list-unstyled small">
-                            <li>Consistency: {score.dimensions.consistency}</li>
-                            <li>Timing: {score.dimensions.timing}</li>
-                            <li>Health: {score.dimensions.healthOutcome}</li>
-                            <li>Responsiveness: {score.dimensions.responsiveness}</li>
-                          </ul>
-                        )}
-                      </Col>
-                      <Col md={3}>
-                        <h6>Watering Pattern</h6>
-                        {plantDetails[score.plantId].pattern ? (
-                          <>
-                            <Badge style={{ backgroundColor: PATTERN_COLORS[plantDetails[score.plantId].pattern.pattern] }}>
-                              {PATTERN_LABELS[plantDetails[score.plantId].pattern.pattern] || plantDetails[score.plantId].pattern.pattern}
-                            </Badge>
-                            <ul className="list-unstyled small mt-2">
-                              {(plantDetails[score.plantId].pattern.contributingFactors || []).map((f, i) => <li key={i}>{f}</li>)}
-                            </ul>
-                          </>
-                        ) : <small className="text-muted">Unavailable</small>}
-                      </Col>
-                      <Col md={3}>
-                        <h6>Health Prediction</h6>
-                        {plantDetails[score.plantId].prediction ? (
-                          <>
-                            <p className="mb-1">
-                              In 2 weeks: <strong>{plantDetails[score.plantId].prediction.predictedHealth}</strong>
-                              {' '}({plantDetails[score.plantId].prediction.trend})
-                            </p>
+                    <>
+                      {/* Row 1: Care dimensions */}
+                      <Row className="mb-3">
+                        <Col md={3}>
+                          <h6>Score Dimensions</h6>
+                          {score.dimensions && (
                             <ul className="list-unstyled small">
-                              {(plantDetails[score.plantId].prediction.keyRisks || []).map((r, i) => <li key={i}>{r}</li>)}
+                              <li>Consistency: <strong>{score.dimensions.consistency}</strong></li>
+                              <li>Timing: <strong>{score.dimensions.timing}</strong></li>
+                              <li>Health: <strong>{score.dimensions.healthOutcome}</strong></li>
+                              <li>Responsiveness: <strong>{score.dimensions.responsiveness}</strong></li>
                             </ul>
-                          </>
-                        ) : <small className="text-muted">Unavailable</small>}
-                      </Col>
-                      <Col md={3}>
-                        <h6>Recommendation</h6>
-                        {plantDetails[score.plantId].recommendation ? (
-                          <>
-                            <p className="mb-1">
-                              Every <strong>{plantDetails[score.plantId].recommendation.recommendedFrequencyDays}</strong> days
-                              {plantDetails[score.plantId].recommendation.confidenceInterval &&
-                                ` (${plantDetails[score.plantId].recommendation.confidenceInterval[0]}-${plantDetails[score.plantId].recommendation.confidenceInterval[1]})`
-                              }
-                            </p>
-                            <small className="text-muted">{plantDetails[score.plantId].recommendation.basis}</small>
-                          </>
-                        ) : <small className="text-muted">Unavailable</small>}
-                      </Col>
-                    </Row>
+                          )}
+                        </Col>
+                        <Col md={3}>
+                          <h6>Watering Pattern</h6>
+                          {plantDetails[score.plantId].pattern ? (
+                            <>
+                              <Badge style={{ backgroundColor: PATTERN_COLORS[plantDetails[score.plantId].pattern.pattern] }}>
+                                {PATTERN_LABELS[plantDetails[score.plantId].pattern.pattern] || plantDetails[score.plantId].pattern.pattern}
+                              </Badge>
+                              <ul className="list-unstyled small mt-2">
+                                {(plantDetails[score.plantId].pattern.contributingFactors || []).map((f, i) => <li key={i}>{f}</li>)}
+                              </ul>
+                            </>
+                          ) : <small className="text-muted">Unavailable</small>}
+                        </Col>
+                        <Col md={3}>
+                          <h6>Health Prediction</h6>
+                          {plantDetails[score.plantId].prediction ? (
+                            <>
+                              <p className="mb-1">
+                                In 2 weeks: <strong>{plantDetails[score.plantId].prediction.predictedHealth}</strong>
+                                {' '}({plantDetails[score.plantId].prediction.trend})
+                              </p>
+                              <ul className="list-unstyled small">
+                                {(plantDetails[score.plantId].prediction.keyRisks || []).map((r, i) => <li key={i}>{r}</li>)}
+                              </ul>
+                            </>
+                          ) : <small className="text-muted">Unavailable</small>}
+                        </Col>
+                        <Col md={3}>
+                          <h6>Recommendation</h6>
+                          {plantDetails[score.plantId].recommendation ? (
+                            <>
+                              <p className="mb-1">
+                                Every <strong>{plantDetails[score.plantId].recommendation.recommendedFrequencyDays}</strong> days
+                                {plantDetails[score.plantId].recommendation.confidenceInterval &&
+                                  ` (${plantDetails[score.plantId].recommendation.confidenceInterval[0]}-${plantDetails[score.plantId].recommendation.confidenceInterval[1]})`
+                                }
+                              </p>
+                              <small className="text-muted">{plantDetails[score.plantId].recommendation.basis}</small>
+                            </>
+                          ) : <small className="text-muted">Unavailable</small>}
+                        </Col>
+                      </Row>
+
+                      {/* Row 2: Anomaly, Seasonal, Cluster */}
+                      <Row className="pt-2 border-top">
+                        <Col md={4} data-testid="anomaly-section">
+                          <h6>Anomaly Detection</h6>
+                          {plantDetails[score.plantId].anomaly ? (
+                            <>
+                              <div className="d-flex align-items-center gap-2 mb-1">
+                                {plantDetails[score.plantId].anomaly.isAnomaly ? (
+                                  <Badge bg="danger">⚠ Anomaly detected</Badge>
+                                ) : (
+                                  <Badge bg="success">Normal behaviour</Badge>
+                                )}
+                                <small className="text-muted">score: {plantDetails[score.plantId].anomaly.score}</small>
+                              </div>
+                              {(plantDetails[score.plantId].anomaly.flags || []).map((f, i) => (
+                                <div key={i} className="small text-danger">• {f}</div>
+                              ))}
+                              {(!plantDetails[score.plantId].anomaly.flags?.length && !plantDetails[score.plantId].anomaly.isAnomaly) && (
+                                <small className="text-muted">No unusual watering patterns detected.</small>
+                              )}
+                            </>
+                          ) : <small className="text-muted">Unavailable</small>}
+                        </Col>
+
+                        <Col md={4} data-testid="seasonal-section">
+                          <h6>Seasonal Adjustment</h6>
+                          {plantDetails[score.plantId].seasonal ? (
+                            <>
+                              <p className="mb-1">
+                                <Badge bg="secondary" className="me-1 text-capitalize">{plantDetails[score.plantId].seasonal.season}</Badge>
+                                {plantDetails[score.plantId].seasonal.multiplier && (
+                                  <span className="small">
+                                    ×{plantDetails[score.plantId].seasonal.multiplier.toFixed(2)} multiplier
+                                  </span>
+                                )}
+                              </p>
+                              {plantDetails[score.plantId].seasonal.adjustedFrequencyDays && (
+                                <p className="mb-1 small">
+                                  Adjusted: every <strong>{plantDetails[score.plantId].seasonal.adjustedFrequencyDays}</strong> days
+                                </p>
+                              )}
+                              {plantDetails[score.plantId].seasonal.note && (
+                                <small className="text-muted">{plantDetails[score.plantId].seasonal.note}</small>
+                              )}
+                            </>
+                          ) : <small className="text-muted">Unavailable</small>}
+                        </Col>
+
+                        <Col md={4} data-testid="cluster-section">
+                          <h6>Species Cluster</h6>
+                          {plantDetails[score.plantId].cluster && plantDetails[score.plantId].cluster.clusterId ? (
+                            <>
+                              <div className="mb-1">
+                                <span className="me-1">{CLUSTER_ICONS[plantDetails[score.plantId].cluster.clusterId] || '🌱'}</span>
+                                <strong>{plantDetails[score.plantId].cluster.clusterLabel}</strong>
+                              </div>
+                              {plantDetails[score.plantId].cluster.clusterCareProfile && (
+                                <ul className="list-unstyled small">
+                                  <li>Avg frequency: every {plantDetails[score.plantId].cluster.clusterCareProfile.avgFrequency} days</li>
+                                  <li>Drought tolerance: {plantDetails[score.plantId].cluster.clusterCareProfile.droughtTolerance}</li>
+                                  <li>Humidity need: {plantDetails[score.plantId].cluster.clusterCareProfile.humidityNeed}</li>
+                                </ul>
+                              )}
+                              {(plantDetails[score.plantId].cluster.similarSpecies || []).length > 0 && (
+                                <small className="text-muted">
+                                  Similar: {plantDetails[score.plantId].cluster.similarSpecies.slice(0, 3).join(', ')}
+                                </small>
+                              )}
+                            </>
+                          ) : (
+                            <small className="text-muted">
+                              {score.species ? 'No cluster match for this species.' : 'Add a species to see cluster info.'}
+                            </small>
+                          )}
+                        </Col>
+                      </Row>
+                    </>
                   )}
                 </Card.Footer>
               )}


### PR DESCRIPTION
## Summary

Completes the ML Insights dashboard by wiring up the three ML signals that had backend routes but no frontend display:

- **Anomaly Detection (#100)** — shows an `⚠ Anomaly detected` badge + flag list per plant when `isAnomaly: true`; also renders a collection-level alert banner at the top of the page listing all affected plants and their flags
- **Seasonal Adjustment (#101)** — displays current season, frequency multiplier, adjusted watering interval, and the source note for each expanded plant
- **Species Clustering (#102)** — shows the cluster label, care profile (avg frequency, drought tolerance, humidity need), and similar species for each expanded plant
- **Care Score (#103)** — already rendered; expanded the dimension labels from plain text to labelled `<li>` items with bold values for readability
- **ML Insights dashboard (#104)** — all of the above together complete the dashboard; the `AnomalyBadge` also appears inline on the plant row once its data is loaded

### What changed
| File | Change |
|---|---|
| `src/pages/InsightsPage.jsx` | `loadPlantDetails` now also fetches `seasonalAdjustment` + `speciesCluster`; expanded card renders a second details row; anomaly alert banner added |
| `src/__tests__/InsightsPage.test.jsx` | New — 13 tests covering empty state, loading, overview, grades, expand/collapse, anomaly/seasonal/cluster display, alert banner, missing-species fallback |

## Test plan
- [ ] All 759 existing tests pass (`npm test`)
- [ ] Coverage thresholds pass (`npm run test:coverage`)
- [ ] Expand a plant card → Anomaly Detection, Seasonal Adjustment, Species Cluster sections render
- [ ] Plant with `isAnomaly: true` shows red badge + flags + top alert banner
- [ ] Plant with no species shows "Add a species to see cluster info." fallback

Closes #100, #101, #102, #103, #104

https://claude.ai/code/session_019p5kUGzF2TWBHAp3zCdhid

---
_Generated by [Claude Code](https://claude.ai/code/session_019p5kUGzF2TWBHAp3zCdhid)_