### PR TITLE
feat: public REST API with API key management — issue #168

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -3690,6 +3690,86 @@ app.post('/import/plants', requireUser, requireTier('home_pro'), async (req, res
   }
 });
 
+// ── API key management ────────────────────────────────────────────────────────
+// Keys are stored in two places for efficient lookup:
+//   apiKeyHashes/{sha256hash}  — top-level, fast lookup by hash in requireApiKey
+//   users/{userId}/apiKeys/{docId} — user-scoped, for listing/revocation UI
+
+function userApiKeys(userId) {
+  return db.collection('users').doc(userId).collection('apiKeys');
+}
+
+function apiKeyHashesRef() {
+  return db.collection('apiKeyHashes');
+}
+
+function generateApiKey() {
+  return `pt_live_${crypto.randomBytes(24).toString('hex')}`;
+}
+
+function hashApiKey(key) {
+  return crypto.createHash('sha256').update(key).digest('hex');
+}
+
+function maskApiKey(prefix) {
+  return `${prefix}...`;
+}
+
+// Middleware: authenticate via x-plant-api-key header, resolve userId
+async function requireApiKey(req, res, next) {
+  const rawKey = req.headers['x-plant-api-key'];
+  if (!rawKey) return res.status(401).json({ error: 'Missing x-plant-api-key header' });
+
+  const hash = hashApiKey(rawKey);
+  try {
+    const hashDoc = await apiKeyHashesRef().doc(hash).get();
+    if (!hashDoc.exists || hashDoc.data().revokedAt) {
+      return res.status(401).json({ error: 'Invalid or revoked API key' });
+    }
+    req.userId = hashDoc.data().userId;
+    // Update lastUsedAt asynchronously — do not block request
+    apiKeyHashesRef().doc(hash).set({ lastUsedAt: new Date().toISOString() }, { merge: true }).catch(() => {});
+    next();
+  } catch (err) {
+    res.status(500).json({ error: 'API key lookup failed' });
+  }
+}
+
+// Per-user public API rate limiter — 1,000 req/hour (express-rate-limit is no-op in tests)
+const publicApiLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 1000,
+  keyGenerator: (req) => req.userId || req.ip,
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { trustProxy: false, xForwardedForHeader: false },
+  message: { error: 'API rate limit exceeded. Upgrade to a higher tier for more requests.' },
+});
+
+// POST /api-keys — create a new API key (max 3 active per user)
+app.post('/api-keys', requireUser, requireTier('home_pro'), async (req, res) => {
+  try {
+    const { name = 'My API Key' } = req.body || {};
+    const keysRef = userApiKeys(req.userId);
+    const existing = await keysRef.get();
+    const active = existing.docs.filter((d) => !d.data().revokedAt);
+    if (active.length >= 3) {
+      return res.status(400).json({ error: 'Maximum of 3 active API keys allowed. Revoke an existing key first.' });
+    }
+    const plaintext = generateApiKey();
+    const keyHash = hashApiKey(plaintext);
+    const prefix = plaintext.slice(0, 12);
+    const now = new Date().toISOString();
+    const keyName = String(name).trim().slice(0, 64) || 'My API Key';
+    const docRef = await keysRef.add({ name: keyName, prefix, keyHash, revokedAt: null, createdAt: now, lastUsedAt: null });
+    // Write to top-level hash index for fast lookup
+    await apiKeyHashesRef().doc(keyHash).set({ userId: req.userId, revokedAt: null, createdAt: now });
+    res.status(201).json({ id: docRef.id, key: plaintext, name: keyName, prefix, createdAt: now });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // GET /import/plants/template — download CSV template
 app.get('/import/plants/template', requireUser, (req, res) => {
   const headers = ['name', 'species', 'room', 'floor', 'health', 'frequencyDays', 'potSize', 'soilType', 'notes'];
@@ -3698,6 +3778,88 @@ app.get('/import/plants/template', requireUser, (req, res) => {
   res.setHeader('Content-Type', 'text/csv');
   res.setHeader('Content-Disposition', 'attachment; filename="plant-import-template.csv"');
   res.status(200).send(csv);
+});
+
+// GET /api-keys — list active API keys (masked, no hash exposed)
+app.get('/api-keys', requireUser, async (req, res) => {
+  try {
+    const snap = await userApiKeys(req.userId).get();
+    const keys = snap.docs
+      .filter((d) => !d.data().revokedAt)
+      .sort((a, b) => (b.data().createdAt || '').localeCompare(a.data().createdAt || ''))
+      .map((d) => {
+        const { keyHash: _h, ...safe } = d.data();
+        return { id: d.id, ...safe, key: maskApiKey(safe.prefix) };
+      });
+    res.status(200).json({ keys });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// DELETE /api-keys/:id — revoke an API key
+app.delete('/api-keys/:id', requireUser, async (req, res) => {
+  try {
+    const ref = userApiKeys(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'API key not found' });
+    if (doc.data().revokedAt) return res.status(409).json({ error: 'API key already revoked' });
+    const { keyHash } = doc.data();
+    const now = new Date().toISOString();
+    await ref.set({ revokedAt: now }, { merge: true });
+    if (keyHash) await apiKeyHashesRef().doc(keyHash).set({ revokedAt: now }, { merge: true });
+    res.status(200).json({ revoked: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ── Public REST API v1 ────────────────────────────────────────────────────────
+// These routes accept API key auth (x-plant-api-key) and are rate-limited.
+
+app.get('/api/v1/plants', requireApiKey, publicApiLimiter, async (req, res) => {
+  try {
+    const snap = await userPlants(req.userId).orderBy('name').get();
+    const plants = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    res.status(200).json({ plants });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/v1/plants/:id', requireApiKey, publicApiLimiter, async (req, res) => {
+  try {
+    const doc = await userPlants(req.userId).doc(req.params.id).get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+    res.status(200).json({ id: doc.id, ...doc.data() });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/v1/plants/:id/water', requireApiKey, publicApiLimiter, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+    const now = new Date().toISOString();
+    await ref.set({ lastWatered: now, updatedAt: now }, { merge: true });
+    res.status(200).json({ watered: true, lastWatered: now });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/v1/plants/:id/care-score', requireApiKey, publicApiLimiter, requireTier('home_pro'), async (req, res) => {
+  try {
+    const doc = await userPlants(req.userId).doc(req.params.id).get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+    const plant = { id: doc.id, ...doc.data() };
+    const score = computeCareScore(plant);
+    res.status(200).json({ id: plant.id, name: plant.name, ...score });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 });
 
 functions.http('plantsApi', app);

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -3730,7 +3730,7 @@ async function requireApiKey(req, res, next) {
     // Update lastUsedAt asynchronously — do not block request
     apiKeyHashesRef().doc(hash).set({ lastUsedAt: new Date().toISOString() }, { merge: true }).catch(() => {});
     next();
-  } catch (err) {
+  } catch {
     res.status(500).json({ error: 'API key lookup failed' });
   }
 }

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -4253,3 +4253,212 @@ describe('GET /import/plants/template', () => {
     expect(lines.length).toBeGreaterThanOrEqual(2);
   });
 });
+
+// ── API key management ────────────────────────────────────────────────────────
+
+import { createHash, randomBytes } from 'crypto';
+
+function makeTestApiKey() {
+  const plaintext = `pt_live_${randomBytes(24).toString('hex')}`;
+  const hash = createHash('sha256').update(plaintext).digest('hex');
+  return { plaintext, hash, prefix: plaintext.slice(0, 12) };
+}
+
+const apiKeyPath = (id) => `users/${USER_SUB}/apiKeys/${id}`;
+const apiKeyHashPath = (hash) => `apiKeyHashes/${hash}`;
+
+describe('POST /api-keys', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).post('/api-keys').send({ name: 'Test' });
+    expect(res.status).toBe(401);
+  });
+
+  it('creates a new API key and returns the plaintext once', async () => {
+    const res = await request(app)
+      .post('/api-keys')
+      .set('Authorization', authHeader())
+      .send({ name: 'Home Assistant' });
+    expect(res.status).toBe(201);
+    expect(res.body.key).toMatch(/^pt_live_/);
+    expect(res.body.name).toBe('Home Assistant');
+    expect(res.body.id).toBeDefined();
+    expect(res.body.prefix).toBe(res.body.key.slice(0, 12));
+  });
+
+  it('stores the key hash in apiKeyHashes and user subcollection', async () => {
+    const res = await request(app)
+      .post('/api-keys')
+      .set('Authorization', authHeader())
+      .send({ name: 'Dashboard' });
+    expect(res.status).toBe(201);
+    const { id, key } = res.body;
+    const hash = createHash('sha256').update(key).digest('hex');
+    // hash index stored
+    expect(store[apiKeyHashPath(hash)]).toBeDefined();
+    expect(store[apiKeyHashPath(hash)].userId).toBe(USER_SUB);
+    expect(store[apiKeyHashPath(hash)].revokedAt).toBeNull();
+    // user subcollection stored
+    expect(store[apiKeyPath(id)]).toBeDefined();
+    expect(store[apiKeyPath(id)].revokedAt).toBeNull();
+  });
+
+  it('rejects when 3 active keys already exist', async () => {
+    // Pre-create 3 active keys
+    store[apiKeyPath('k1')] = { name: 'K1', prefix: 'pt_live_aaa1', keyHash: 'h1', revokedAt: null, createdAt: '2026-01-01T00:00:00Z', lastUsedAt: null };
+    store[apiKeyPath('k2')] = { name: 'K2', prefix: 'pt_live_aaa2', keyHash: 'h2', revokedAt: null, createdAt: '2026-01-02T00:00:00Z', lastUsedAt: null };
+    store[apiKeyPath('k3')] = { name: 'K3', prefix: 'pt_live_aaa3', keyHash: 'h3', revokedAt: null, createdAt: '2026-01-03T00:00:00Z', lastUsedAt: null };
+    const res = await request(app)
+      .post('/api-keys')
+      .set('Authorization', authHeader())
+      .send({ name: 'Fourth Key' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Maximum of 3/);
+  });
+
+  it('allows creating a key when previously-revoked ones exist', async () => {
+    store[apiKeyPath('k1')] = { name: 'Old', prefix: 'pt_live_bbb1', keyHash: 'hh1', revokedAt: '2026-01-01T00:00:00Z', createdAt: '2026-01-01T00:00:00Z', lastUsedAt: null };
+    store[apiKeyPath('k2')] = { name: 'Also Old', prefix: 'pt_live_bbb2', keyHash: 'hh2', revokedAt: '2026-01-01T00:00:00Z', createdAt: '2026-01-01T00:00:00Z', lastUsedAt: null };
+    store[apiKeyPath('k3')] = { name: 'Old3', prefix: 'pt_live_bbb3', keyHash: 'hh3', revokedAt: '2026-01-01T00:00:00Z', createdAt: '2026-01-01T00:00:00Z', lastUsedAt: null };
+    const res = await request(app)
+      .post('/api-keys')
+      .set('Authorization', authHeader())
+      .send({ name: 'Fresh Key' });
+    expect(res.status).toBe(201);
+  });
+});
+
+describe('GET /api-keys', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/api-keys');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns empty list when no keys exist', async () => {
+    const res = await request(app).get('/api-keys').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.keys).toEqual([]);
+  });
+
+  it('lists active keys with masked values (no hash)', async () => {
+    const { hash } = makeTestApiKey();
+    store[apiKeyPath('k1')] = { name: 'Home Assistant', prefix: 'pt_live_hass', keyHash: hash, revokedAt: null, createdAt: '2026-04-01T00:00:00Z', lastUsedAt: null };
+    store[apiKeyPath('k2')] = { name: 'Revoked', prefix: 'pt_live_rev1', keyHash: 'revoked_hash', revokedAt: '2026-04-02T00:00:00Z', createdAt: '2026-04-01T00:00:00Z', lastUsedAt: null };
+    const res = await request(app).get('/api-keys').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.keys).toHaveLength(1);
+    expect(res.body.keys[0].name).toBe('Home Assistant');
+    expect(res.body.keys[0].key).toBe('pt_live_hass...');
+    expect(res.body.keys[0].keyHash).toBeUndefined();
+  });
+});
+
+describe('DELETE /api-keys/:id', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).delete('/api-keys/k1');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for unknown key id', async () => {
+    const res = await request(app).delete('/api-keys/no-such-key').set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when key is already revoked', async () => {
+    store[apiKeyPath('k1')] = { name: 'Old', prefix: 'pt_live_xxx', keyHash: 'hhh', revokedAt: '2026-01-01T00:00:00Z', createdAt: '2026-01-01T00:00:00Z' };
+    const res = await request(app).delete('/api-keys/k1').set('Authorization', authHeader());
+    expect(res.status).toBe(409);
+  });
+
+  it('revokes an active key and marks both store entries', async () => {
+    const { hash } = makeTestApiKey();
+    store[apiKeyPath('k1')] = { name: 'Active Key', prefix: 'pt_live_act1', keyHash: hash, revokedAt: null, createdAt: '2026-04-01T00:00:00Z' };
+    store[apiKeyHashPath(hash)] = { userId: USER_SUB, revokedAt: null };
+    const res = await request(app).delete('/api-keys/k1').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.revoked).toBe(true);
+    expect(store[apiKeyPath('k1')].revokedAt).not.toBeNull();
+    expect(store[apiKeyHashPath(hash)].revokedAt).not.toBeNull();
+  });
+});
+
+describe('requireApiKey middleware (public API routes)', () => {
+  it('returns 401 when x-plant-api-key header is missing', async () => {
+    const res = await request(app).get('/api/v1/plants');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/Missing x-plant-api-key/);
+  });
+
+  it('returns 401 for an unknown key hash', async () => {
+    const res = await request(app).get('/api/v1/plants').set('x-plant-api-key', 'pt_live_invalid');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/Invalid or revoked/);
+  });
+
+  it('returns 401 for a revoked key', async () => {
+    const { plaintext, hash } = makeTestApiKey();
+    store[apiKeyHashPath(hash)] = { userId: USER_SUB, revokedAt: '2026-04-01T00:00:00Z' };
+    const res = await request(app).get('/api/v1/plants').set('x-plant-api-key', plaintext);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/v1/plants', () => {
+  it('returns plants for a valid API key', async () => {
+    const { plaintext, hash } = makeTestApiKey();
+    store[apiKeyHashPath(hash)] = { userId: USER_SUB, revokedAt: null };
+    store[plantPath('p1')] = { name: 'Fern', species: 'Nephrolepis' };
+    const res = await request(app).get('/api/v1/plants').set('x-plant-api-key', plaintext);
+    expect(res.status).toBe(200);
+    expect(res.body.plants).toHaveLength(1);
+    expect(res.body.plants[0].name).toBe('Fern');
+  });
+});
+
+describe('GET /api/v1/plants/:id', () => {
+  it('returns 404 for unknown plant', async () => {
+    const { plaintext, hash } = makeTestApiKey();
+    store[apiKeyHashPath(hash)] = { userId: USER_SUB, revokedAt: null };
+    const res = await request(app).get('/api/v1/plants/nope').set('x-plant-api-key', plaintext);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the plant data for a valid key and plant', async () => {
+    const { plaintext, hash } = makeTestApiKey();
+    store[apiKeyHashPath(hash)] = { userId: USER_SUB, revokedAt: null };
+    store[plantPath('p1')] = { name: 'Monstera', species: 'Monstera deliciosa', health: 'Good' };
+    const res = await request(app).get('/api/v1/plants/p1').set('x-plant-api-key', plaintext);
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Monstera');
+  });
+});
+
+describe('POST /api/v1/plants/:id/water', () => {
+  it('returns 404 for unknown plant', async () => {
+    const { plaintext, hash } = makeTestApiKey();
+    store[apiKeyHashPath(hash)] = { userId: USER_SUB, revokedAt: null };
+    const res = await request(app).post('/api/v1/plants/nope/water').set('x-plant-api-key', plaintext);
+    expect(res.status).toBe(404);
+  });
+
+  it('records lastWatered timestamp on the plant', async () => {
+    const { plaintext, hash } = makeTestApiKey();
+    store[apiKeyHashPath(hash)] = { userId: USER_SUB, revokedAt: null };
+    store[plantPath('p1')] = { name: 'Fern', lastWatered: null };
+    const res = await request(app).post('/api/v1/plants/p1/water').set('x-plant-api-key', plaintext);
+    expect(res.status).toBe(200);
+    expect(res.body.watered).toBe(true);
+    expect(res.body.lastWatered).toBeTruthy();
+    expect(store[plantPath('p1')].lastWatered).toBeTruthy();
+  });
+});
+
+describe('GET /api/v1/plants/:id/care-score', () => {
+  it('returns care score for a valid plant', async () => {
+    const { plaintext, hash } = makeTestApiKey();
+    store[apiKeyHashPath(hash)] = { userId: USER_SUB, revokedAt: null };
+    store[plantPath('p1')] = { name: 'Monstera', species: 'Monstera deliciosa', health: 'Good', frequencyDays: 7, lastWatered: new Date().toISOString() };
+    const res = await request(app).get('/api/v1/plants/p1/care-score').set('x-plant-api-key', plaintext);
+    expect(res.status).toBe(200);
+    expect(res.body.score).toBeDefined();
+  });
+});

--- a/src/__tests__/SettingsPage.test.jsx
+++ b/src/__tests__/SettingsPage.test.jsx
@@ -36,6 +36,16 @@ vi.mock('../api/plants.js', () => ({
     exportData: vi.fn().mockResolvedValue({ plants: [], floors: [], exportedAt: '2024-01-01', userId: 'u1' }),
     deleteAccount: vi.fn().mockResolvedValue(null),
   },
+  exportApi: {
+    downloadPlants: vi.fn().mockResolvedValue(undefined),
+    downloadWateringHistory: vi.fn().mockResolvedValue(undefined),
+    downloadCareSchedule: vi.fn().mockResolvedValue(undefined),
+  },
+  apiKeysApi: {
+    list: vi.fn().mockResolvedValue({ keys: [] }),
+    create: vi.fn(),
+    revoke: vi.fn(),
+  },
 }))
 
 // LeafletFloorplan touches canvas APIs not available in jsdom
@@ -44,7 +54,7 @@ vi.mock('../components/LeafletFloorplan.jsx', () => ({
 }))
 
 import SettingsPage from '../pages/SettingsPage.jsx'
-import { accountApi } from '../api/plants.js'
+import { accountApi, apiKeysApi } from '../api/plants.js'
 
 function renderAt(path) {
   return render(
@@ -192,5 +202,92 @@ describe('SettingsPage Data tab', () => {
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
     expect(screen.queryByPlaceholderText(/Type DELETE to confirm/i)).toBeNull()
     expect(screen.getByRole('button', { name: /delete my account/i })).toBeInTheDocument()
+  })
+})
+
+describe('SettingsPage API Keys tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiKeysApi.list.mockResolvedValue({ keys: [] })
+  })
+
+  it('shows the API Keys tab in navigation', () => {
+    renderAt('/settings/api-keys')
+    expect(screen.getByText('API Keys')).toBeInTheDocument()
+  })
+
+  it('renders the Public REST API section', async () => {
+    renderAt('/settings/api-keys')
+    await waitFor(() => expect(screen.getByText(/Public REST API/)).toBeInTheDocument())
+  })
+
+  it('shows no-keys message when list is empty', async () => {
+    renderAt('/settings/api-keys')
+    await waitFor(() => expect(screen.getByTestId('no-keys-message')).toBeInTheDocument())
+    expect(screen.getByText(/No API keys yet/)).toBeInTheDocument()
+  })
+
+  it('displays existing active keys in table', async () => {
+    apiKeysApi.list.mockResolvedValue({
+      keys: [
+        { id: 'k1', name: 'Home Assistant', key: 'pt_live_hass...', prefix: 'pt_live_hass', createdAt: '2026-04-01T00:00:00Z', lastUsedAt: null, revokedAt: null },
+      ],
+    })
+    renderAt('/settings/api-keys')
+    await waitFor(() => expect(screen.getByTestId('api-keys-table')).toBeInTheDocument())
+    expect(screen.getByText('Home Assistant')).toBeInTheDocument()
+    expect(screen.getByText('pt_live_hass...')).toBeInTheDocument()
+  })
+
+  it('shows create key button and name input', async () => {
+    renderAt('/settings/api-keys')
+    await waitFor(() => expect(screen.getByTestId('create-key-btn')).toBeInTheDocument())
+    expect(screen.getByTestId('new-key-name-input')).toBeInTheDocument()
+  })
+
+  it('create key button is disabled when name input is empty', async () => {
+    renderAt('/settings/api-keys')
+    await waitFor(() => expect(screen.getByTestId('create-key-btn')).toBeDisabled())
+  })
+
+  it('calls apiKeysApi.create with the entered name', async () => {
+    apiKeysApi.create.mockResolvedValue({ id: 'new-k', key: 'pt_live_newkeyxxx', name: 'My App', prefix: 'pt_live_newk', createdAt: '2026-04-23T00:00:00Z' })
+    renderAt('/settings/api-keys')
+    await waitFor(() => expect(screen.getByTestId('new-key-name-input')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('new-key-name-input'), { target: { value: 'My App' } })
+    fireEvent.click(screen.getByTestId('create-key-btn'))
+    await waitFor(() => expect(apiKeysApi.create).toHaveBeenCalledWith('My App'))
+  })
+
+  it('shows the new plaintext key banner after creation', async () => {
+    apiKeysApi.create.mockResolvedValue({ id: 'new-k', key: 'pt_live_secret123', name: 'My App', prefix: 'pt_live_secr', createdAt: '2026-04-23T00:00:00Z' })
+    renderAt('/settings/api-keys')
+    await waitFor(() => expect(screen.getByTestId('new-key-name-input')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('new-key-name-input'), { target: { value: 'My App' } })
+    fireEvent.click(screen.getByTestId('create-key-btn'))
+    await waitFor(() => expect(screen.getByTestId('new-key-banner')).toBeInTheDocument())
+    expect(screen.getByTestId('new-key-value')).toHaveTextContent('pt_live_secret123')
+  })
+
+  it('shows revoke button for each key and calls apiKeysApi.revoke', async () => {
+    apiKeysApi.list.mockResolvedValue({
+      keys: [{ id: 'k1', name: 'HA', key: 'pt_live_ha...', prefix: 'pt_live_ha', createdAt: '2026-04-01T00:00:00Z', lastUsedAt: null }],
+    })
+    apiKeysApi.revoke.mockResolvedValue({ revoked: true })
+    renderAt('/settings/api-keys')
+    await waitFor(() => expect(screen.getByTestId('revoke-key-k1')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('revoke-key-k1'))
+    await waitFor(() => expect(apiKeysApi.revoke).toHaveBeenCalledWith('k1'))
+  })
+
+  it('removes key from list after successful revoke', async () => {
+    apiKeysApi.list.mockResolvedValue({
+      keys: [{ id: 'k1', name: 'HA', key: 'pt_live_ha...', prefix: 'pt_live_ha', createdAt: '2026-04-01T00:00:00Z', lastUsedAt: null }],
+    })
+    apiKeysApi.revoke.mockResolvedValue({ revoked: true })
+    renderAt('/settings/api-keys')
+    await waitFor(() => expect(screen.getByTestId('revoke-key-k1')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('revoke-key-k1'))
+    await waitFor(() => expect(screen.queryByTestId('revoke-key-k1')).not.toBeInTheDocument())
   })
 })

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -337,6 +337,21 @@ export const importApi = {
   },
 }
 
+export const apiKeysApi = {
+  async list() {
+    return request('/api-keys')
+  },
+  async create(name) {
+    return request('/api-keys', {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    })
+  },
+  async revoke(id) {
+    return request(`/api-keys/${id}`, { method: 'DELETE' })
+  },
+}
+
 export const imagesApi = {
   async upload(file, prefix = 'plants') {
     const ext = file.name.split('.').pop()

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useMemo } from 'react'
+import { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import { Link, useParams, Navigate } from 'react-router'
 import { Button, Form, Table, Badge, Nav, InputGroup, FormControl } from 'react-bootstrap'
 import { usePlantContext } from '../context/PlantContext.jsx'
@@ -11,12 +11,13 @@ import { TIMEZONE_GROUPS } from '../hooks/useTimezone.js'
 import { SUPPORTED_LANGUAGES } from '../i18n/index.js'
 import { useTranslation } from 'react-i18next'
 import i18n from '../i18n/index.js'
-import { accountApi, exportApi } from '../api/plants.js'
+import { accountApi, exportApi, apiKeysApi } from '../api/plants.js'
 
 const TABS = [
   { id: 'property', label: 'Property', icon: 'layers', tags: 'floors zones floorplan rooms upload property' },
   { id: 'preferences', label: 'Preferences', icon: 'sliders', tags: 'theme dark mode light temperature celsius fahrenheit metric imperial units location city weather' },
   { id: 'data', label: 'Data & export', icon: 'download', tags: 'export csv download backup data' },
+  { id: 'api-keys', label: 'API Keys', icon: 'key', tags: 'api keys rest integration home assistant automation developer' },
   { id: 'advanced', label: 'Advanced', icon: 'tool', tags: 'reset onboarding developer version advanced' },
 ]
 
@@ -650,6 +651,160 @@ function DataTab({ search }) {
   )
 }
 
+function ApiKeysTab({ search }) {
+  const [keys, setKeys] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [creating, setCreating] = useState(false)
+  const [newKeyName, setNewKeyName] = useState('')
+  const [newKeyValue, setNewKeyValue] = useState(null)
+  const [revoking, setRevoking] = useState(null)
+
+  const loadKeys = useCallback(async () => {
+    try {
+      setLoading(true)
+      const { keys: list } = await apiKeysApi.list()
+      setKeys(list)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { loadKeys() }, [loadKeys])
+
+  const handleCreate = async () => {
+    if (!newKeyName.trim()) return
+    setCreating(true)
+    setError(null)
+    try {
+      const result = await apiKeysApi.create(newKeyName.trim())
+      setNewKeyValue(result.key)
+      setNewKeyName('')
+      await loadKeys()
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleRevoke = async (id) => {
+    setRevoking(id)
+    setError(null)
+    try {
+      await apiKeysApi.revoke(id)
+      setKeys((prev) => prev.filter((k) => k.id !== id))
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setRevoking(null)
+    }
+  }
+
+  return (
+    <>
+      <SettingSection id="api-keys-intro" title="Public REST API" icon="key" search={search}>
+        <p className="text-muted fs-sm mb-3">
+          Use API keys to integrate your plant data with external tools — Home Assistant, custom dashboards, and smart irrigation systems.
+          API keys are available on <strong>Home Pro</strong> and <strong>Landscaper Pro</strong> plans. Each key is shown <strong>once</strong> at creation.
+        </p>
+        <div className="alert alert-info py-2 fs-sm mb-0">
+          <strong>Base URL:</strong> <code>{import.meta.env.VITE_API_BASE_URL || 'https://api.plants.lopezcloud.dev'}/api/v1</code>
+          {' · '}
+          Pass the key as <code>x-plant-api-key: pt_live_...</code>
+        </div>
+      </SettingSection>
+
+      <SettingSection id="api-keys-manage" title="Your API Keys" icon="shield" search={search}>
+        {error && <div className="alert alert-danger py-2 mb-3" data-testid="api-key-error">{error}</div>}
+
+        {newKeyValue && (
+          <div className="alert alert-success mb-3" data-testid="new-key-banner">
+            <strong>Copy your new API key — it won&apos;t be shown again:</strong>
+            <div className="d-flex align-items-center gap-2 mt-2">
+              <code className="flex-grow-1 text-break" data-testid="new-key-value">{newKeyValue}</code>
+              <Button size="sm" variant="outline-success" onClick={() => { navigator.clipboard?.writeText(newKeyValue); }}>
+                Copy
+              </Button>
+            </div>
+            <Button size="sm" variant="link" className="p-0 mt-1 text-muted" onClick={() => setNewKeyValue(null)}>Dismiss</Button>
+          </div>
+        )}
+
+        {loading ? (
+          <p className="text-muted fs-sm">Loading…</p>
+        ) : keys.length === 0 ? (
+          <p className="text-muted fs-sm mb-3" data-testid="no-keys-message">No API keys yet. Create one below.</p>
+        ) : (
+          <Table size="sm" className="mb-3" data-testid="api-keys-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Key</th>
+                <th>Created</th>
+                <th>Last used</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => (
+                <tr key={k.id}>
+                  <td>{k.name}</td>
+                  <td><code>{k.key}</code></td>
+                  <td className="text-muted fs-xs">{new Date(k.createdAt).toLocaleDateString()}</td>
+                  <td className="text-muted fs-xs">{k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleDateString() : 'Never'}</td>
+                  <td>
+                    <Button
+                      variant="outline-danger"
+                      size="sm"
+                      onClick={() => handleRevoke(k.id)}
+                      disabled={revoking === k.id}
+                      data-testid={`revoke-key-${k.id}`}
+                    >
+                      {revoking === k.id ? 'Revoking…' : 'Revoke'}
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+
+        {keys.length < 3 && (
+          <div className="d-flex gap-2 align-items-end">
+            <Form.Group controlId="new-key-name" className="flex-grow-1">
+              <Form.Label className="fs-sm fw-500 mb-1">New key name</Form.Label>
+              <Form.Control
+                size="sm"
+                placeholder="e.g. Home Assistant"
+                value={newKeyName}
+                onChange={(e) => setNewKeyName(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+                maxLength={64}
+                data-testid="new-key-name-input"
+              />
+            </Form.Group>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleCreate}
+              disabled={creating || !newKeyName.trim()}
+              data-testid="create-key-btn"
+            >
+              {creating ? 'Creating…' : 'Create key'}
+            </Button>
+          </div>
+        )}
+        {keys.length >= 3 && (
+          <p className="text-muted fs-xs mb-0">Maximum of 3 active API keys reached. Revoke one to create a new key.</p>
+        )}
+      </SettingSection>
+    </>
+  )
+}
+
 function AdvancedTab({ search }) {
   return (
     <SettingSection id="version" title="About" icon="info" search={search}>
@@ -730,6 +885,7 @@ export default function SettingsPage() {
         {tab === 'property' && <PropertyTab search={search} />}
         {tab === 'preferences' && <PreferencesTab search={search} />}
         {tab === 'data' && <DataTab search={search} />}
+        {tab === 'api-keys' && <ApiKeysTab search={search} />}
         {tab === 'advanced' && <AdvancedTab search={search} />}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Implements API key management and a public REST API for external integrations (Home Assistant, smart irrigation, custom dashboards).

- **API key management** — `POST /api-keys`, `GET /api-keys`, `DELETE /api-keys/:id` (Home Pro+ only, max 3 active keys)
- **Secure storage** — SHA-256 hashed keys stored in top-level `apiKeyHashes/{hash}` collection for fast O(1) lookup; user-scoped `users/{userId}/apiKeys` subcollection for listing/revocation
- **`requireApiKey` middleware** — accepts `x-plant-api-key` header on public routes; resolves `userId` from hash lookup
- **Public REST API v1** — `GET /api/v1/plants`, `GET /api/v1/plants/:id`, `POST /api/v1/plants/:id/water`, `GET /api/v1/plants/:id/care-score`
- **Rate limiting** — 1,000 req/hour per user via `express-rate-limit`
- **Frontend** — `apiKeysApi` in `src/api/plants.js` with `list()`, `create(name)`, `revoke(id)`
- **Settings tab** — new "API Keys" tab in SettingsPage with key creation form, masked key display table, one-time plaintext reveal banner, and revoke buttons

## Test plan
- [ ] Create API key → plaintext shown once in Settings → masked thereafter
- [ ] Send `x-plant-api-key: pt_live_...` to `/api/v1/plants` → returns plant list
- [ ] Revoke a key → subsequent requests with that key return 401
- [ ] Create 4th key → blocked with "Maximum of 3 active keys" error
- [ ] Backend: 21 new tests covering all new routes + middleware
- [ ] Frontend: 10 new SettingsPage API Keys tab tests
- [ ] All 769 frontend tests passing, backend coverage 84.93% (above 80% threshold)

Closes #168

https://claude.ai/code/session_019p5kUGzF2TWBHAp3zCdhid

---
_Generated by [Claude Code](https://claude.ai/code/session_019p5kUGzF2TWBHAp3zCdhid)_