### PR TITLE
feat: white-label branding settings for Landscaper Pro — issue #167

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1081,6 +1081,46 @@ app.put('/config/floorplan', requireUser, async (req, res) => {
   }
 });
 
+// ── Branding config ───────────────────────────────────────────────────────────
+
+app.get('/config/branding', requireUser, requireTier('landscaper_pro'), async (req, res) => {
+  try {
+    const doc = await userConfig(req.userId).doc('branding').get();
+    const data = doc.exists ? doc.data() : {};
+    if (data.logoUrl) {
+      try { data.logoUrl = await signReadUrl(data.logoUrl); } catch { /* serve raw URL on signing failure */ }
+    }
+    res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const HEX_COLOUR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+app.put('/config/branding', requireUser, requireTier('landscaper_pro'), async (req, res) => {
+  try {
+    const { businessName, logoUrl, brandColour, contactPhone, contactEmail, contactWebsite } = req.body || {};
+    if (brandColour != null && !HEX_COLOUR_RE.test(brandColour)) {
+      return res.status(400).json({ error: 'brandColour must be a valid hex colour (e.g. #3a7d44)' });
+    }
+    const update = { updatedAt: new Date().toISOString() };
+    if (businessName !== undefined) update.businessName = String(businessName).trim().slice(0, 100);
+    if (logoUrl !== undefined) update.logoUrl = logoUrl;
+    if (brandColour !== undefined) update.brandColour = brandColour;
+    if (contactPhone !== undefined) update.contactPhone = String(contactPhone).trim().slice(0, 50);
+    if (contactEmail !== undefined) update.contactEmail = String(contactEmail).trim().slice(0, 254);
+    if (contactWebsite !== undefined) update.contactWebsite = String(contactWebsite).trim().slice(0, 2048);
+    await userConfig(req.userId).doc('branding').set(update, { merge: true });
+    if (update.logoUrl) {
+      try { update.logoUrl = await signReadUrl(update.logoUrl); } catch { /* serve raw on failure */ }
+    }
+    res.status(200).json(update);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Plants CRUD ───────────────────────────────────────────────────────────────
 
 app.get('/plants', requireUser, async (req, res) => {

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -587,6 +587,88 @@ describe('PUT /config/floors', () => {
   });
 });
 
+// ── GET /config/branding ──────────────────────────────────────────────────────
+
+const brandingPath = () => `users/${USER_SUB}/config/branding`;
+
+describe('GET /config/branding', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).get('/config/branding');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns empty object when no branding is saved', async () => {
+    const res = await request(app).get('/config/branding').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({});
+  });
+
+  it('returns saved branding fields', async () => {
+    store[brandingPath()] = { businessName: 'Green Thumb', brandColour: '#3a7d44', updatedAt: '2026-01-01T00:00:00Z' };
+    const res = await request(app).get('/config/branding').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.businessName).toBe('Green Thumb');
+    expect(res.body.brandColour).toBe('#3a7d44');
+  });
+});
+
+// ── PUT /config/branding ──────────────────────────────────────────────────────
+
+describe('PUT /config/branding', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).put('/config/branding').send({ businessName: 'Test' });
+    expect(res.status).toBe(401);
+  });
+
+  it('saves branding and returns the updated fields', async () => {
+    const res = await request(app)
+      .put('/config/branding')
+      .set('Authorization', authHeader())
+      .send({ businessName: 'Leaf & Co', brandColour: '#4a8c55', contactPhone: '+1 555 0001', contactEmail: 'hi@leaf.co', contactWebsite: 'https://leaf.co' });
+    expect(res.status).toBe(200);
+    expect(res.body.businessName).toBe('Leaf & Co');
+    expect(res.body.brandColour).toBe('#4a8c55');
+    expect(res.body.contactEmail).toBe('hi@leaf.co');
+  });
+
+  it('persists branding to Firestore', async () => {
+    await request(app)
+      .put('/config/branding')
+      .set('Authorization', authHeader())
+      .send({ businessName: 'Verdure Ltd' });
+    expect(store[brandingPath()].businessName).toBe('Verdure Ltd');
+    expect(store[brandingPath()].updatedAt).toBeTruthy();
+  });
+
+  it('returns 400 for an invalid brandColour', async () => {
+    const res = await request(app)
+      .put('/config/branding')
+      .set('Authorization', authHeader())
+      .send({ brandColour: 'not-a-colour' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/hex colour/i);
+  });
+
+  it('accepts a 3-digit hex colour', async () => {
+    const res = await request(app)
+      .put('/config/branding')
+      .set('Authorization', authHeader())
+      .send({ brandColour: '#abc' });
+    expect(res.status).toBe(200);
+    expect(res.body.brandColour).toBe('#abc');
+  });
+
+  it('allows partial updates without overwriting omitted fields', async () => {
+    store[brandingPath()] = { businessName: 'Original', brandColour: '#111111', updatedAt: '2026-01-01T00:00:00Z' };
+    await request(app)
+      .put('/config/branding')
+      .set('Authorization', authHeader())
+      .send({ contactPhone: '+44 7700 900000' });
+    expect(store[brandingPath()].businessName).toBe('Original');
+    expect(store[brandingPath()].contactPhone).toBe('+44 7700 900000');
+  });
+});
+
 // ── GET /plants ───────────────────────────────────────────────────────────────
 
 describe('GET /plants', () => {

--- a/src/__tests__/SettingsPage.test.jsx
+++ b/src/__tests__/SettingsPage.test.jsx
@@ -46,6 +46,13 @@ vi.mock('../api/plants.js', () => ({
     create: vi.fn(),
     revoke: vi.fn(),
   },
+  brandingApi: {
+    get: vi.fn().mockResolvedValue({}),
+    save: vi.fn().mockResolvedValue({}),
+  },
+  imagesApi: {
+    upload: vi.fn().mockResolvedValue('https://storage.example.com/branding/logo.png'),
+  },
 }))
 
 // LeafletFloorplan touches canvas APIs not available in jsdom
@@ -54,7 +61,7 @@ vi.mock('../components/LeafletFloorplan.jsx', () => ({
 }))
 
 import SettingsPage from '../pages/SettingsPage.jsx'
-import { accountApi, apiKeysApi } from '../api/plants.js'
+import { accountApi, apiKeysApi, brandingApi, imagesApi } from '../api/plants.js'
 
 function renderAt(path) {
   return render(
@@ -289,5 +296,74 @@ describe('SettingsPage API Keys tab', () => {
     await waitFor(() => expect(screen.getByTestId('revoke-key-k1')).toBeInTheDocument())
     fireEvent.click(screen.getByTestId('revoke-key-k1'))
     await waitFor(() => expect(screen.queryByTestId('revoke-key-k1')).not.toBeInTheDocument())
+  })
+})
+
+describe('SettingsPage Branding tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    brandingApi.get.mockResolvedValue({})
+    brandingApi.save.mockResolvedValue({})
+  })
+
+  it('shows the Branding tab in navigation', () => {
+    renderAt('/settings/branding')
+    expect(screen.getAllByText('Branding').length).toBeGreaterThan(0)
+  })
+
+  it('renders business identity section', async () => {
+    renderAt('/settings/branding')
+    await waitFor(() => expect(screen.getByText(/Business Identity/i)).toBeInTheDocument())
+  })
+
+  it('renders logo upload section', async () => {
+    renderAt('/settings/branding')
+    await waitFor(() => expect(screen.getByTestId('branding-upload-logo-btn')).toBeInTheDocument())
+  })
+
+  it('renders contact info section', async () => {
+    renderAt('/settings/branding')
+    await waitFor(() => expect(screen.getByTestId('branding-contact-phone')).toBeInTheDocument())
+    expect(screen.getByTestId('branding-contact-email')).toBeInTheDocument()
+    expect(screen.getByTestId('branding-contact-website')).toBeInTheDocument()
+  })
+
+  it('loads existing branding data on mount', async () => {
+    brandingApi.get.mockResolvedValue({
+      businessName: 'Green Thumb Landscaping',
+      brandColour: '#4a8c55',
+      contactEmail: 'hi@greenthumb.com',
+    })
+    renderAt('/settings/branding')
+    await waitFor(() => expect(screen.getByTestId('branding-business-name')).toHaveValue('Green Thumb Landscaping'))
+    expect(screen.getByTestId('branding-colour-hex')).toHaveValue('#4a8c55')
+    expect(screen.getByTestId('branding-contact-email')).toHaveValue('hi@greenthumb.com')
+  })
+
+  it('calls brandingApi.save with form data on save', async () => {
+    renderAt('/settings/branding')
+    await waitFor(() => expect(screen.getByTestId('branding-business-name')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('branding-business-name'), { target: { value: 'Leaf & Co' } })
+    fireEvent.change(screen.getByTestId('branding-contact-phone'), { target: { value: '+1 555 0001' } })
+    fireEvent.click(screen.getByTestId('branding-save-btn'))
+    await waitFor(() => expect(brandingApi.save).toHaveBeenCalledWith(
+      expect.objectContaining({ businessName: 'Leaf & Co', contactPhone: '+1 555 0001' })
+    ))
+  })
+
+  it('shows logo preview when branding has a logoUrl', async () => {
+    brandingApi.get.mockResolvedValue({ logoUrl: 'https://storage.example.com/branding/logo.png' })
+    renderAt('/settings/branding')
+    await waitFor(() => expect(screen.getByTestId('branding-logo-preview')).toBeInTheDocument())
+    expect(screen.getByTestId('branding-logo-preview')).toHaveAttribute('src', 'https://storage.example.com/branding/logo.png')
+  })
+
+  it('calls imagesApi.upload and brandingApi.save on logo file selection', async () => {
+    renderAt('/settings/branding')
+    await waitFor(() => expect(screen.getByTestId('branding-logo-input')).toBeInTheDocument())
+    const file = new File(['logo'], 'logo.png', { type: 'image/png' })
+    fireEvent.change(screen.getByTestId('branding-logo-input'), { target: { files: [file] } })
+    await waitFor(() => expect(imagesApi.upload).toHaveBeenCalledWith(file, 'branding'))
+    await waitFor(() => expect(brandingApi.save).toHaveBeenCalledWith({ logoUrl: 'https://storage.example.com/branding/logo.png' }))
   })
 })

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -337,6 +337,11 @@ export const importApi = {
   },
 }
 
+export const brandingApi = {
+  get: () => request('/config/branding'),
+  save: (data) => request('/config/branding', { method: 'PUT', body: JSON.stringify(data) }),
+}
+
 export const apiKeysApi = {
   async list() {
     return request('/api-keys')

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -11,13 +11,14 @@ import { TIMEZONE_GROUPS } from '../hooks/useTimezone.js'
 import { SUPPORTED_LANGUAGES } from '../i18n/index.js'
 import { useTranslation } from 'react-i18next'
 import i18n from '../i18n/index.js'
-import { accountApi, exportApi, apiKeysApi } from '../api/plants.js'
+import { accountApi, exportApi, apiKeysApi, brandingApi, imagesApi } from '../api/plants.js'
 
 const TABS = [
   { id: 'property', label: 'Property', icon: 'layers', tags: 'floors zones floorplan rooms upload property' },
   { id: 'preferences', label: 'Preferences', icon: 'sliders', tags: 'theme dark mode light temperature celsius fahrenheit metric imperial units location city weather' },
   { id: 'data', label: 'Data & export', icon: 'download', tags: 'export csv download backup data' },
   { id: 'api-keys', label: 'API Keys', icon: 'key', tags: 'api keys rest integration home assistant automation developer' },
+  { id: 'branding', label: 'Branding', icon: 'star', tags: 'branding logo colour color business name landscaper white label report pdf' },
   { id: 'advanced', label: 'Advanced', icon: 'tool', tags: 'reset onboarding developer version advanced' },
 ]
 
@@ -805,6 +806,177 @@ function ApiKeysTab({ search }) {
   )
 }
 
+function BrandingTab({ search }) {
+  const [form, setForm] = useState({ businessName: '', brandColour: '#3a7d44', contactPhone: '', contactEmail: '', contactWebsite: '' })
+  const [logoUrl, setLogoUrl] = useState(null)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState(null)
+  const [uploadingLogo, setUploadingLogo] = useState(false)
+  const logoInputRef = useRef(null)
+
+  useEffect(() => {
+    brandingApi.get().then((data) => {
+      setForm({
+        businessName: data.businessName || '',
+        brandColour: data.brandColour || '#3a7d44',
+        contactPhone: data.contactPhone || '',
+        contactEmail: data.contactEmail || '',
+        contactWebsite: data.contactWebsite || '',
+      })
+      if (data.logoUrl) setLogoUrl(data.logoUrl)
+    }).catch(() => {})
+  }, [])
+
+  const handleLogoUpload = async (file) => {
+    if (!file) return
+    setUploadingLogo(true)
+    setError(null)
+    try {
+      const url = await imagesApi.upload(file, 'branding')
+      setLogoUrl(url)
+      await brandingApi.save({ logoUrl: url })
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setUploadingLogo(false)
+    }
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      await brandingApi.save(form)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <SettingSection id="branding-identity" title="Business Identity" icon="star" search={search}>
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-sm fw-semibold">Business name</Form.Label>
+          <Form.Control
+            data-testid="branding-business-name"
+            value={form.businessName}
+            onChange={(e) => setForm((f) => ({ ...f, businessName: e.target.value }))}
+            placeholder="e.g. Green Thumb Landscaping"
+            maxLength={100}
+          />
+          <Form.Text className="text-muted">Shown in PDF report headers and client-facing views.</Form.Text>
+        </Form.Group>
+
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-sm fw-semibold">Primary brand colour</Form.Label>
+          <div className="d-flex align-items-center gap-2">
+            <Form.Control
+              data-testid="branding-colour-picker"
+              type="color"
+              value={form.brandColour}
+              onChange={(e) => setForm((f) => ({ ...f, brandColour: e.target.value }))}
+              style={{ width: 48, height: 38, padding: 2, cursor: 'pointer' }}
+            />
+            <Form.Control
+              data-testid="branding-colour-hex"
+              value={form.brandColour}
+              onChange={(e) => setForm((f) => ({ ...f, brandColour: e.target.value }))}
+              placeholder="#3a7d44"
+              style={{ maxWidth: 120 }}
+            />
+          </div>
+          <Form.Text className="text-muted">Applied to report headers and accent elements.</Form.Text>
+        </Form.Group>
+      </SettingSection>
+
+      <SettingSection id="branding-logo" title="Logo" icon="image" search={search}>
+        {logoUrl && (
+          <div className="mb-3">
+            <img
+              data-testid="branding-logo-preview"
+              src={logoUrl}
+              alt="Business logo"
+              style={{ maxWidth: 200, maxHeight: 60, objectFit: 'contain', borderRadius: 4 }}
+            />
+          </div>
+        )}
+        <div className="d-flex align-items-center gap-2">
+          <Button
+            data-testid="branding-upload-logo-btn"
+            variant="outline-secondary"
+            size="sm"
+            onClick={() => logoInputRef.current?.click()}
+            disabled={uploadingLogo}
+          >
+            {uploadingLogo ? 'Uploading…' : logoUrl ? 'Replace logo' : 'Upload logo'}
+          </Button>
+          <span className="text-muted fs-xs">PNG, SVG or JPEG · max 2 MB · displayed at up to 200×60 px</span>
+        </div>
+        <input
+          ref={logoInputRef}
+          type="file"
+          accept="image/png,image/svg+xml,image/jpeg"
+          style={{ display: 'none' }}
+          data-testid="branding-logo-input"
+          onChange={(e) => handleLogoUpload(e.target.files?.[0])}
+        />
+      </SettingSection>
+
+      <SettingSection id="branding-contact" title="Contact Info" icon="phone" search={search}>
+        <Form.Text className="text-muted d-block mb-3">Shown in PDF report footers and client-facing views.</Form.Text>
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-sm fw-semibold">Phone</Form.Label>
+          <Form.Control
+            data-testid="branding-contact-phone"
+            value={form.contactPhone}
+            onChange={(e) => setForm((f) => ({ ...f, contactPhone: e.target.value }))}
+            placeholder="+1 555 123 4567"
+            maxLength={50}
+          />
+        </Form.Group>
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-sm fw-semibold">Email</Form.Label>
+          <Form.Control
+            data-testid="branding-contact-email"
+            type="email"
+            value={form.contactEmail}
+            onChange={(e) => setForm((f) => ({ ...f, contactEmail: e.target.value }))}
+            placeholder="hello@greenthumb.com"
+            maxLength={254}
+          />
+        </Form.Group>
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-sm fw-semibold">Website</Form.Label>
+          <Form.Control
+            data-testid="branding-contact-website"
+            type="url"
+            value={form.contactWebsite}
+            onChange={(e) => setForm((f) => ({ ...f, contactWebsite: e.target.value }))}
+            placeholder="https://greenthumb.com"
+            maxLength={2048}
+          />
+        </Form.Group>
+
+        {error && <p className="text-danger fs-sm mb-2">{error}</p>}
+        <Button
+          data-testid="branding-save-btn"
+          variant="primary"
+          size="sm"
+          onClick={handleSave}
+          disabled={saving}
+        >
+          {saving ? 'Saving…' : saved ? 'Saved!' : 'Save branding'}
+        </Button>
+      </SettingSection>
+    </>
+  )
+}
+
 function AdvancedTab({ search }) {
   return (
     <SettingSection id="version" title="About" icon="info" search={search}>
@@ -886,6 +1058,7 @@ export default function SettingsPage() {
         {tab === 'preferences' && <PreferencesTab search={search} />}
         {tab === 'data' && <DataTab search={search} />}
         {tab === 'api-keys' && <ApiKeysTab search={search} />}
+        {tab === 'branding' && <BrandingTab search={search} />}
         {tab === 'advanced' && <AdvancedTab search={search} />}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Implements white-label branding configuration storage and Settings UI for Landscaper Pro subscribers (issue #167).

- **Backend** — `GET /config/branding` and `PUT /config/branding`, gated to `landscaper_pro` tier; stores `businessName`, `logoUrl`, `brandColour`, `contactPhone`, `contactEmail`, `contactWebsite` in `users/{userId}/config/branding` (Firestore); hex colour validated; partial updates via `set({merge:true})`; logo URL signed for reading
- **Frontend API** — `brandingApi.get()` and `brandingApi.save(data)` added to `src/api/plants.js`
- **Settings tab** — new "Branding" tab in SettingsPage with three sections:
  - *Business Identity* — business name input + colour picker (hex + native color input)
  - *Logo* — file upload using existing `imagesApi` GCS signed-URL flow (PNG/SVG/JPEG, max 2 MB); logo preview shown when set
  - *Contact Info* — phone, email, website; all saved together with a single "Save branding" button
- **Tests** — 7 backend tests (auth gate, GET empty/populated, PUT round-trip/persistence/partial-update/colour-validation); 8 frontend Branding tab tests

> **Note on Stripe add-on**: The issue requests a purchasable Stripe add-on. That requires a Stripe product/price ID provisioned in platform-infra Terraform — outside the scope of this PR. The branding data model and UI are ready for that when the product is set up.

## Test plan
- [ ] Visit `/settings/branding` → see Business Identity, Logo, and Contact Info sections
- [ ] Enter business name + colour → Save → reload → values persist
- [ ] Upload a logo image → preview appears below upload button
- [ ] GET/PUT `/config/branding` with `x-api-gateway-api-userinfo` header → 200 with correct fields
- [ ] PUT with `brandColour: "notahex"` → 400 with hex colour error
- [ ] Backend: 7 new tests all passing, coverage above 80% threshold

Closes #167

https://claude.ai/code/session_019p5kUGzF2TWBHAp3zCdhid

---
_Generated by [Claude Code](https://claude.ai/code/session_019p5kUGzF2TWBHAp3zCdhid)_