### PR TITLE
feat(#305): plant propagation lineage — parent/child relationships and success-rate stats

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -3131,6 +3131,136 @@ app.get('/plants/:id/anomaly', requireUser, async (req, res) => {
   }
 });
 
+// GET /plants/:id/lineage — ancestry and descendants (depth ≤ 3)
+app.get('/plants/:id/lineage', requireUser, async (req, res) => {
+  try {
+    const depth = Math.min(parseInt(req.query.depth) || 3, 3);
+    const targetId = req.params.id;
+
+    const snap = await userPlants(req.userId).get();
+    const allPlants = {};
+    for (const doc of snap.docs) {
+      allPlants[doc.id] = { id: doc.id, ...doc.data() };
+    }
+
+    if (!allPlants[targetId]) {
+      return res.status(404).json({ error: 'Plant not found' });
+    }
+
+    // Walk up parentPlantId chain for ancestors
+    const ancestors = [];
+    const visited = new Set([targetId]);
+    let cursor = allPlants[targetId];
+    for (let d = 0; d < depth; d++) {
+      if (!cursor.parentPlantId || !allPlants[cursor.parentPlantId]) break;
+      if (visited.has(cursor.parentPlantId)) break; // cycle guard
+      visited.add(cursor.parentPlantId);
+      cursor = allPlants[cursor.parentPlantId];
+      ancestors.unshift({ id: cursor.id, name: cursor.name, species: cursor.species, health: cursor.health });
+    }
+
+    // Collect direct children recursively (BFS, depth-limited)
+    function getChildren(plantId, currentDepth) {
+      if (currentDepth >= depth) return [];
+      return Object.values(allPlants)
+        .filter(p => p.parentPlantId === plantId)
+        .map(p => ({
+          id: p.id, name: p.name, species: p.species, health: p.health,
+          propagationMethod: p.propagationMethod || null,
+          children: getChildren(p.id, currentDepth + 1),
+        }));
+    }
+
+    const plant = allPlants[targetId];
+    res.status(200).json({
+      plant: { id: plant.id, name: plant.name, species: plant.species, health: plant.health, parentPlantId: plant.parentPlantId || null },
+      ancestors,
+      children: getChildren(targetId, 0),
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /propagation/stats — success-rate analytics by species, method, month + top mothers
+app.get('/propagation/stats', requireUser, async (req, res) => {
+  try {
+    const [propSnap, plantSnap] = await Promise.all([
+      userPropagations(req.userId).get(),
+      userPlants(req.userId).get(),
+    ]);
+
+    const propagations = propSnap.docs.map(d => ({ id: d.id, ...d.data() }));
+    const plants = plantSnap.docs.map(d => ({ id: d.id, ...d.data() }));
+    const plantById = Object.fromEntries(plants.map(p => [p.id, p]));
+
+    const GOOD_HEALTH = new Set(['Good', 'Excellent']);
+    const SURVIVAL_MS = 90 * 86400000;
+    const now = Date.now();
+
+    function isSurvived(prop) {
+      const child = plants.find(p => p.parentPropagationId === prop.id);
+      if (!child) return false;
+      if (!GOOD_HEALTH.has(child.health)) return false;
+      const created = new Date(child.createdAt || prop.startDate).getTime();
+      return now - created >= SURVIVAL_MS;
+    }
+
+    const bySpecies = {};
+    const byMethod = {};
+    const byMonth = {};
+    const motherTotal = {};
+    const motherSucceeded = {};
+
+    for (const prop of propagations) {
+      if (!['transplanted', 'failed'].includes(prop.status)) continue;
+      const success = prop.status === 'transplanted' && isSurvived(prop);
+
+      const sp = prop.species || 'Unknown';
+      bySpecies[sp] = bySpecies[sp] || { total: 0, succeeded: 0 };
+      bySpecies[sp].total++;
+      if (success) bySpecies[sp].succeeded++;
+
+      const mt = prop.method || 'unknown';
+      byMethod[mt] = byMethod[mt] || { total: 0, succeeded: 0 };
+      byMethod[mt].total++;
+      if (success) byMethod[mt].succeeded++;
+
+      const mo = (prop.startDate || '').slice(0, 7) || 'unknown';
+      byMonth[mo] = byMonth[mo] || { total: 0, succeeded: 0 };
+      byMonth[mo].total++;
+      if (success) byMonth[mo].succeeded++;
+
+      if (prop.parentPlantId) {
+        motherTotal[prop.parentPlantId] = (motherTotal[prop.parentPlantId] || 0) + 1;
+        if (success) motherSucceeded[prop.parentPlantId] = (motherSucceeded[prop.parentPlantId] || 0) + 1;
+      }
+    }
+
+    const rate = (s, t) => t > 0 ? Math.round((s / t) * 100) : 0;
+
+    const topMothers = Object.entries(motherTotal)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 5)
+      .map(([plantId, childrenCount]) => ({
+        plantId,
+        name: plantById[plantId]?.name || null,
+        species: plantById[plantId]?.species || null,
+        childrenCount,
+        survivalRate: rate(motherSucceeded[plantId] || 0, childrenCount),
+      }));
+
+    res.status(200).json({
+      successRateBySpecies: Object.entries(bySpecies).map(([species, v]) => ({ species, ...v, rate: rate(v.succeeded, v.total) })),
+      successRateByMethod: Object.entries(byMethod).map(([method, v]) => ({ method, ...v, rate: rate(v.succeeded, v.total) })),
+      successRateByMonth: Object.entries(byMonth).sort(([a], [b]) => a.localeCompare(b)).map(([month, v]) => ({ month, ...v, rate: rate(v.succeeded, v.total) })),
+      topMothers,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 app.delete('/plants/:id', requireUser, async (req, res) => {
   try {
     const ref = userPlants(req.userId).doc(req.params.id);

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -4544,3 +4544,104 @@ describe('GET /api/v1/plants/:id/care-score', () => {
     expect(res.body.score).toBeDefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// GET /plants/:id/lineage  (#305 propagation lineage)
+// ---------------------------------------------------------------------------
+
+describe('GET /plants/:id/lineage', () => {
+  beforeEach(() => {
+    store[plantPath('parent')] = { name: 'Mother Monstera', species: 'Monstera', health: 'Good' };
+    store[plantPath('child')] = { name: 'Child Monstera', species: 'Monstera', health: 'Good', parentPlantId: 'parent' };
+    store[plantPath('grandchild')] = { name: 'Grandchild Monstera', species: 'Monstera', health: 'Good', parentPlantId: 'child' };
+  });
+
+  it('returns 404 for unknown plant', async () => {
+    const res = await request(app).get('/plants/nope/lineage').set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns plant with no ancestors or children', async () => {
+    const res = await request(app).get('/plants/parent/lineage').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.plant.id).toBe('parent');
+    expect(res.body.ancestors).toHaveLength(0);
+  });
+
+  it('returns ancestors for a child plant', async () => {
+    const res = await request(app).get('/plants/child/lineage').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.ancestors).toHaveLength(1);
+    expect(res.body.ancestors[0].id).toBe('parent');
+  });
+
+  it('returns children of a parent plant', async () => {
+    const res = await request(app).get('/plants/parent/lineage').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.children).toHaveLength(1);
+    expect(res.body.children[0].id).toBe('child');
+  });
+
+  it('returns nested children up to depth 3', async () => {
+    const res = await request(app).get('/plants/parent/lineage?depth=3').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.children[0].children).toHaveLength(1);
+    expect(res.body.children[0].children[0].id).toBe('grandchild');
+  });
+
+  it('prevents cycles via visited set', async () => {
+    store[plantPath('cycleA')] = { name: 'A', species: 'X', health: 'Good', parentPlantId: 'cycleB' };
+    store[plantPath('cycleB')] = { name: 'B', species: 'X', health: 'Good', parentPlantId: 'cycleA' };
+    const res = await request(app).get('/plants/cycleA/lineage').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    // Should not hang — ancestors capped by cycle guard
+    expect(res.body.ancestors.length).toBeLessThanOrEqual(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /propagation/stats  (#305 propagation lineage)
+// ---------------------------------------------------------------------------
+
+describe('GET /propagation/stats', () => {
+  it('returns empty stats when no data', async () => {
+    const res = await request(app).get('/propagation/stats').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.successRateBySpecies).toHaveLength(0);
+    expect(res.body.topMothers).toHaveLength(0);
+  });
+
+  it('calculates success rate correctly for transplanted propagations', async () => {
+    const ninetyOneDaysAgo = new Date(Date.now() - 91 * 86400000).toISOString();
+    store[propPath('s1')] = { method: 'cutting', species: 'Basil', status: 'transplanted', startDate: '2026-01-01' };
+    store[propPath('s2')] = { method: 'cutting', species: 'Basil', status: 'failed', startDate: '2026-01-01' };
+    // Plant promoted from s1, alive 91+ days with Good health
+    store[plantPath('promoted1')] = { name: 'Basil Jr', species: 'Basil', health: 'Good', parentPropagationId: 's1', createdAt: ninetyOneDaysAgo };
+    const res = await request(app).get('/propagation/stats').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    const basil = res.body.successRateBySpecies.find(r => r.species === 'Basil');
+    expect(basil).toBeDefined();
+    expect(basil.total).toBe(2);
+    expect(basil.succeeded).toBe(1);
+    expect(basil.rate).toBe(50);
+  });
+
+  it('includes top mothers when parentPlantId is set', async () => {
+    const ninetyOneDaysAgo = new Date(Date.now() - 91 * 86400000).toISOString();
+    store[plantPath('mother')] = { name: 'Mother Plant', species: 'Pothos', health: 'Good' };
+    store[propPath('pm1')] = { method: 'cutting', species: 'Pothos', status: 'transplanted', startDate: '2026-01-01', parentPlantId: 'mother' };
+    store[plantPath('pchild')] = { name: 'Pothos Jr', species: 'Pothos', health: 'Good', parentPropagationId: 'pm1', createdAt: ninetyOneDaysAgo };
+    const res = await request(app).get('/propagation/stats').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.topMothers).toHaveLength(1);
+    expect(res.body.topMothers[0].plantId).toBe('mother');
+    expect(res.body.topMothers[0].name).toBe('Mother Plant');
+  });
+
+  it('skips in-progress propagations from stats', async () => {
+    store[propPath('active')] = { method: 'seed', species: 'Tomato', status: 'sown', startDate: '2026-04-01' };
+    const res = await request(app).get('/propagation/stats').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.successRateBySpecies).toHaveLength(0);
+  });
+});

--- a/src/__tests__/Propagation.test.jsx
+++ b/src/__tests__/Propagation.test.jsx
@@ -9,11 +9,13 @@ vi.mock('../api/plants.js', () => ({
     update: vi.fn(),
     promote: vi.fn(),
     delete: vi.fn(),
+    stats: vi.fn().mockResolvedValue({ successRateBySpecies: [], successRateByMethod: [], successRateByMonth: [], topMothers: [] }),
+    lineage: vi.fn(),
   },
 }))
 
 vi.mock('../context/PlantContext.jsx', () => ({
-  usePlantContext: () => ({ isGuest: false, reloadPlants: vi.fn() }),
+  usePlantContext: () => ({ isGuest: false, reloadPlants: vi.fn(), plants: [] }),
 }))
 
 vi.mock('../components/EmptyState.jsx', () => ({
@@ -145,5 +147,40 @@ describe('buildPropagationTasks', () => {
     const result = buildPropagationTasks(props, now)
     expect(result.tasks[0].propagationId).toBe('a')
     expect(result.tasks[1].propagationId).toBe('b')
+  })
+})
+
+// ── Stats tab tests ────────────────────────────────────────────────────────────
+describe('PropagationPage stats tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    propagationApi.list.mockResolvedValue([])
+    propagationApi.stats.mockResolvedValue({
+      successRateBySpecies: [{ species: 'Pothos', total: 4, succeeded: 3, rate: 75 }],
+      successRateByMethod: [{ method: 'cutting', total: 4, succeeded: 3, rate: 75 }],
+      successRateByMonth: [],
+      topMothers: [{ plantId: 'p1', name: 'Mother Plant', species: 'Pothos', childrenCount: 3, survivalRate: 80 }],
+    })
+  })
+
+  it('renders Stats button in column tabs', async () => {
+    render(<PropagationPage />)
+    await waitFor(() => expect(screen.getByText('Stats')).toBeInTheDocument())
+  })
+
+  it('shows species stats table when Stats tab is clicked', async () => {
+    render(<PropagationPage />)
+    await waitFor(() => screen.getByText('Stats'))
+    fireEvent.click(screen.getByText('Stats'))
+    await waitFor(() => expect(screen.getByText('By species')).toBeInTheDocument())
+    expect(screen.getAllByText('Pothos').length).toBeGreaterThan(0)
+  })
+
+  it('shows top mothers table on Stats tab', async () => {
+    render(<PropagationPage />)
+    await waitFor(() => screen.getByText('Stats'))
+    fireEvent.click(screen.getByText('Stats'))
+    await waitFor(() => expect(screen.getByText('Top producing plants')).toBeInTheDocument())
+    expect(screen.getByText('Mother Plant')).toBeInTheDocument()
   })
 })

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -238,6 +238,8 @@ export const propagationApi = {
   promote: (id, data) => request(`/propagations/${id}/promote`, { method: 'POST', body: JSON.stringify(data) }),
   delete: (id) => request(`/propagations/${id}`, { method: 'DELETE' }),
   recommend: (data) => request('/recommend-propagation', { method: 'POST', body: JSON.stringify(data) }),
+  lineage: (plantId, depth = 3) => request(`/plants/${plantId}/lineage?depth=${depth}`),
+  stats: () => request('/propagation/stats'),
 }
 
 export const accountApi = {

--- a/src/pages/PropagationPage.jsx
+++ b/src/pages/PropagationPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Button, Badge, Form, Modal, Row, Col } from 'react-bootstrap'
+import { Button, Badge, Form, Modal, Row, Col, Table } from 'react-bootstrap'
 import { propagationApi } from '../api/plants.js'
 import { usePlantContext } from '../context/PlantContext.jsx'
 import EmptyState from '../components/EmptyState.jsx'
@@ -20,6 +20,105 @@ const STATUS_COLUMNS = {
   growing:  { label: 'Growing',  statuses: ['germinated'],       icon: 'trending-up', color: 'success' },
   ready:    { label: 'Ready',    statuses: ['ready'],             icon: 'check-circle', color: 'primary' },
   done:     { label: 'Done',     statuses: ['transplanted', 'failed'], icon: 'archive', color: 'secondary' },
+}
+
+function StatsPanel({ isGuest }) {
+  const [stats, setStats] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (isGuest) { setLoading(false); return }
+    propagationApi.stats()
+      .then(data => { setStats(data); setError(null) })
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
+  }, [isGuest])
+
+  if (isGuest) return (
+    <div className="panel panel-icon">
+      <div className="panel-container"><div className="panel-content">
+        <EmptyState icon="bar-chart-2" title="Sign in to see propagation stats" description="Track your success rates across species, methods, and seasons." actions={[{ label: 'Sign in', icon: 'log-in', href: '/login' }]} />
+      </div></div>
+    </div>
+  )
+
+  if (loading) return <div className="text-center py-5 text-muted"><div className="spinner-border spinner-border-sm me-2" />Loading…</div>
+  if (error) return <div className="alert alert-danger">{error}</div>
+  if (!stats) return null
+
+  const noData = !stats.successRateByMethod?.length && !stats.topMothers?.length
+
+  if (noData) return (
+    <div className="panel panel-icon">
+      <div className="panel-container"><div className="panel-content">
+        <EmptyState icon="bar-chart-2" title="No completed propagations yet" description="Stats appear once batches are marked as transplanted or failed." />
+      </div></div>
+    </div>
+  )
+
+  return (
+    <div>
+      <Row className="g-3 mb-3">
+        {stats.successRateByMethod?.map(row => (
+          <Col key={row.method} xs={6} md={3}>
+            <div className="panel panel-icon">
+              <div className="panel-container"><div className="panel-content text-center py-3">
+                <div className="tx-title fs-4 fw-bold">{row.rate}%</div>
+                <div className="tx-muted text-capitalize">{row.method}</div>
+                <div className="tx-muted" style={{ fontSize: 11 }}>{row.succeeded}/{row.total} survived</div>
+              </div></div>
+            </div>
+          </Col>
+        ))}
+      </Row>
+
+      {stats.topMothers?.length > 0 && (
+        <div className="panel panel-icon mb-3">
+          <div className="panel-hdr"><h2>Top producing plants</h2></div>
+          <div className="panel-container"><div className="panel-content p-0">
+            <Table size="sm" className="mb-0" responsive>
+              <thead><tr><th>Plant</th><th>Species</th><th className="text-end">Cuttings</th><th className="text-end">Survival</th></tr></thead>
+              <tbody>
+                {stats.topMothers.map(m => (
+                  <tr key={m.plantId}>
+                    <td>{m.name || '—'}</td>
+                    <td className="tx-muted">{m.species || '—'}</td>
+                    <td className="text-end">{m.childrenCount}</td>
+                    <td className="text-end">
+                      <Badge bg={m.survivalRate >= 70 ? 'success' : m.survivalRate >= 40 ? 'warning' : 'danger'}>{m.survivalRate}%</Badge>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </div></div>
+        </div>
+      )}
+
+      {stats.successRateBySpecies?.length > 0 && (
+        <div className="panel panel-icon">
+          <div className="panel-hdr"><h2>By species</h2></div>
+          <div className="panel-container"><div className="panel-content p-0">
+            <Table size="sm" className="mb-0" responsive>
+              <thead><tr><th>Species</th><th className="text-end">Total</th><th className="text-end">Survival rate</th></tr></thead>
+              <tbody>
+                {stats.successRateBySpecies.map(row => (
+                  <tr key={row.species}>
+                    <td>{row.species}</td>
+                    <td className="text-end">{row.total}</td>
+                    <td className="text-end">
+                      <Badge bg={row.rate >= 70 ? 'success' : row.rate >= 40 ? 'warning' : 'danger'}>{row.rate}%</Badge>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </div></div>
+        </div>
+      )}
+    </div>
+  )
 }
 
 const STATUS_NEXT = {
@@ -46,11 +145,12 @@ function daysSince(dateStr) {
   return Math.floor((Date.now() - new Date(dateStr).getTime()) / 86400000)
 }
 
-function PropagationCard({ prop, onAdvance, onFail, onPromote, onDelete }) {
+function PropagationCard({ prop, onAdvance, onFail, onPromote, onDelete, plants }) {
   const days = daysSince(prop.startDate)
   const isOverdue = prop.expectedDays && days > prop.expectedDays && !['transplanted', 'failed'].includes(prop.status)
   const nextStatus = STATUS_NEXT[prop.status]
   const isDone = ['transplanted', 'failed'].includes(prop.status)
+  const parentPlant = prop.parentPlantId && plants ? plants.find(p => p.id === prop.parentPlantId) : null
 
   return (
     <div className={`panel panel-icon mb-3 ${isOverdue ? 'border-warning border-opacity-50' : ''}`}>
@@ -64,6 +164,12 @@ function PropagationCard({ prop, onAdvance, onFail, onPromote, onDelete }) {
                 <span className="tx-muted">{days}d ago</span>
                 {prop.batchSize > 1 && <span className="tx-muted">× {prop.batchSize}</span>}
                 {prop.source && <span className="tx-muted text-truncate">{prop.source}</span>}
+                {parentPlant && (
+                  <span className="tx-muted">
+                    <svg className="sa-icon me-1" style={{ width: 11, height: 11 }}><use href="/icons/sprite.svg#git-branch" /></svg>
+                    from <strong>{parentPlant.name}</strong>
+                  </span>
+                )}
               </div>
               {isOverdue && (
                 <div className="text-warning fs-xs mt-1">
@@ -230,7 +336,7 @@ function PromoteModal({ prop, onHide, onPromote }) {
 }
 
 export default function PropagationPage() {
-  const { isGuest, reloadPlants } = usePlantContext()
+  const { isGuest, reloadPlants, plants } = usePlantContext()
   const [propagations, setPropagations] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -325,9 +431,19 @@ export default function PropagationPage() {
             </button>
           )
         })}
+        <button
+          type="button"
+          className={`btn btn-sm ${column === 'stats' ? 'btn-primary' : 'btn-outline-secondary'}`}
+          onClick={() => setColumn('stats')}
+        >
+          <svg className="sa-icon me-1" style={{ width: 12, height: 12 }}><use href="/icons/sprite.svg#bar-chart-2" /></svg>
+          Stats
+        </button>
       </div>
 
-      {loading ? (
+      {column === 'stats' ? (
+        <StatsPanel isGuest={isGuest} />
+      ) : loading ? (
         <div className="text-center py-5 text-muted">
           <div className="spinner-border spinner-border-sm me-2" />
           Loading…
@@ -364,6 +480,7 @@ export default function PropagationPage() {
               onFail={handleFail}
               onPromote={setPromotingProp}
               onDelete={handleDelete}
+              plants={plants}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

Closes #305

- **`GET /plants/:id/lineage`** — returns ancestors (up to depth 3, cycle-safe) and descendant tree for a plant
- **`GET /propagation/stats`** — success rates by species, method, month + top 5 mother plants (90-day survival definition)
- **PropagationPage Stats tab** — method-level rate cards, top-producing-mothers table, species success table
- **PropagationCard** — shows parent plant name inline when `parentPlantId` is set
- **API client** — `propagationApi.lineage()` and `propagationApi.stats()`

## Test plan
- [ ] 10 new backend tests: lineage (404, ancestry, children, depth-3 nesting, cycle guard) + stats (empty, 50% rate, top mothers, skips in-progress)
- [ ] 3 new frontend tests: Stats tab renders, species table, top mothers table
- [ ] All 408 backend tests pass; all 17 propagation frontend tests pass
- [ ] Frontend coverage: lines 51.89% (above 35% threshold); backend: statements 85% (above 80% threshold)

https://claude.ai/code/session_01FBBo2bV6WtYY69GjChB33d

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBBo2bV6WtYY69GjChB33d)_