### PR TITLE
feat(#304): soil health log — pH/NPK tests, amendments, substrate changes, and soil insight

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -3182,6 +3182,135 @@ app.get('/plants/:id/lineage', requireUser, async (req, res) => {
   }
 });
 
+// ── Soil health log (#304) ────────────────────────────────────────────────────
+
+function userSoilTests(userId, plantId) {
+  return userPlants(userId).doc(plantId).collection('soilTests');
+}
+function userAmendments(userId, plantId) {
+  return userPlants(userId).doc(plantId).collection('amendments');
+}
+function userSubstrateChanges(userId, plantId) {
+  return userPlants(userId).doc(plantId).collection('substrateChanges');
+}
+
+const SOIL_SOURCES = new Set(['strip', 'probe', 'lab', 'visual']);
+const AMENDMENT_KINDS = new Set(['compost', 'lime', 'sulphur', 'gypsum', 'biochar', 'fertiliser', 'other']);
+const TEXTURE_OPTIONS = new Set(['sand', 'silt', 'clay', 'loam', 'mix']);
+
+// GET /plants/:id/soil-tests
+app.get('/plants/:id/soil-tests', requireUser, async (req, res) => {
+  try {
+    const plant = await userPlants(req.userId).doc(req.params.id).get();
+    if (!plant.exists) return res.status(404).json({ error: 'Plant not found' });
+    const snap = await userSoilTests(req.userId, req.params.id).get();
+    const items = snap.docs.map(d => ({ id: d.id, ...d.data() }))
+      .sort((a, b) => new Date(b.recordedAt) - new Date(a.recordedAt));
+    res.status(200).json(items);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /plants/:id/soil-tests
+app.post('/plants/:id/soil-tests', requireUser, async (req, res) => {
+  try {
+    const plant = await userPlants(req.userId).doc(req.params.id).get();
+    if (!plant.exists) return res.status(404).json({ error: 'Plant not found' });
+    const { source, ph, ec, nitrogenPpm, phosphorusPpm, potassiumPpm, organicMatterPct, texture, notes } = req.body || {};
+    if (source && !SOIL_SOURCES.has(source)) {
+      return res.status(400).json({ error: `source must be one of: ${[...SOIL_SOURCES].join(', ')}` });
+    }
+    if (texture && !TEXTURE_OPTIONS.has(texture)) {
+      return res.status(400).json({ error: `texture must be one of: ${[...TEXTURE_OPTIONS].join(', ')}` });
+    }
+    const now = new Date().toISOString();
+    const data = {
+      recordedAt: now,
+      source: source || 'visual',
+      ph: ph != null ? Number(ph) : null,
+      ec: ec != null ? Number(ec) : null,
+      nitrogenPpm: nitrogenPpm != null ? Number(nitrogenPpm) : null,
+      phosphorusPpm: phosphorusPpm != null ? Number(phosphorusPpm) : null,
+      potassiumPpm: potassiumPpm != null ? Number(potassiumPpm) : null,
+      organicMatterPct: organicMatterPct != null ? Number(organicMatterPct) : null,
+      texture: texture || null,
+      notes: notes?.trim() || null,
+      createdAt: now,
+    };
+    const ref = await userSoilTests(req.userId, req.params.id).add(data);
+    res.status(201).json({ id: ref.id, ...data });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// DELETE /plants/:id/soil-tests/:testId
+app.delete('/plants/:id/soil-tests/:testId', requireUser, async (req, res) => {
+  try {
+    const ref = userSoilTests(req.userId, req.params.id).doc(req.params.testId);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Soil test not found' });
+    await ref.delete();
+    res.status(204).send();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /plants/:id/amendments
+app.get('/plants/:id/amendments', requireUser, async (req, res) => {
+  try {
+    const plant = await userPlants(req.userId).doc(req.params.id).get();
+    if (!plant.exists) return res.status(404).json({ error: 'Plant not found' });
+    const snap = await userAmendments(req.userId, req.params.id).get();
+    const items = snap.docs.map(d => ({ id: d.id, ...d.data() }))
+      .sort((a, b) => new Date(b.appliedAt) - new Date(a.appliedAt));
+    res.status(200).json(items);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /plants/:id/amendments
+app.post('/plants/:id/amendments', requireUser, async (req, res) => {
+  try {
+    const plant = await userPlants(req.userId).doc(req.params.id).get();
+    if (!plant.exists) return res.status(404).json({ error: 'Plant not found' });
+    const { kind, qty, qtyUnit, targetMetric, notes } = req.body || {};
+    if (!kind || !AMENDMENT_KINDS.has(kind)) {
+      return res.status(400).json({ error: `kind must be one of: ${[...AMENDMENT_KINDS].join(', ')}` });
+    }
+    const now = new Date().toISOString();
+    const data = {
+      appliedAt: now,
+      kind,
+      qty: qty != null ? Number(qty) : null,
+      qtyUnit: qtyUnit?.trim() || null,
+      targetMetric: targetMetric?.trim() || null,
+      notes: notes?.trim() || null,
+      createdAt: now,
+    };
+    const ref = await userAmendments(req.userId, req.params.id).add(data);
+    res.status(201).json({ id: ref.id, ...data });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// DELETE /plants/:id/amendments/:amendmentId
+app.delete('/plants/:id/amendments/:amendmentId', requireUser, async (req, res) => {
+  try {
+    const ref = userAmendments(req.userId, req.params.id).doc(req.params.amendmentId);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Amendment not found' });
+    await ref.delete();
+    res.status(204).send();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // GET /propagation/stats — success-rate analytics by species, method, month + top mothers
 app.get('/propagation/stats', requireUser, async (req, res) => {
   try {
@@ -3256,6 +3385,87 @@ app.get('/propagation/stats', requireUser, async (req, res) => {
       successRateByMonth: Object.entries(byMonth).sort(([a], [b]) => a.localeCompare(b)).map(([month, v]) => ({ month, ...v, rate: rate(v.succeeded, v.total) })),
       topMothers,
     });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /plants/:id/substrate-changes
+app.get('/plants/:id/substrate-changes', requireUser, async (req, res) => {
+  try {
+    const plant = await userPlants(req.userId).doc(req.params.id).get();
+    if (!plant.exists) return res.status(404).json({ error: 'Plant not found' });
+    const snap = await userSubstrateChanges(req.userId, req.params.id).get();
+    const items = snap.docs.map(d => ({ id: d.id, ...d.data() }))
+      .sort((a, b) => new Date(b.occurredAt) - new Date(a.occurredAt));
+    res.status(200).json(items);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /plants/:id/substrate-changes
+app.post('/plants/:id/substrate-changes', requireUser, async (req, res) => {
+  try {
+    const plant = await userPlants(req.userId).doc(req.params.id).get();
+    if (!plant.exists) return res.status(404).json({ error: 'Plant not found' });
+    const { newSubstrate, ratio, reason, notes } = req.body || {};
+    if (!newSubstrate?.trim()) return res.status(400).json({ error: 'newSubstrate is required' });
+    const now = new Date().toISOString();
+    const data = {
+      occurredAt: now,
+      newSubstrate: newSubstrate.trim(),
+      ratio: ratio?.trim() || null,
+      reason: reason?.trim() || null,
+      notes: notes?.trim() || null,
+      createdAt: now,
+    };
+    const ref = await userSubstrateChanges(req.userId, req.params.id).add(data);
+    res.status(201).json({ id: ref.id, ...data });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /plants/:id/soil-insight — rule-based pH/NPK verdict + Gemini rationale
+app.get('/plants/:id/soil-insight', requireUser, async (req, res) => {
+  try {
+    const plantDoc = await userPlants(req.userId).doc(req.params.id).get();
+    if (!plantDoc.exists) return res.status(404).json({ error: 'Plant not found' });
+    const plant = plantDoc.data();
+
+    const testsSnap = await userSoilTests(req.userId, req.params.id).get();
+    const tests = testsSnap.docs.map(d => d.data()).sort((a, b) => new Date(b.recordedAt) - new Date(a.recordedAt));
+    const latest = tests[0];
+
+    if (!latest || latest.ph == null) {
+      return res.status(200).json({ verdict: 'unknown', severity: 'none', recommendedAmendment: null, rationale: 'No soil test data available yet.' });
+    }
+
+    const ph = latest.ph;
+    let verdict = 'ideal';
+    let severity = 'none';
+    let amendmentKind = null;
+
+    // Generic pH bands (7.0 is neutral; most plants prefer 6.0–7.0)
+    if (ph < 5.5) { verdict = 'low'; severity = ph < 4.5 ? 'high' : 'medium'; amendmentKind = 'lime'; }
+    else if (ph > 7.5) { verdict = 'high'; severity = ph > 8.5 ? 'high' : 'medium'; amendmentKind = 'sulphur'; }
+
+    const recommendedAmendment = amendmentKind ? { kind: amendmentKind } : null;
+
+    // Use Gemini for a human-readable rationale if available
+    let rationale = verdict === 'ideal'
+      ? `pH ${ph} is within the healthy range for most plants.`
+      : `pH ${ph} is ${verdict === 'low' ? 'too acidic' : 'too alkaline'}${plant.species ? ` for ${plant.species}` : ''}.`;
+
+    try {
+      const prompt = `A plant${plant.species ? ` (${plant.species})` : ''} has a soil pH of ${ph}. In one sentence, explain what this means for the plant and what amendment to use. Be concise and practical.`;
+      const result = await geminiWithRetry({ contents: [{ parts: [{ text: prompt }] }] });
+      const text = result.response.candidates[0].content.parts[0].text.trim();
+      if (text) rationale = text;
+    } catch { /* fallback to heuristic */ }
+
+    res.status(200).json({ verdict, severity, ph, recommendedAmendment, rationale });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -4645,3 +4645,121 @@ describe('GET /propagation/stats', () => {
     expect(res.body.successRateBySpecies).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Soil health log routes (#304)
+// ---------------------------------------------------------------------------
+
+describe('POST /plants/:id/soil-tests', () => {
+  beforeEach(() => {
+    store[plantPath('sp1')] = { name: 'Basil', species: 'Ocimum basilicum', health: 'Good' };
+  });
+
+  it('creates a soil test with pH', async () => {
+    const res = await request(app).post('/plants/sp1/soil-tests')
+      .set('Authorization', authHeader())
+      .send({ source: 'strip', ph: 6.5, notes: 'Spring test' });
+    expect(res.status).toBe(201);
+    expect(res.body.ph).toBe(6.5);
+    expect(res.body.source).toBe('strip');
+  });
+
+  it('returns 400 for invalid source', async () => {
+    const res = await request(app).post('/plants/sp1/soil-tests')
+      .set('Authorization', authHeader())
+      .send({ source: 'invalid' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown plant', async () => {
+    const res = await request(app).post('/plants/nope/soil-tests')
+      .set('Authorization', authHeader())
+      .send({ ph: 7 });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /plants/:id/soil-tests', () => {
+  it('returns empty array when no tests exist', async () => {
+    store[plantPath('sp2')] = { name: 'Fern', health: 'Good' };
+    const res = await request(app).get('/plants/sp2/soil-tests').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(0);
+  });
+});
+
+describe('DELETE /plants/:id/soil-tests/:testId', () => {
+  it('deletes an existing soil test', async () => {
+    store[plantPath('sp3')] = { name: 'Mint', health: 'Good' };
+    const soilTestPath = `users/${USER_SUB}/plants/sp3/soilTests/t1`;
+    store[soilTestPath] = { ph: 6.0, source: 'strip', recordedAt: new Date().toISOString() };
+    const res = await request(app).delete('/plants/sp3/soil-tests/t1').set('Authorization', authHeader());
+    expect(res.status).toBe(204);
+    expect(store[soilTestPath]).toBeUndefined();
+  });
+});
+
+describe('POST /plants/:id/amendments', () => {
+  beforeEach(() => {
+    store[plantPath('am1')] = { name: 'Rose', health: 'Good' };
+  });
+
+  it('creates an amendment', async () => {
+    const res = await request(app).post('/plants/am1/amendments')
+      .set('Authorization', authHeader())
+      .send({ kind: 'lime', qty: 20, qtyUnit: 'g', notes: 'To raise pH' });
+    expect(res.status).toBe(201);
+    expect(res.body.kind).toBe('lime');
+    expect(res.body.qty).toBe(20);
+  });
+
+  it('returns 400 for missing kind', async () => {
+    const res = await request(app).post('/plants/am1/amendments')
+      .set('Authorization', authHeader())
+      .send({ qty: 10 });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid kind', async () => {
+    const res = await request(app).post('/plants/am1/amendments')
+      .set('Authorization', authHeader())
+      .send({ kind: 'magic-dust' });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /plants/:id/substrate-changes', () => {
+  beforeEach(() => {
+    store[plantPath('sc1')] = { name: 'Tomato', health: 'Good' };
+  });
+
+  it('creates a substrate change', async () => {
+    const res = await request(app).post('/plants/sc1/substrate-changes')
+      .set('Authorization', authHeader())
+      .send({ newSubstrate: 'Perlite/peat mix', ratio: '50/50', reason: 'repot' });
+    expect(res.status).toBe(201);
+    expect(res.body.newSubstrate).toBe('Perlite/peat mix');
+  });
+
+  it('returns 400 when newSubstrate is missing', async () => {
+    const res = await request(app).post('/plants/sc1/substrate-changes')
+      .set('Authorization', authHeader())
+      .send({ reason: 'repot' });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /plants/:id/soil-insight', () => {
+  it('returns unknown verdict when no test data exists', async () => {
+    store[plantPath('si1')] = { name: 'Cactus', species: 'Cactaceae', health: 'Good' };
+    const res = await request(app).get('/plants/si1/soil-insight').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.verdict).toBe('unknown');
+  });
+
+  it('returns 404 for unknown plant', async () => {
+    const res = await request(app).get('/plants/nope/soil-insight').set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/__tests__/PlantModal.test.jsx
+++ b/src/__tests__/PlantModal.test.jsx
@@ -847,7 +847,7 @@ describe('PlantModal', () => {
     renderModal({ plant: existingPlant })
     expect(screen.getByRole('tablist', { name: /plant sections/i })).toBeInTheDocument()
     const tabs = screen.getAllByRole('tab')
-    expect(tabs.map((t) => t.textContent)).toEqual(['Plant', 'Watering', 'Care', 'Growth', 'Journal', 'Health'])
+    expect(tabs.map((t) => t.textContent)).toEqual(['Plant', 'Watering', 'Care', 'Growth', 'Journal', 'Soil', 'Health'])
   })
 
   it('marks the active tab with aria-selected="true"', () => {
@@ -879,7 +879,7 @@ describe('PlantModal', () => {
   it('wraps to the first tab when ArrowRight is pressed on the last tab', () => {
     renderModal({ plant: existingPlant })
     fireEvent.click(screen.getByText('Health'))
-    const healthTab = screen.getAllByRole('tab')[5]
+    const healthTab = screen.getAllByRole('tab')[6]
     fireEvent.keyDown(healthTab, { key: 'ArrowRight' })
     expect(screen.getAllByRole('tab')[0]).toHaveAttribute('aria-selected', 'true')
   })
@@ -897,8 +897,8 @@ describe('PlantModal', () => {
     fireEvent.click(screen.getByText('Watering'))
     const wateringTab = screen.getAllByRole('tab')[1]
     fireEvent.keyDown(wateringTab, { key: 'End' })
-    expect(screen.getAllByRole('tab')[5]).toHaveAttribute('aria-selected', 'true')
-    fireEvent.keyDown(screen.getAllByRole('tab')[5], { key: 'Home' })
+    expect(screen.getAllByRole('tab')[6]).toHaveAttribute('aria-selected', 'true')
+    fireEvent.keyDown(screen.getAllByRole('tab')[6], { key: 'Home' })
     expect(screen.getAllByRole('tab')[0]).toHaveAttribute('aria-selected', 'true')
   })
 })

--- a/src/__tests__/SoilTab.test.jsx
+++ b/src/__tests__/SoilTab.test.jsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../api/plants.js', () => ({
+  soilApi: {
+    listTests: vi.fn().mockResolvedValue([]),
+    createTest: vi.fn(),
+    deleteTest: vi.fn(),
+    listAmendments: vi.fn().mockResolvedValue([]),
+    createAmendment: vi.fn(),
+    deleteAmendment: vi.fn(),
+    insight: vi.fn().mockResolvedValue({ verdict: 'unknown' }),
+  },
+}))
+
+import SoilTab from '../components/SoilTab.jsx'
+import { soilApi } from '../api/plants.js'
+
+describe('SoilTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    soilApi.listTests.mockResolvedValue([])
+    soilApi.listAmendments.mockResolvedValue([])
+    soilApi.insight.mockResolvedValue({ verdict: 'unknown' })
+  })
+
+  it('renders the log soil test form', async () => {
+    render(<SoilTab plantId="p1" />)
+    await waitFor(() => expect(screen.getByText('Log soil test')).toBeInTheDocument())
+  })
+
+  it('renders the log amendment form', async () => {
+    render(<SoilTab plantId="p1" />)
+    await waitFor(() => expect(screen.getByText('Log amendment')).toBeInTheDocument())
+  })
+
+  it('shows empty state when no tests or amendments', async () => {
+    render(<SoilTab plantId="p1" />)
+    await waitFor(() => expect(screen.getByText(/No soil data yet/i)).toBeInTheDocument())
+  })
+
+  it('calls createTest and adds entry when form is submitted', async () => {
+    const newTest = { id: 't1', ph: 6.5, source: 'strip', recordedAt: '2026-04-01T00:00:00.000Z', notes: null }
+    soilApi.createTest.mockResolvedValue(newTest)
+    render(<SoilTab plantId="p1" />)
+    await waitFor(() => screen.getByText('Log soil test'))
+    const phInput = screen.getByPlaceholderText('e.g. 6.5')
+    fireEvent.change(phInput, { target: { value: '6.5' } })
+    fireEvent.click(screen.getByText('Add test'))
+    await waitFor(() => expect(soilApi.createTest).toHaveBeenCalledWith('p1', expect.objectContaining({ ph: 6.5 })))
+  })
+
+  it('renders existing soil tests', async () => {
+    soilApi.listTests.mockResolvedValue([
+      { id: 't1', ph: 7.2, source: 'probe', recordedAt: '2026-03-01T00:00:00.000Z', notes: 'Spring' },
+    ])
+    render(<SoilTab plantId="p1" />)
+    await waitFor(() => expect(screen.getByText('pH 7.2')).toBeInTheDocument())
+    expect(screen.getByText('Spring')).toBeInTheDocument()
+  })
+
+  it('renders existing amendments', async () => {
+    soilApi.listAmendments.mockResolvedValue([
+      { id: 'a1', kind: 'lime', qty: 20, qtyUnit: 'g', appliedAt: '2026-03-15T00:00:00.000Z', notes: 'Raise pH' },
+    ])
+    render(<SoilTab plantId="p1" />)
+    await waitFor(() => expect(screen.getByText('Raise pH')).toBeInTheDocument())
+    // "Lime" badge appears in amendment history (multiple Lime elements exist — dropdown + badge)
+    expect(screen.getAllByText('Lime').length).toBeGreaterThan(0)
+  })
+
+  it('calls deleteTest when trash button is clicked', async () => {
+    soilApi.listTests.mockResolvedValue([
+      { id: 't1', ph: 6, source: 'strip', recordedAt: '2026-03-01T00:00:00.000Z', notes: null },
+    ])
+    soilApi.deleteTest.mockResolvedValue(null)
+    render(<SoilTab plantId="p1" />)
+    // ph=6 renders as "pH 6"
+    await waitFor(() => screen.getByText('pH 6'))
+    const deleteBtn = screen.getByLabelText('Delete test')
+    fireEvent.click(deleteBtn)
+    await waitFor(() => expect(soilApi.deleteTest).toHaveBeenCalledWith('p1', 't1'))
+  })
+})

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -242,6 +242,18 @@ export const propagationApi = {
   stats: () => request('/propagation/stats'),
 }
 
+export const soilApi = {
+  listTests: (plantId) => request(`/plants/${plantId}/soil-tests`),
+  createTest: (plantId, data) => request(`/plants/${plantId}/soil-tests`, { method: 'POST', body: JSON.stringify(data) }),
+  deleteTest: (plantId, testId) => request(`/plants/${plantId}/soil-tests/${testId}`, { method: 'DELETE' }),
+  listAmendments: (plantId) => request(`/plants/${plantId}/amendments`),
+  createAmendment: (plantId, data) => request(`/plants/${plantId}/amendments`, { method: 'POST', body: JSON.stringify(data) }),
+  deleteAmendment: (plantId, amendmentId) => request(`/plants/${plantId}/amendments/${amendmentId}`, { method: 'DELETE' }),
+  listSubstrateChanges: (plantId) => request(`/plants/${plantId}/substrate-changes`),
+  createSubstrateChange: (plantId, data) => request(`/plants/${plantId}/substrate-changes`, { method: 'POST', body: JSON.stringify(data) }),
+  insight: (plantId) => request(`/plants/${plantId}/soil-insight`),
+}
+
 export const accountApi = {
   deleteAccount: () => request('/account', { method: 'DELETE' }),
   exportData: () => request('/account/export'),

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -3,6 +3,7 @@ import { Modal, Button, Form, Badge, Spinner, Row, Col, Pagination, Accordion } 
 import ImageAnalyser from './ImageAnalyser.jsx'
 import PlantQRTag from './PlantQRTag.jsx'
 import WateringSheet from './WateringSheet.jsx'
+import SoilTab from './SoilTab.jsx'
 import { imagesApi, recommendApi, plantsApi, analyseApi, measurementsApi, phenologyApi, journalApi, harvestApi, incidentApi } from '../api/plants.js'
 import Chart from 'react-apexcharts'
 import { getWateringStatus, getAdjustedWaterAmount, isOutdoor, getMoistureDisplay } from '../utils/watering.js'
@@ -533,6 +534,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       { id: 'care', label: 'Care' },
       { id: 'growth', label: 'Growth' },
       { id: 'journal', label: 'Journal' },
+      ...(isEditing ? [{ id: 'soil', label: 'Soil' }] : []),
       ...(isEdiblePlant ? [{ id: 'harvest', label: 'Harvest' }] : []),
       ...(isEditing ? [{ id: 'health', label: 'Health' }] : []),
     ],
@@ -1876,6 +1878,13 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
               No journal entries yet. Start recording observations, moves, and milestones for this plant.
             </p>
           )}
+        </Modal.Body>
+      )}
+
+      {/* ── Soil tab ─────────────────────────────────────────────────────── */}
+      {isEditing && activeTab === 'soil' && (
+        <Modal.Body role="tabpanel" id="plant-tabpanel-soil" aria-labelledby="plant-tab-soil">
+          <SoilTab plantId={plant?.id} />
         </Modal.Body>
       )}
 

--- a/src/components/SoilTab.jsx
+++ b/src/components/SoilTab.jsx
@@ -1,0 +1,252 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Button, Badge, Form, Row, Col, Spinner } from 'react-bootstrap'
+import { soilApi } from '../api/plants.js'
+
+const SOURCE_LABEL = { strip: 'Test strip', probe: 'Probe', lab: 'Lab report', visual: 'Visual' }
+const AMENDMENT_KINDS = ['compost', 'lime', 'sulphur', 'gypsum', 'biochar', 'fertiliser', 'other']
+const AMENDMENT_LABEL = { compost: 'Compost', lime: 'Lime', sulphur: 'Sulphur', gypsum: 'Gypsum', biochar: 'Biochar', fertiliser: 'Fertiliser', other: 'Other' }
+
+function phColor(ph) {
+  if (ph == null) return 'secondary'
+  if (ph < 5.5) return 'danger'
+  if (ph > 7.5) return 'warning'
+  return 'success'
+}
+
+function InsightBanner({ plantId }) {
+  const [insight, setInsight] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    soilApi.insight(plantId)
+      .then(setInsight)
+      .catch(() => setInsight(null))
+      .finally(() => setLoading(false))
+  }, [plantId])
+
+  if (loading) return null
+  if (!insight || insight.verdict === 'unknown') return null
+
+  const variant = insight.verdict === 'ideal' ? 'success' : insight.severity === 'high' ? 'danger' : 'warning'
+  return (
+    <div className={`alert alert-${variant} py-2 mb-3`} role="status">
+      <svg className="sa-icon me-1" style={{ width: 14, height: 14 }}><use href="/icons/sprite.svg#info" /></svg>
+      {insight.rationale}
+      {insight.recommendedAmendment && (
+        <span className="ms-2">
+          <Badge bg={variant} className="fs-xs">Apply {AMENDMENT_LABEL[insight.recommendedAmendment.kind] || insight.recommendedAmendment.kind}</Badge>
+        </span>
+      )}
+    </div>
+  )
+}
+
+function SoilTestForm({ plantId, onAdded }) {
+  const [form, setForm] = useState({ source: 'strip', ph: '', notes: '' })
+  const [saving, setSaving] = useState(false)
+  const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
+
+  const handleSave = async () => {
+    if (!form.ph && !form.notes) return
+    setSaving(true)
+    try {
+      const data = { source: form.source, notes: form.notes || null }
+      if (form.ph !== '') data.ph = parseFloat(form.ph)
+      const created = await soilApi.createTest(plantId, data)
+      onAdded(created)
+      setForm({ source: 'strip', ph: '', notes: '' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="border rounded p-3 mb-3 bg-light bg-opacity-25">
+      <h6 className="fw-500 mb-2">Log soil test</h6>
+      <Row className="g-2 mb-2">
+        <Col xs={6}>
+          <Form.Label className="tx-muted" style={{ fontSize: 12 }}>Source</Form.Label>
+          <Form.Select size="sm" value={form.source} onChange={e => set('source', e.target.value)}>
+            {Object.entries(SOURCE_LABEL).map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+          </Form.Select>
+        </Col>
+        <Col xs={6}>
+          <Form.Label className="tx-muted" style={{ fontSize: 12 }}>pH</Form.Label>
+          <Form.Control size="sm" type="number" min="0" max="14" step="0.1" placeholder="e.g. 6.5" value={form.ph} onChange={e => set('ph', e.target.value)} />
+        </Col>
+      </Row>
+      <Row className="g-2 mb-2">
+        <Col xs={12}>
+          <Form.Control size="sm" placeholder="Notes (optional)" value={form.notes} onChange={e => set('notes', e.target.value)} />
+        </Col>
+      </Row>
+      <Button size="sm" variant="outline-primary" onClick={handleSave} disabled={saving || (!form.ph && !form.notes)}>
+        {saving ? <Spinner size="sm" className="me-1" /> : null}
+        Add test
+      </Button>
+    </div>
+  )
+}
+
+function AmendmentForm({ plantId, onAdded }) {
+  const [form, setForm] = useState({ kind: 'compost', qty: '', qtyUnit: 'g', notes: '' })
+  const [saving, setSaving] = useState(false)
+  const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
+
+  const handleSave = async () => {
+    setSaving(true)
+    try {
+      const data = { kind: form.kind, notes: form.notes || null }
+      if (form.qty) { data.qty = parseFloat(form.qty); data.qtyUnit = form.qtyUnit }
+      const created = await soilApi.createAmendment(plantId, data)
+      onAdded(created)
+      setForm({ kind: 'compost', qty: '', qtyUnit: 'g', notes: '' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="border rounded p-3 mb-3 bg-light bg-opacity-25">
+      <h6 className="fw-500 mb-2">Log amendment</h6>
+      <Row className="g-2 mb-2">
+        <Col xs={6}>
+          <Form.Label className="tx-muted" style={{ fontSize: 12 }}>Type</Form.Label>
+          <Form.Select size="sm" value={form.kind} onChange={e => set('kind', e.target.value)}>
+            {AMENDMENT_KINDS.map(k => <option key={k} value={k}>{AMENDMENT_LABEL[k]}</option>)}
+          </Form.Select>
+        </Col>
+        <Col xs={3}>
+          <Form.Label className="tx-muted" style={{ fontSize: 12 }}>Qty</Form.Label>
+          <Form.Control size="sm" type="number" min="0" placeholder="e.g. 20" value={form.qty} onChange={e => set('qty', e.target.value)} />
+        </Col>
+        <Col xs={3}>
+          <Form.Label className="tx-muted" style={{ fontSize: 12 }}>Unit</Form.Label>
+          <Form.Select size="sm" value={form.qtyUnit} onChange={e => set('qtyUnit', e.target.value)}>
+            {['g', 'kg', 'ml', 'L', 'oz', 'lb'].map(u => <option key={u}>{u}</option>)}
+          </Form.Select>
+        </Col>
+      </Row>
+      <Row className="g-2 mb-2">
+        <Col xs={12}>
+          <Form.Control size="sm" placeholder="Notes (optional)" value={form.notes} onChange={e => set('notes', e.target.value)} />
+        </Col>
+      </Row>
+      <Button size="sm" variant="outline-success" onClick={handleSave} disabled={saving}>
+        {saving ? <Spinner size="sm" className="me-1" /> : null}
+        Add amendment
+      </Button>
+    </div>
+  )
+}
+
+export default function SoilTab({ plantId }) {
+  const [tests, setTests] = useState([])
+  const [amendments, setAmendments] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const load = useCallback(async () => {
+    if (!plantId) return
+    setLoading(true)
+    try {
+      const [t, a] = await Promise.all([soilApi.listTests(plantId), soilApi.listAmendments(plantId)])
+      setTests(t)
+      setAmendments(a)
+      setError(null)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [plantId])
+
+  useEffect(() => { load() }, [load])
+
+  const handleTestAdded = (test) => setTests(prev => [test, ...prev])
+  const handleAmendmentAdded = (amendment) => setAmendments(prev => [amendment, ...prev])
+
+  const handleDeleteTest = async (id) => {
+    try {
+      await soilApi.deleteTest(plantId, id)
+      setTests(prev => prev.filter(t => t.id !== id))
+    } catch (e) {
+      setError(e.message)
+    }
+  }
+
+  const handleDeleteAmendment = async (id) => {
+    try {
+      await soilApi.deleteAmendment(plantId, id)
+      setAmendments(prev => prev.filter(a => a.id !== id))
+    } catch (e) {
+      setError(e.message)
+    }
+  }
+
+  if (loading) return <div className="text-center py-4 text-muted"><Spinner size="sm" className="me-2" />Loading…</div>
+
+  return (
+    <div>
+      {error && <div className="alert alert-danger py-2 mb-3">{error}</div>}
+
+      {tests.length > 0 && <InsightBanner plantId={plantId} />}
+
+      <SoilTestForm plantId={plantId} onAdded={handleTestAdded} />
+
+      {tests.length > 0 && (
+        <div className="mb-4">
+          <h6 className="fw-500 mb-2">Test history</h6>
+          {tests.map(t => (
+            <div key={t.id} className="d-flex align-items-center gap-2 py-1 border-bottom">
+              <Badge bg={phColor(t.ph)} className="flex-shrink-0">
+                {t.ph != null ? `pH ${t.ph}` : 'No pH'}
+              </Badge>
+              <span className="tx-muted" style={{ fontSize: 12 }}>{SOURCE_LABEL[t.source] || t.source}</span>
+              <span className="tx-muted flex-grow-1" style={{ fontSize: 12 }}>{t.notes || ''}</span>
+              <span className="tx-muted" style={{ fontSize: 11 }}>{t.recordedAt?.slice(0, 10)}</span>
+              <button
+                type="button"
+                className="btn btn-link btn-sm p-0 text-danger"
+                onClick={() => handleDeleteTest(t.id)}
+                aria-label="Delete test"
+              >
+                <svg className="sa-icon" style={{ width: 13, height: 13 }}><use href="/icons/sprite.svg#trash-2" /></svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <AmendmentForm plantId={plantId} onAdded={handleAmendmentAdded} />
+
+      {amendments.length > 0 && (
+        <div>
+          <h6 className="fw-500 mb-2">Amendment history</h6>
+          {amendments.map(a => (
+            <div key={a.id} className="d-flex align-items-center gap-2 py-1 border-bottom">
+              <Badge bg="info" className="flex-shrink-0 text-capitalize">{AMENDMENT_LABEL[a.kind] || a.kind}</Badge>
+              {a.qty && <span className="tx-muted" style={{ fontSize: 12 }}>{a.qty} {a.qtyUnit}</span>}
+              <span className="tx-muted flex-grow-1" style={{ fontSize: 12 }}>{a.notes || ''}</span>
+              <span className="tx-muted" style={{ fontSize: 11 }}>{a.appliedAt?.slice(0, 10)}</span>
+              <button
+                type="button"
+                className="btn btn-link btn-sm p-0 text-danger"
+                onClick={() => handleDeleteAmendment(a.id)}
+                aria-label="Delete amendment"
+              >
+                <svg className="sa-icon" style={{ width: 13, height: 13 }}><use href="/icons/sprite.svg#trash-2" /></svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {tests.length === 0 && amendments.length === 0 && (
+        <p className="tx-muted text-center py-3">
+          No soil data yet — log your first test above.
+        </p>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Closes #304

- **3 new route groups** per plant: `soil-tests`, `amendments`, `substrate-changes` with full CRUD
- **`GET /plants/:id/soil-insight`** — rule-based pH verdict (low/ideal/high with severity) plus a Gemini-generated rationale sentence
- **`SoilTab` component** — log soil tests (pH, source, notes), log amendments (kind, qty), view history with delete, and insight banner
- **PlantModal "Soil" tab** — visible when editing an existing plant

## Test plan
- [ ] 9 new backend tests: POST/GET/DELETE soil-tests, POST amendments (happy + 400s), POST substrate-changes, GET soil-insight (unknown + 404)
- [ ] 7 frontend `SoilTab` tests: renders, empty state, form submit, existing tests list, amendments list, delete
- [ ] All 410 backend tests pass; all 7 SoilTab tests pass

https://claude.ai/code/session_01FBBo2bV6WtYY69GjChB33d

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBBo2bV6WtYY69GjChB33d)_