### PR TITLE
fix(sidebar): mobile drawer, active highlight, item styling, /today default

### DIFF
--- a/src/assets/sass/app/_mobile.scss
+++ b/src/assets/sass/app/_mobile.scss
@@ -2,6 +2,35 @@
    Targets ≤ 480 px (xs) and ≤ 575.98 px (below `sm`) so the app stays
    usable on 320–414 px screens. Resolves issue #220. */
 
+/* Sidebar on phones (below `md`): slide-in drawer.
+   Smart Admin's own rule kicks in at ≤ 991.98 px, but the grid layout
+   here leaves it occupying a fixed column on narrow viewports. Force
+   a drawer on phones and rely on the Topbar hamburger to toggle
+   `.app-mobile-menu-open` on <html>. */
+@media (max-width: 767.98px) {
+  .app-wrap {
+    grid-template-columns: 0 auto !important;
+    grid-template-areas: "sidebar header" "sidebar main" "sidebar main" !important;
+  }
+
+  .app-sidebar {
+    position: fixed !important;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: min(85vw, 18rem);
+    z-index: 1050;
+    transform: translate3d(-100%, 0, 0) !important;
+    transition: transform 0.25s ease;
+    overflow-y: auto;
+    box-shadow: 2px 0 12px rgba(0, 0, 0, 0.15);
+  }
+
+  html.app-mobile-menu-open .app-sidebar {
+    transform: translate3d(0, 0, 0) !important;
+  }
+}
+
 /* Plant modal tabs: horizontally scroll instead of overflowing the modal,
    keep visible scroll snap points and ≥ 44 px touch targets on phones. */
 .modal .nav-tabs {

--- a/src/assets/sass/app/_plant-tracker.scss
+++ b/src/assets/sass/app/_plant-tracker.scss
@@ -192,21 +192,50 @@
   gap: 0.25rem;
 }
 
-/* Sign-out lives in the sidebar's nav-menu but is a <button> (performs an
-   action) rather than a <NavLink>. Mirror the surrounding anchor styles so
-   it looks identical while staying keyboard- and screen-reader-correct. */
+/* Sidebar <button> items (Sign out, Help, What's new, Take a tour) live in
+   the nav-menu alongside NavLink <a>s. Mirror the full anchor layout
+   (flex row, gap, padding, icon sizing) so icons and labels align with
+   the primary nav items above them. */
 .nav-menu li > .nav-link-btn {
-  line-height: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem; //12px — matches .primary-nav li > a
+  padding: 0.5rem 0;
   padding-inline-start: calc(1.9rem + 2px);
+  line-height: 2;
+  font-size: 0.9375rem; //15px — matches .primary-nav li > a
+  font-weight: var(--app-nav-parent-fw, 600);
   border-radius: 0.625rem;
-  font-size: 0.85rem;
-  font-weight: 400;
   cursor: pointer;
-  color: inherit;
+  color: var(--app-nav-link-color);
+  text-decoration: none;
+  width: 100%;
+  background: transparent;
+  border: 0;
+
+  .sa-icon {
+    width: var(--app-nav-svgicon-size);
+    height: var(--app-nav-svgicon-size);
+    flex-shrink: 0;
+  }
 
   &:hover {
     background-color: var(--app-nav-item-hover-bg);
+    color: var(--app-nav-link-hover-color);
   }
+}
+
+/* React Router's <NavLink> applies `active` to the <a>, but Smart Admin's
+   own active styles target `li.active`. Bridge the two so the current
+   route reads as highlighted in the sidebar. */
+.app-sidebar .nav-menu li a.active {
+  color: var(--app-nav-link-active-color);
+  background-color: var(--app-nav-item-active-bg);
+}
+
+.set-nav-dark .app-sidebar .nav-menu li a.active {
+  color: #fff !important;
+  background: rgba(255, 255, 255, 0.12) !important;
 }
 
 /* Skeleton loader shimmer animation */

--- a/src/layouts/AuthLayout.jsx
+++ b/src/layouts/AuthLayout.jsx
@@ -14,7 +14,7 @@ export default function AuthLayout() {
     )
   }
 
-  if (isAuthenticated) return <Navigate to="/" replace />
+  if (isAuthenticated) return <Navigate to="/today" replace />
 
   return <Outlet />
 }


### PR DESCRIPTION
## Summary

Four sidebar/nav regressions visible on the first post-deploy-freeze production push.

1. **Mobile sidebar hogs ~40% of narrow viewports.** Smart Admin's own ≤991.98px rule should turn it into a drawer but the grid cascade keeps it in-flow. Added an explicit ≤767.98px rule in `_mobile.scss`: `position: fixed`, translated off-screen, revealed by `.app-mobile-menu-open` on `<html>` (which the Topbar hamburger already toggles).
2. **Sidebar button items** (What's new, Take a tour, Help, Sign Out) render icons stacked above labels. `.nav-link-btn` lacked the flex layout that Smart Admin applies to `.nav-menu li > a`. Mirrored the anchor rules so icon + label sit on one row.
3. **Active-route highlight missing.** React Router's `<NavLink>` puts `active` on the `<a>`, but Smart Admin's styles target `li.active`. Added `.app-sidebar .nav-menu li a.active` selectors (light + `set-nav-dark` variants).
4. **Post-login lands on `/today`** (daily care tasks) instead of `/` (Dashboard). Dashboard remains at `/` for direct URL visits.

## Test plan

- [ ] Narrow the browser below 768px → sidebar hidden; hamburger in topbar opens it as a drawer with backdrop
- [ ] Widen above 768px → sidebar back as a column
- [ ] Navigate between pages → current page reads as highlighted in the sidebar
- [ ] Sign-Out / Help / What's-new items line up with Today / Garden / Propagation
- [ ] Fresh login redirects to `/today`

🤖 Generated with [Claude Code](https://claude.com/claude-code)