### PR TITLE
Post-freeze audit: fix stale App test mock, document env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
-# Get this value from: terraform output -raw iap_client_id
-# after running terraform apply
+# Google OAuth 2.0 Web client ID
+# Get this value from: terraform output -raw iap_client_id (in platform-infra)
 VITE_GOOGLE_CLIENT_ID=your-iap-client-id.apps.googleusercontent.com
+
+# API Gateway URL (without trailing slash)
+VITE_API_BASE_URL=https://your-gateway.apigateway.your-project.cloud.goog
+
+# API Gateway x-api-key
+VITE_API_KEY=your-api-gateway-api-key
+
+# Optional: show the /insights page (ML care scores, anomaly detection)
+# Leave unset or set to any value other than 'true' to hide the page
+VITE_ML_INSIGHTS_ENABLED=false

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -64,9 +64,9 @@ vi.mock('react-apexcharts', () => ({
   default: () => <div data-testid="apex-chart" />,
 }))
 
-// react-joyride uses DOM APIs not available in jsdom
+// react-joyride v3 uses DOM APIs not available in jsdom (named export, no default)
 vi.mock('react-joyride', () => ({
-  default: () => null,
+  Joyride: () => null,
   STATUS: { FINISHED: 'finished', SKIPPED: 'skipped' },
 }))
 


### PR DESCRIPTION
## Summary

Post-freeze audit of everything that landed during the 3-day deploy outage. Two real fixes, rest clean.

### Fixes

1. **`src/__tests__/App.test.jsx` was failing on main** (1 of 801 frontend tests). The `react-joyride` mock still used `default: () => null`, but PR #316 switched `FeatureTour.jsx` to the v3 named import `{ Joyride, STATUS }`. Mock now exports `Joyride` as named.
2. **`.env.example` missing required env vars.** Added `VITE_API_BASE_URL`, `VITE_API_KEY` (both required — CI deploys use GH secrets but a local dev would see silent fetch failures), and the optional `VITE_ML_INSIGHTS_ENABLED` feature flag.

### Audit findings (no action needed)

- **i18n provider** — `src/main.jsx` imports `./i18n/index.js` which calls `initReactI18next()` — react-i18next reads from the global singleton, no `<I18nextProvider>` wrapper required. Verified in prod.
- **Locale coverage** — only `en` and `es` have all 8 namespaces; `fr/de/pt/ja/ar` ship with `common` + `onboarding` only. `fallbackLng: 'en'` silently fills the rest. Content debt, not a break. (And only `common`, `onboarding`, `settings` are actually used by any `useTranslation()` caller.)
- **Library imports** — `react-window@1.8.11` matches the `FixedSizeList` usage in `PlantListPanel.jsx`; `react-joyride@3` matches the `{ Joyride, STATUS }` named import in `FeatureTour.jsx`. Both correct after PR #316.
- **Routes / navigation** — all pages reachable (Privacy/Terms via footer, Scan via deep link, Propagation/Today/Garden via sidebar).
- **Risky render paths** — CommandPalette, FeatureTour, HelpDrawer, PlantQRTag have no dedicated tests but render paths look defensive (empty-state early returns, hooks unconditional, no required-provider chains beyond what MainLayout wires).

### Test plan

- [ ] `npm test` → 801/801 passing on CI
- [ ] No prod behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)