### PR TITLE
feat(#161): gate ML insights behind home_pro; runtime tier check replaces env flag

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -2353,7 +2353,7 @@ function isCacheValid(cache, key) {
   return age < ML_CACHE_TTL_MS;
 }
 
-app.get('/plants/:id/watering-pattern', requireUser, async (req, res) => {
+app.get('/plants/:id/watering-pattern', requireUser, requireTier('home_pro'), async (req, res) => {
   try {
     const ref = userPlants(req.userId).doc(req.params.id);
     const doc = await ref.get();
@@ -2409,7 +2409,7 @@ app.get('/plants/:id/watering-pattern', requireUser, async (req, res) => {
 
 const RECOMMENDATION_CACHE_TTL_MS = 48 * 60 * 60 * 1000; // 48 hours
 
-app.get('/plants/:id/watering-recommendation', requireUser, async (req, res) => {
+app.get('/plants/:id/watering-recommendation', requireUser, requireTier('home_pro'), async (req, res) => {
   try {
     const ref = userPlants(req.userId).doc(req.params.id);
     const doc = await ref.get();
@@ -2679,7 +2679,7 @@ function computeSeasonalAdjustment(plant, hemisphere) {
   };
 }
 
-app.get('/plants/:id/seasonal-adjustment', requireUser, async (req, res) => {
+app.get('/plants/:id/seasonal-adjustment', requireUser, requireTier('home_pro'), async (req, res) => {
   try {
     const ref = userPlants(req.userId).doc(req.params.id);
     const doc = await ref.get();
@@ -3112,7 +3112,7 @@ app.post('/ml/anomaly-scan', async (req, res) => {
 });
 
 // User-facing anomaly status
-app.get('/plants/:id/anomaly', requireUser, async (req, res) => {
+app.get('/plants/:id/anomaly', requireUser, requireTier('home_pro'), async (req, res) => {
   try {
     const doc = await userPlants(req.userId).doc(req.params.id).get();
     if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
@@ -2583,6 +2583,42 @@ describe('Billing — requireTier on /plants/:id/health-prediction', () => {
     expect(res.body.requiredTier).toBe('home_pro');
     expect(res.body.currentTier).toBe('free');
     delete process.env.BILLING_ENABLED;
+  });
+});
+
+describe('Billing — requireTier on ML insight routes (#161)', () => {
+  beforeEach(() => {
+    process.env.BILLING_ENABLED = 'true';
+    store[plantPath('p1')] = { name: 'Fern', frequencyDays: 7, lastWatered: new Date().toISOString() };
+  });
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  const mlRoutes = [
+    '/plants/p1/watering-pattern',
+    '/plants/p1/watering-recommendation',
+    '/plants/p1/seasonal-adjustment',
+    '/plants/p1/anomaly',
+  ];
+
+  for (const path of mlRoutes) {
+    it(`GET ${path} 403s free-tier with upgrade_required`, async () => {
+      const res = await request(app).get(path).set('Authorization', authHeader());
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('upgrade_required');
+      expect(res.body.requiredTier).toBe('home_pro');
+    });
+
+    it(`GET ${path} allows a home_pro user past the gate`, async () => {
+      store[`users/${USER_SUB}/subscription/current`] = { tier: 'home_pro', status: 'active' };
+      const res = await request(app).get(path).set('Authorization', authHeader());
+      expect(res.status).not.toBe(403);
+    });
+  }
+
+  it('no-ops the gate entirely when BILLING_ENABLED is unset', async () => {
+    delete process.env.BILLING_ENABLED;
+    const res = await request(app).get('/plants/p1/watering-pattern').set('Authorization', authHeader());
+    expect(res.status).not.toBe(403);
   });
 });
 

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -64,9 +64,9 @@ vi.mock('react-apexcharts', () => ({
   default: () => <div data-testid="apex-chart" />,
 }))
 
-// react-joyride uses DOM APIs not available in jsdom
+// react-joyride v3 uses DOM APIs not available in jsdom (named export, no default)
 vi.mock('react-joyride', () => ({
-  default: () => null,
+  Joyride: () => null,
   STATUS: { FINISHED: 'finished', SKIPPED: 'skipped' },
 }))
 
@@ -111,8 +111,9 @@ const samplePlant = {
 describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Skip onboarding modal so dashboard content is visible
+    // Skip onboarding + What's-new modal so dashboard content is visible
     localStorage.setItem('plant-tracker-onboarded', '1')
+    localStorage.setItem('plant-tracker-whats-new-seen', '99.0.0')
     plantsApi.list.mockResolvedValue({ plants: [], hasMore: false, nextCursor: null })
     floorsApi.get.mockResolvedValue({ floors: [{ id: 'ground', name: 'Ground Floor', order: 0, type: 'interior' }] })
     useAuth.mockReturnValue({

--- a/src/layouts/components/SidebarMenu.jsx
+++ b/src/layouts/components/SidebarMenu.jsx
@@ -1,8 +1,10 @@
 import { NavLink } from 'react-router'
 import { useTranslation } from 'react-i18next'
+import { useSubscription } from '../../context/SubscriptionContext.jsx'
 
 export default function SidebarMenu({ items, badges = {} }) {
   const { t } = useTranslation('common')
+  const { canAccess, billingEnabled } = useSubscription()
   return (
     <ul className="nav-menu d-flex flex-column">
       {items.map((item) => {
@@ -12,6 +14,9 @@ export default function SidebarMenu({ items, badges = {} }) {
           )
         }
         const badge = badges[item.key]
+        // Only show the PRO indicator once billing is actually live — during the
+        // dark-ship phase everyone has access so the badge would be misleading.
+        const locked = billingEnabled && item.requiresTier && !canAccess(item.requiresTier)
         return (
           <li key={item.key} data-tour={`nav-${item.key}`}>
             <NavLink
@@ -27,6 +32,9 @@ export default function SidebarMenu({ items, badges = {} }) {
               <span className="nav-link-text">{t(`nav.${item.key}`, item.label)}</span>
               {badge > 0 && (
                 <span className="badge bg-primary rounded-pill ms-auto" aria-label={`${badge} pending`}>{badge}</span>
+              )}
+              {locked && (
+                <span className="badge bg-warning text-dark ms-auto" aria-label="Pro feature">PRO</span>
               )}
             </NavLink>
           </li>

--- a/src/layouts/components/menuData.js
+++ b/src/layouts/components/menuData.js
@@ -1,5 +1,3 @@
-const mlInsightsEnabled = import.meta.env.VITE_ML_INSIGHTS_ENABLED === 'true'
-
 export const menuItems = [
   { key: 'overview', label: 'Overview', isTitle: true },
   { key: 'today', label: 'Today', icon: '/icons/sprite.svg#check-circle', url: '/today' },
@@ -8,7 +6,7 @@ export const menuItems = [
   { key: 'analytics', label: 'Analytics', icon: '/icons/sprite.svg#bar-chart-2', url: '/analytics' },
   { key: 'calendar', label: 'Care Calendar', icon: '/icons/sprite.svg#calendar', url: '/calendar' },
   { key: 'forecast', label: 'Forecast', icon: '/icons/sprite.svg#cloud', url: '/forecast' },
-  ...(mlInsightsEnabled ? [{ key: 'insights', label: 'Insights', icon: '/icons/sprite.svg#zap', url: '/insights' }] : []),
+  { key: 'insights', label: 'Insights', icon: '/icons/sprite.svg#zap', url: '/insights', requiresTier: 'home_pro' },
   { key: 'manage', label: 'Manage', isTitle: true },
   { key: 'bulk-upload', label: 'Bulk Upload', icon: '/icons/sprite.svg#upload', url: '/bulk-upload' },
   { key: 'settings', label: 'Settings', icon: '/icons/sprite.svg#settings', url: '/settings' },

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -19,8 +19,6 @@ const TermsPage = lazy(() => import('../pages/TermsPage.jsx'))
 const ScanPage = lazy(() => import('../pages/ScanPage.jsx'))
 const PropagationPage = lazy(() => import('../pages/PropagationPage.jsx'))
 
-const mlInsightsEnabled = import.meta.env.VITE_ML_INSIGHTS_ENABLED === 'true'
-
 export const routes = [
   { path: '/privacy', element: <Suspense fallback={null}><PrivacyPage /></Suspense> },
   { path: '/terms', element: <Suspense fallback={null}><TermsPage /></Suspense> },
@@ -41,7 +39,7 @@ export const routes = [
       { path: 'analytics', element: <AnalyticsPage /> },
       { path: 'calendar', element: <CalendarPage /> },
       { path: 'forecast', element: <ForecastPage /> },
-      ...(mlInsightsEnabled ? [{ path: 'insights', element: <InsightsPage /> }] : []),
+      { path: 'insights', element: <InsightsPage /> },
       { path: 'bulk-upload', element: <BulkUploadPage /> },
       { path: 'settings', element: <Navigate to="/settings/property" replace /> },
       { path: 'settings/billing', element: <BillingPage /> },


### PR DESCRIPTION
Closes #161 (first increment — hard gate). Deferred: teaser-200 responses for free tier (see issue technical notes).

## Context

The ML insight endpoints are monetisation's primary differentiator. With billing activation imminent, we need the backend gates in place so that flipping `BILLING_ENABLED=true` immediately separates free from home_pro without a frontend redeploy. Until the flip, `tierGate` middleware is a no-op and behaviour is unchanged.

## Backend

Added `requireTier('home_pro')` to four previously ungated ML routes:

- `GET /plants/:id/watering-pattern`
- `GET /plants/:id/watering-recommendation`
- `GET /plants/:id/seasonal-adjustment`
- `GET /plants/:id/anomaly`

Already gated (unchanged): `/ml/care-scores`, `/plants/:id/health-prediction`.
Deliberately ungated (free-tier per issue spec): `/plants/:id/care-score` — the basic per-plant badge stays free.

## Frontend

- Drop `VITE_ML_INSIGHTS_ENABLED` env flag in `routes/index.jsx` and `menuData.js`. `/insights` is always mounted; `InsightsPage` already renders `<UpgradePrompt feature="home_pro">` (which is a no-op when `billingEnabled=false`).
- Tag the Insights sidebar item with `requiresTier: 'home_pro'` and have `SidebarMenu` render a PRO badge when `billingEnabled && !canAccess(tier)`. Badge stays hidden during the dark-ship phase to avoid misleading free users while everyone still has access.

## Tests

Added 9 assertions in `api/plants/index.test.js`:
- Each of the 4 routes returns 403 + `upgrade_required` for free tier
- Each lets home_pro through
- Stays open entirely when `BILLING_ENABLED` is unset

Also pulled in the `react-joyride` v3 named-export mock fix in `App.test.jsx` (duplicate of PR #318; harmless if both merge).

## Notes

- Teaser-response UX (200 with `{ preview: {...}, upgrade_required: true }`) deferred to a follow-up.
- `App.test.jsx > renders the dashboard when authenticated` flakes in the full suite with a modal-open body state — reproduces on clean main, so not a regression from this PR.

## Test plan

- [ ] Backend CI green (new ML-gate tests pass)
- [ ] Frontend CI green (flaky test documented above; should pass as it does on current main)
- [ ] With `BILLING_ENABLED=true` and a free-tier user, the 4 routes return 403
- [ ] After Stripe activation, free users see a PRO badge on the Insights sidebar entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)