### PR TITLE
fix(settings): guard API calls in guest mode; expand smoke to every Settings sub-tab

### DIFF
--- a/e2e/console-smoke.spec.js
+++ b/e2e/console-smoke.spec.js
@@ -33,25 +33,56 @@ const IGNORED_ERROR_PATTERNS = [
 ]
 
 const ROUTES = [
-  { path: '/today',        label: 'Today (daily tasks)' },
-  { path: '/',             label: 'Dashboard (Garden)' },
-  { path: '/propagation',  label: 'Propagation' },
-  { path: '/analytics',    label: 'Analytics' },
-  { path: '/calendar',     label: 'Care Calendar' },
-  { path: '/forecast',     label: 'Forecast' },
-  { path: '/bulk-upload',  label: 'Bulk Upload' },
-  { path: '/settings',     label: 'Settings' },
-  { path: '/pricing',      label: 'Pricing' },
+  { path: '/today',                label: 'Today (daily tasks)' },
+  { path: '/',                     label: 'Dashboard (Garden)' },
+  { path: '/propagation',          label: 'Propagation' },
+  { path: '/analytics',            label: 'Analytics' },
+  { path: '/calendar',             label: 'Care Calendar' },
+  { path: '/forecast',             label: 'Forecast' },
+  { path: '/bulk-upload',          label: 'Bulk Upload' },
+  // Settings sub-tabs — each mounts a different tab component and may
+  // trigger its own API calls. Bugs on one tab (e.g. API Keys unguarded
+  // fetch in guest mode, catching a NetworkError) won't surface if we only
+  // hit `/settings` since that redirects to `/settings/property`.
+  { path: '/settings/property',    label: 'Settings → Property' },
+  { path: '/settings/preferences', label: 'Settings → Preferences' },
+  { path: '/settings/data',        label: 'Settings → Data & export' },
+  { path: '/settings/api-keys',    label: 'Settings → API Keys' },
+  { path: '/settings/branding',    label: 'Settings → Branding' },
+  { path: '/settings/advanced',    label: 'Settings → Advanced' },
+  { path: '/settings/billing',     label: 'Settings → Billing' },
+  { path: '/pricing',              label: 'Pricing' },
 ]
 
 const PUBLIC_ROUTES = [
-  { path: '/login',   label: 'Login' },
-  { path: '/privacy', label: 'Privacy policy' },
-  { path: '/terms',   label: 'Terms of service' },
+  { path: '/login',               label: 'Login' },
+  { path: '/privacy',             label: 'Privacy policy' },
+  { path: '/terms',               label: 'Terms of service' },
+  // Param routes that hit the API on mount. The test stubs the API to 404 so
+  // we exercise the graceful "not found" render path without tripping CORS
+  // against the real gateway. See `stubApi` below.
+  { path: '/scan/invalid-code',   label: 'Scan (invalid short code)', stubApi: true },
+  { path: '/portal/invalid-tok',  label: 'Portal (invalid token)',    stubApi: true },
 ]
 
 function isIgnored(text) {
   return IGNORED_ERROR_PATTERNS.some((rx) => rx.test(text))
+}
+
+// Stub the API endpoints that /scan/:code and /portal/:token fetch on mount
+// with a 404 so we can exercise the graceful "not found" render path without
+// the test hitting the real prod gateway (CORS) or a placeholder host (DNS).
+// Selective on purpose — we don't want to also stub Google Fonts or similar.
+async function stubApiCalls(page) {
+  const stubPaths = [/\/scan\/[^/]+$/, /\/portal\/[^/]+$/]
+  await page.route((url) => {
+    if (url.host === 'localhost:4173') return false
+    return stubPaths.some((rx) => rx.test(url.pathname))
+  }, (route) => route.fulfill({
+    status: 404,
+    contentType: 'application/json',
+    body: JSON.stringify({ error: 'not_found' }),
+  }))
 }
 
 async function enterGuestMode(page) {
@@ -63,20 +94,32 @@ async function enterGuestMode(page) {
   await page.waitForURL(/\/today|\/$/, { timeout: 10_000 })
 }
 
+// Chromium logs every failed fetch (4xx/5xx) as a console.error with no URL
+// context, which is pure noise when the test is exercising a "not found" code
+// path. Widen the ignore list only for those opted-in routes.
+const NOT_FOUND_CONSOLE_NOISE = /Failed to load resource.*(404|Not Found)/i
+
 test.describe('Public routes: no console errors on load', () => {
-  for (const { path, label } of PUBLIC_ROUTES) {
+  for (const { path, label, stubApi } of PUBLIC_ROUTES) {
     test(`${label} (${path})`, async ({ page }) => {
+      if (stubApi) await stubApiCalls(page)
+      const extraIgnore = stubApi ? [NOT_FOUND_CONSOLE_NOISE] : []
       const errors = []
+      const isNoisy = (text) => isIgnored(text) || extraIgnore.some((rx) => rx.test(text))
       page.on('console', (msg) => {
-        if (msg.type() === 'error' && !isIgnored(msg.text())) errors.push(`console.error: ${msg.text()}`)
+        if (msg.type() === 'error' && !isNoisy(msg.text())) errors.push(`console.error: ${msg.text()}`)
       })
       page.on('pageerror', (err) => {
-        if (!isIgnored(err.message)) errors.push(`pageerror: ${err.message}\n${err.stack || ''}`)
+        if (!isNoisy(err.message)) errors.push(`pageerror: ${err.message}\n${err.stack || ''}`)
+      })
+      page.on('requestfailed', (req) => {
+        const url = req.url()
+        const failure = req.failure()?.errorText || 'unknown'
+        const msg = `requestfailed: ${req.method()} ${url} — ${failure}`
+        if (!isNoisy(msg)) errors.push(msg)
       })
 
       await page.goto(path, { waitUntil: 'networkidle', timeout: 20_000 })
-
-      // Give any deferred render-time errors a moment to fire.
       await page.waitForTimeout(500)
 
       expect(errors, `Unexpected browser errors on ${path}:\n${errors.join('\n\n')}`).toEqual([])

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -653,8 +653,9 @@ function DataTab({ search }) {
 }
 
 function ApiKeysTab({ search }) {
+  const { isGuest } = useAuth()
   const [keys, setKeys] = useState([])
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(!isGuest)
   const [error, setError] = useState(null)
   const [creating, setCreating] = useState(false)
   const [newKeyName, setNewKeyName] = useState('')
@@ -673,7 +674,9 @@ function ApiKeysTab({ search }) {
     }
   }, [])
 
-  useEffect(() => { loadKeys() }, [loadKeys])
+  // Guests never have API keys — skip the fetch so demo/preview modes don't
+  // produce a spurious NetworkError in the console.
+  useEffect(() => { if (!isGuest) loadKeys() }, [loadKeys, isGuest])
 
   const handleCreate = async () => {
     if (!newKeyName.trim()) return
@@ -807,6 +810,7 @@ function ApiKeysTab({ search }) {
 }
 
 function BrandingTab({ search }) {
+  const { isGuest } = useAuth()
   const [form, setForm] = useState({ businessName: '', brandColour: '#3a7d44', contactPhone: '', contactEmail: '', contactWebsite: '' })
   const [logoUrl, setLogoUrl] = useState(null)
   const [saving, setSaving] = useState(false)
@@ -815,7 +819,10 @@ function BrandingTab({ search }) {
   const [uploadingLogo, setUploadingLogo] = useState(false)
   const logoInputRef = useRef(null)
 
+  // Guests don't have a persisted branding config — skip the fetch so demo
+  // and preview modes don't produce a spurious NetworkError.
   useEffect(() => {
+    if (isGuest) return
     brandingApi.get().then((data) => {
       setForm({
         businessName: data.businessName || '',
@@ -826,7 +833,7 @@ function BrandingTab({ search }) {
       })
       if (data.logoUrl) setLogoUrl(data.logoUrl)
     }).catch(() => {})
-  }, [])
+  }, [isGuest])
 
   const handleLogoUpload = async (file) => {
     if (!file) return


### PR DESCRIPTION
Direct follow-up to the NetworkError you spotted in the API Keys section. Root-causes it + widens the smoke so a repeat of the same class of bug on any other sub-tab will fail CI.

## Two real bugs fixed

Both tabs were unconditionally fetching on mount regardless of auth state, producing a console `NetworkError` (or `403` after Stripe activation) for any guest-mode user — which previously meant the smoke test landed on `/settings` (redirects to `/settings/property`) and never saw these tabs at all.

| Tab | Fetch | Guard |
|---|---|---|
| `ApiKeysTab` | `apiKeysApi.list()` | `if (!isGuest) loadKeys()` |
| `BrandingTab` | `brandingApi.get()` | `if (isGuest) return` |

Same pattern PlantContext already uses — guests never touch the network.

## Smoke coverage: every page now

- Added all 7 settings sub-routes: `/settings/{property,preferences,data,api-keys,branding,advanced,billing}`.
- Added `/scan/:shortCode` and `/portal/:token` with a selective `page.route` stub that returns 404 for those endpoints only — exercises the "not found" render path without CORS failures against the prod gateway.
- Added `page.on('requestfailed')` listener so DNS / connection-refused / aborted requests get flagged even when they don't surface as `console.error`.
- Per-route `extraIgnore` list so the stubbed 404 routes can silence the browser's expected `"Failed to load resource: 404"` chrome-log without widening the global ignore.

## Total coverage

| | Before | After |
|---|---|---|
| Public routes | 3 | 5 (+scan, +portal) |
| Authenticated routes | 9 | 15 (+7 settings sub-tabs, -1 redirect) |
| Total Playwright tests | 12 | 20 |
| Local run time | ~1.5 min | ~2.5 min |

Verified locally: API Keys + Branding tabs now pass; all 20 tests green.

## Test plan

- [ ] PR CI `E2E smoke (Playwright)` goes green with all 20 tests
- [ ] If someone adds a new unconditional fetch to any settings tab (or any other page route), the smoke fails before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)