### PR TITLE
chore: ignore Playwright output dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ terraform/tmp/
 api/plants/integration/images/*.jpg
 api/plants/integration/images/*.jpeg
 api/plants/integration/images/*.png
+
+# Playwright
+test-results/
+playwright-report/
+.playwright/


### PR DESCRIPTION
## Summary
- Add `test-results/`, `playwright-report/`, `.playwright/` to `.gitignore`.
- Stops local Playwright runs from showing as untracked in `git status`.

## Test plan
- [x] `git status` no longer flags `test-results/` after a Playwright run

🤖 Generated with [Claude Code](https://claude.com/claude-code)