### PR TITLE
fix(e2e): ignore net::ERR_ABORTED on lazy chunk fetches

### DIFF
--- a/e2e/console-smoke.spec.js
+++ b/e2e/console-smoke.spec.js
@@ -30,6 +30,9 @@ const IGNORED_ERROR_PATTERNS = [
   /Subscription lookup failed/i,                                          // billingApi has graceful fallback
   /identity-v1.*400/i,
   /\[vite\]/i,                                                            // Vite HMR / preview messages
+  // Lazily loaded chunks aborted by a subsequent navigation (benign — the
+  // chunk is no longer needed). Real network errors surface as ERR_FAILED.
+  /net::ERR_ABORTED/i,
 ]
 
 const ROUTES = [

--- a/e2e/interactions.spec.js
+++ b/e2e/interactions.spec.js
@@ -20,6 +20,12 @@ const IGNORED_ERROR_PATTERNS = [
   /Subscription lookup failed/i,
   /identity-v1.*400/i,
   /\[vite\]/i,
+  // Code-split chunks (UpgradePrompt, Dropdown, ButtonGroup, …) and the SVG
+  // sprite are fetched lazily; if a test navigates or the page tears down
+  // before they resolve, the browser cancels the in-flight request and emits
+  // a `requestfailed` with net::ERR_ABORTED. That's benign — the chunk is no
+  // longer needed. Real failures surface as ERR_FAILED / ERR_NAME_NOT_RESOLVED.
+  /net::ERR_ABORTED/i,
 ]
 
 function attachErrorListeners(page) {


### PR DESCRIPTION
Modal-mount and console-smoke tests intermittently failed on CI when
navigation cancelled an in-flight code-split chunk fetch (UpgradePrompt,
Dropdown, ButtonGroup, /icons/sprite.svg, accounts.google credential
button library, etc.). The browser surfaces those as `requestfailed`
events with `net::ERR_ABORTED` — benign, since the chunk is no longer
needed. Real network failures still come through as ERR_FAILED /
ERR_NAME_NOT_RESOLVED.

Add `/net::ERR_ABORTED/i` to the IGNORED_ERROR_PATTERNS arrays in both
`e2e/interactions.spec.js` and `e2e/console-smoke.spec.js` so these
benign aborts don't fail the build. (PR #338's `e2e/_helpers.js`
duplicates the pattern array — that copy needs the same line on
rebase.)

https://claude.ai/code/session_012UbtN3dKREDUDUL2DuimcF