### PR TITLE
fix(ci): de-duplicate E2E helpers; stabilise Cmd+K shortcut test

### DIFF
--- a/e2e/_helpers.js
+++ b/e2e/_helpers.js
@@ -1,0 +1,99 @@
+/**
+ * Shared E2E helpers.
+ *
+ * Single source of truth for the ignore list, error listener wiring, and
+ * guest-mode bootstrap used by every spec in this directory. Adding a new
+ * benign-error pattern (lazy-chunk aborts, third-party iframe noise, etc.)
+ * happens here once — previously the same pattern had to land in both
+ * console-smoke.spec.js and interactions.spec.js, and CI broke whenever a
+ * patch updated only one.
+ */
+
+// Errors that are expected on every load. Keep this list tight — noise here
+// masks real regressions.
+export const IGNORED_ERROR_PATTERNS = [
+  /favicon/i,
+  /GSI_LOGGER|FedCM|Sign-In|gstatic\.com\/cast\/sdk|accounts\.google/i,    // Google OAuth in preview
+  /Failed to load resource.*(403|401)/i,                                    // Google auth 403s
+  /Download the React DevTools/i,
+  /ERR_FAILED.*weather|open-meteo/i,                                        // geolocation flakes
+  /Subscription lookup failed/i,                                            // billingApi has graceful fallback
+  /identity-v1.*400/i,
+  /\[vite\]/i,                                                              // Vite HMR / preview messages
+  // Code-split chunks (UpgradePrompt, Dropdown, ButtonGroup, …) and the SVG
+  // sprite are fetched lazily; if a test navigates or the page tears down
+  // before they resolve, the browser cancels the in-flight request and emits
+  // a `requestfailed` with net::ERR_ABORTED. That's benign — the chunk is no
+  // longer needed. Real failures surface as ERR_FAILED / ERR_NAME_NOT_RESOLVED.
+  /net::ERR_ABORTED/i,
+]
+
+export function isIgnoredError(text, extraPatterns = []) {
+  return [...IGNORED_ERROR_PATTERNS, ...extraPatterns].some((rx) => rx.test(text))
+}
+
+/**
+ * Attach console.error / pageerror / (optional) requestfailed listeners and
+ * return the collected errors array. Pass `extraIgnore` for route-specific
+ * noise (e.g. 404s on opted-in "not found" smoke routes). Set
+ * `requestFailed:false` for authenticated-route smoke where in-flight fetches
+ * (weather, billing, plants) commonly cancel mid-navigation.
+ */
+export function attachErrorListeners(page, extraIgnore = [], { requestFailed = true } = {}) {
+  const errors = []
+  const isNoisy = (text) => isIgnoredError(text, extraIgnore)
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && !isNoisy(msg.text())) errors.push(`console.error: ${msg.text()}`)
+  })
+  page.on('pageerror', (err) => {
+    if (!isNoisy(err.message)) errors.push(`pageerror: ${err.message}\n${err.stack || ''}`)
+  })
+  if (requestFailed) {
+    page.on('requestfailed', (req) => {
+      const msg = `requestfailed: ${req.method()} ${req.url()} — ${req.failure()?.errorText || 'unknown'}`
+      if (!isNoisy(msg)) errors.push(msg)
+    })
+  }
+  return errors
+}
+
+/**
+ * Pre-populate localStorage so first-run overlays (GDPR consent banner,
+ * "What's new" modal, onboarding modal) don't intercept pointer events.
+ */
+export async function dismissFirstRunOverlays(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('plant_tracker_consent', JSON.stringify({
+      analytics: false, ai: false, decidedAt: new Date().toISOString(),
+    }))
+    localStorage.setItem('plant-tracker-whats-new-seen', '99.0.0')
+    localStorage.setItem('plant-tracker-onboarded', '1')
+  })
+}
+
+/**
+ * Land on /login, click "Continue as guest", and wait for the post-login
+ * redirect to settle. Skips first-run overlays unless `dismissOverlays:false`.
+ */
+export async function enterGuestMode(page, { dismissOverlays = true } = {}) {
+  if (dismissOverlays) await dismissFirstRunOverlays(page)
+  await page.goto('/login', { waitUntil: 'domcontentloaded' })
+  const guestButton = page.getByRole('button', { name: /continue as guest|try.*guest|guest mode/i })
+  await guestButton.waitFor({ state: 'visible', timeout: 10_000 })
+  await guestButton.click()
+  // AuthLayout redirect lands on /today (PR #317).
+  await page.waitForURL(/\/today|\/$/, { timeout: 10_000 })
+}
+
+/**
+ * Wait for MainLayout to be fully interactive — i.e. the Topbar has mounted
+ * and `GlobalKeyboardShortcuts`' useEffect has had a chance to attach its
+ * keydown listener. Use this before firing global keyboard shortcuts; it's
+ * deterministic where `waitForLoadState('networkidle')` is racey on CI.
+ */
+export async function waitForLayoutReady(page) {
+  await page.getByRole('button', { name: /open command palette/i }).waitFor({
+    state: 'visible',
+    timeout: 10_000,
+  })
+}

--- a/e2e/console-smoke.spec.js
+++ b/e2e/console-smoke.spec.js
@@ -17,23 +17,7 @@
  */
 
 import { test, expect } from '@playwright/test'
-
-// Errors that are expected on every load (Google Identity Services rejecting
-// the placeholder client ID in preview builds, geolocation flakes, etc.).
-// Keep this list tight — noise here masks real regressions.
-const IGNORED_ERROR_PATTERNS = [
-  /favicon/i,
-  /GSI_LOGGER|FedCM|Sign-In|gstatic\.com\/cast\/sdk|accounts\.google/i,  // Google OAuth in preview
-  /Failed to load resource.*(403|401)/i,                                 // Google auth 403s
-  /Download the React DevTools/i,
-  /ERR_FAILED.*weather|open-meteo/i,                                      // geolocation flakes
-  /Subscription lookup failed/i,                                          // billingApi has graceful fallback
-  /identity-v1.*400/i,
-  /\[vite\]/i,                                                            // Vite HMR / preview messages
-  // Lazily loaded chunks aborted by a subsequent navigation (benign — the
-  // chunk is no longer needed). Real network errors surface as ERR_FAILED.
-  /net::ERR_ABORTED/i,
-]
+import { attachErrorListeners, enterGuestMode } from './_helpers.js'
 
 const ROUTES = [
   { path: '/today',                label: 'Today (daily tasks)' },
@@ -68,10 +52,6 @@ const PUBLIC_ROUTES = [
   { path: '/portal/invalid-tok',  label: 'Portal (invalid token)',    stubApi: true },
 ]
 
-function isIgnored(text) {
-  return IGNORED_ERROR_PATTERNS.some((rx) => rx.test(text))
-}
-
 // Stub the API endpoints that /scan/:code and /portal/:token fetch on mount
 // with a 404 so we can exercise the graceful "not found" render path without
 // the test hitting the real prod gateway (CORS) or a placeholder host (DNS).
@@ -88,15 +68,6 @@ async function stubApiCalls(page) {
   }))
 }
 
-async function enterGuestMode(page) {
-  await page.goto('/login', { waitUntil: 'domcontentloaded' })
-  const guestButton = page.getByRole('button', { name: /continue as guest|try.*guest|guest mode/i })
-  await guestButton.waitFor({ state: 'visible', timeout: 10_000 })
-  await guestButton.click()
-  // Post-login redirect lands on /today (AuthLayout change in PR #317).
-  await page.waitForURL(/\/today|\/$/, { timeout: 10_000 })
-}
-
 // Chromium logs every failed fetch (4xx/5xx) as a console.error with no URL
 // context, which is pure noise when the test is exercising a "not found" code
 // path. Widen the ignore list only for those opted-in routes.
@@ -107,20 +78,7 @@ test.describe('Public routes: no console errors on load', () => {
     test(`${label} (${path})`, async ({ page }) => {
       if (stubApi) await stubApiCalls(page)
       const extraIgnore = stubApi ? [NOT_FOUND_CONSOLE_NOISE] : []
-      const errors = []
-      const isNoisy = (text) => isIgnored(text) || extraIgnore.some((rx) => rx.test(text))
-      page.on('console', (msg) => {
-        if (msg.type() === 'error' && !isNoisy(msg.text())) errors.push(`console.error: ${msg.text()}`)
-      })
-      page.on('pageerror', (err) => {
-        if (!isNoisy(err.message)) errors.push(`pageerror: ${err.message}\n${err.stack || ''}`)
-      })
-      page.on('requestfailed', (req) => {
-        const url = req.url()
-        const failure = req.failure()?.errorText || 'unknown'
-        const msg = `requestfailed: ${req.method()} ${url} — ${failure}`
-        if (!isNoisy(msg)) errors.push(msg)
-      })
+      const errors = attachErrorListeners(page, extraIgnore)
 
       await page.goto(path, { waitUntil: 'networkidle', timeout: 20_000 })
       await page.waitForTimeout(500)
@@ -132,20 +90,18 @@ test.describe('Public routes: no console errors on load', () => {
 
 test.describe('Authenticated routes: guest mode, no console errors', () => {
   test.beforeEach(async ({ page }) => {
-    await enterGuestMode(page)
+    // No first-run overlay dismissal here — the console-load checks should
+    // see the same DOM real users do, including any first-paint side effects
+    // of those overlays mounting.
+    await enterGuestMode(page, { dismissOverlays: false })
   })
 
   for (const { path, label } of ROUTES) {
     test(`${label} (${path})`, async ({ page }) => {
-      const errors = []
       // Start listening AFTER guest-mode bootstrap so we don't catch any
-      // login-page transient noise.
-      page.on('console', (msg) => {
-        if (msg.type() === 'error' && !isIgnored(msg.text())) errors.push(`console.error: ${msg.text()}`)
-      })
-      page.on('pageerror', (err) => {
-        if (!isIgnored(err.message)) errors.push(`pageerror: ${err.message}\n${err.stack || ''}`)
-      })
+      // login-page transient noise. requestfailed off — these routes fan out
+      // to weather / billing / plants and cancellation is too noisy to police.
+      const errors = attachErrorListeners(page, [], { requestFailed: false })
 
       await page.goto(path, { waitUntil: 'networkidle', timeout: 20_000 })
       await page.waitForTimeout(500)

--- a/e2e/interactions.spec.js
+++ b/e2e/interactions.spec.js
@@ -10,61 +10,7 @@
  */
 
 import { test, expect } from '@playwright/test'
-
-const IGNORED_ERROR_PATTERNS = [
-  /favicon/i,
-  /GSI_LOGGER|FedCM|Sign-In|gstatic\.com\/cast\/sdk|accounts\.google/i,
-  /Failed to load resource.*(403|401)/i,
-  /Download the React DevTools/i,
-  /ERR_FAILED.*weather|open-meteo/i,
-  /Subscription lookup failed/i,
-  /identity-v1.*400/i,
-  /\[vite\]/i,
-  // Code-split chunks (UpgradePrompt, Dropdown, ButtonGroup, …) and the SVG
-  // sprite are fetched lazily; if a test navigates or the page tears down
-  // before they resolve, the browser cancels the in-flight request and emits
-  // a `requestfailed` with net::ERR_ABORTED. That's benign — the chunk is no
-  // longer needed. Real failures surface as ERR_FAILED / ERR_NAME_NOT_RESOLVED.
-  /net::ERR_ABORTED/i,
-]
-
-function attachErrorListeners(page) {
-  const errors = []
-  const isIgnored = (t) => IGNORED_ERROR_PATTERNS.some((rx) => rx.test(t))
-  page.on('console', (msg) => {
-    if (msg.type() === 'error' && !isIgnored(msg.text())) errors.push(`console.error: ${msg.text()}`)
-  })
-  page.on('pageerror', (err) => {
-    if (!isIgnored(err.message)) errors.push(`pageerror: ${err.message}\n${err.stack || ''}`)
-  })
-  page.on('requestfailed', (req) => {
-    const msg = `requestfailed: ${req.method()} ${req.url()} — ${req.failure()?.errorText || 'unknown'}`
-    if (!isIgnored(msg)) errors.push(msg)
-  })
-  return errors
-}
-
-// Pre-populate localStorage so first-run overlays (GDPR consent banner,
-// "What's new" modal, onboarding modal) don't intercept pointer events in
-// our interaction tests.
-async function dismissFirstRunOverlays(page) {
-  await page.addInitScript(() => {
-    localStorage.setItem('plant_tracker_consent', JSON.stringify({
-      analytics: false, ai: false, decidedAt: new Date().toISOString(),
-    }))
-    localStorage.setItem('plant-tracker-whats-new-seen', '99.0.0')
-    localStorage.setItem('plant-tracker-onboarded', '1')
-  })
-}
-
-async function enterGuestMode(page) {
-  await dismissFirstRunOverlays(page)
-  await page.goto('/login', { waitUntil: 'domcontentloaded' })
-  const guestButton = page.getByRole('button', { name: /continue as guest|try.*guest|guest mode/i })
-  await guestButton.waitFor({ state: 'visible', timeout: 10_000 })
-  await guestButton.click()
-  await page.waitForURL(/\/today|\/$/, { timeout: 10_000 })
-}
+import { attachErrorListeners, enterGuestMode, waitForLayoutReady } from './_helpers.js'
 
 test.describe('Global overlays', () => {
   test.beforeEach(async ({ page }) => {
@@ -78,15 +24,19 @@ test.describe('Global overlays', () => {
     test.skip(!!viewport && viewport.width < 768, 'Keyboard shortcut is desktop-only')
 
     const errors = attachErrorListeners(page)
-    // GlobalKeyboardShortcuts attaches its keydown listener in a useEffect that
-    // runs after MainLayout mounts. waitForURL resolves on the first matching
-    // navigation, so on slower CI runs the listener may not be attached yet.
-    // Wait for the page to settle before firing the shortcut.
-    await page.waitForLoadState('networkidle')
-    const isMac = process.platform === 'darwin'
-    await page.keyboard.press(isMac ? 'Meta+k' : 'Control+k')
+    // Wait for MainLayout (and GlobalKeyboardShortcuts' useEffect) to mount —
+    // the Topbar palette button is the deterministic mount signal.
+    await waitForLayoutReady(page)
     const dialog = page.getByRole('dialog', { name: /command palette/i })
-    await expect(dialog).toBeVisible({ timeout: 5_000 })
+    // Re-press the shortcut on the auto-retry: on slower CI runners the
+    // keydown handler can attach a tick after the button paints, so a single
+    // keypress can race the listener registration. expect.toPass retries the
+    // whole block (press + visibility check) until either succeeds or 5s.
+    const isMac = process.platform === 'darwin'
+    await expect(async () => {
+      await page.keyboard.press(isMac ? 'Meta+k' : 'Control+k')
+      await expect(dialog).toBeVisible({ timeout: 1_000 })
+    }).toPass({ timeout: 5_000 })
     // Typing into the search input exercises filtering (the fuzzy matcher
     // caused previous hook-rule regressions). Don't assert on results — just
     // confirm the input accepts text without crashing.


### PR DESCRIPTION
Two recurring CI failure patterns this addresses:

1. PRs #344 and #345 both shipped a single-line ignore-pattern update
   that had to be applied in both console-smoke.spec.js and
   interactions.spec.js. Whenever a patch only updated one, the matching
   test in the other file kept failing on benign noise (Cmd+K timing,
   net::ERR_ABORTED on lazy chunk fetches). Extract IGNORED_ERROR_PATTERNS,
   attachErrorListeners, dismissFirstRunOverlays, and enterGuestMode into
   e2e/_helpers.js so future updates land in one place.

2. PR #344's Cmd+K stabilisation used waitForLoadState('networkidle'),
   which is racey on CI when weather/billing/plants fetches stay
   in-flight. Replace it with a deterministic mount signal (Topbar's
   "Open command palette" button) plus an expect.toPass retry around the
   keyboard.press, so a one-tick race between paint and useEffect
   listener registration is automatically retried instead of failing.

Also preserves console-smoke's authenticated-routes behaviour of NOT
listening to requestfailed (those routes fan out to many fetches whose
cancellation is too noisy to police), via a new requestFailed:false
option on attachErrorListeners.

No production code changes. `npm run preflight:fast` passes; Playwright
lists all 62 tests across the three specs.

https://claude.ai/code/session_TXLYa