### PR TITLE
fix(e2e): wait for <main class="app-body"> instead of mobile-only palette button

### DIFF
--- a/e2e/_helpers.js
+++ b/e2e/_helpers.js
@@ -86,13 +86,19 @@ export async function enterGuestMode(page, { dismissOverlays = true } = {}) {
 }
 
 /**
- * Wait for MainLayout to be fully interactive — i.e. the Topbar has mounted
- * and `GlobalKeyboardShortcuts`' useEffect has had a chance to attach its
- * keydown listener. Use this before firing global keyboard shortcuts; it's
- * deterministic where `waitForLoadState('networkidle')` is racey on CI.
+ * Wait for MainLayout to be fully interactive — i.e. the React tree
+ * (CommandPaletteProvider → GlobalKeyboardShortcuts) has rendered and that
+ * effect has had a chance to attach its keydown listener. Use this before
+ * firing global keyboard shortcuts; it's deterministic where
+ * `waitForLoadState('networkidle')` is racey on CI.
+ *
+ * Waits for `<main class="app-body">` — the wrapper rendered unconditionally
+ * by MainLayout — rather than the Topbar palette button. The Topbar carries
+ * `d-md-none` so its palette button is permanently invisible on desktop
+ * chromium (1280×720), which made the previous helper time out every run.
  */
 export async function waitForLayoutReady(page) {
-  await page.getByRole('button', { name: /open command palette/i }).waitFor({
+  await page.locator('main.app-body').waitFor({
     state: 'visible',
     timeout: 10_000,
   })


### PR DESCRIPTION
PR #347's `waitForLayoutReady` helper waited for the Topbar's "Open command
palette" button to become visible — but `Topbar` is rendered with
`className="app-header d-md-none"`, so the entire header (and the button
inside) is `display: none` on every viewport >= 768px. The Cmd+K test only
runs on chromium (skips when viewport.width < 768), so the helper's locator
was waiting for an element that is permanently invisible on the only project
that exercises it. The 10-second `waitFor({ state: 'visible' })` timed out
on every run, failing E2E and gating the deploy.

Switch the mount signal to `<main class="app-body">`, the wrapper rendered
unconditionally inside `MainLayout` (sibling of `<GlobalKeyboardShortcuts>`).
`.app-body` uses `display: flex` in `_layout.scss` with no responsive
overrides, so it's visible on both desktop and mobile — making the helper
correct on any viewport in case future tests reuse it.

The `expect.toPass` retry around the Cmd+K press already handles the
one-tick race between the main element painting and the keydown listener
attaching, so no additional waits are needed.

https://claude.ai/code/session_01SFzuERnoYzKRB16UjTV6hE