### PR TITLE
fix(ci): always install Playwright system deps; cache only browser binaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,9 +110,17 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
+      # System libraries (libwoff2dec, libgstreamer-plugins-bad, etc.) are
+      # NOT part of the cached browser bundle — they live in /usr via apt and
+      # disappear between cache-hit runs. Install them every time, not just
+      # on cache miss, otherwise WebKit fails to launch with
+      # "libwoff2dec.so.1.0.2: cannot open shared object file".
+      - name: Install Playwright system deps
+        run: npx playwright install-deps chromium webkit firefox
+
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium webkit firefox
+        run: npx playwright install chromium webkit firefox
 
       # Build with dummy VITE_* values — the smoke test runs in guest mode and
       # never hits the real API, so placeholder values are sufficient and let
@@ -295,9 +303,13 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
+      # System libs aren't in the browser cache — install on every run.
+      - name: Install Playwright system deps
+        run: npx playwright install-deps chromium webkit firefox
+
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium webkit firefox
+        run: npx playwright install chromium webkit firefox
 
       # Give Firebase Hosting a beat to propagate the new bundle to the CDN
       # before we start hitting it.


### PR DESCRIPTION
## Summary

Main is failing the Playwright job (and so blocking deploys) because WebKit can't launch:

```
libwoff2dec.so.1.0.2: cannot open shared object file
```

**Root cause.** `deploy.yml` skips the entire `npx playwright install --with-deps …` step when the browser cache hits:

```yaml
- name: Install Playwright browsers
  if: steps.playwright-cache.outputs.cache-hit != 'true'
  run: npx playwright install --with-deps chromium webkit firefox
```

The browser binaries under `~/.cache/ms-playwright` ARE cached and survive the cache hit. The system libraries (`libwoff2dec`, `libgstreamer-plugins-bad`, `libnss3`, ...) live under `/usr` via apt and disappear between runner instances. So on a cache-hit run, those apt packages are never installed and WebKit/Firefox crash before the first test runs.

**Fix.** Split the install into two steps in both the `e2e` and `post-deploy-smoke` jobs:

```yaml
- name: Install Playwright system deps
  run: npx playwright install-deps chromium webkit firefox

- name: Install Playwright browsers
  if: steps.playwright-cache.outputs.cache-hit != 'true'
  run: npx playwright install chromium webkit firefox
```

The `install-deps` step runs every time and installs the apt packages (apt no-ops if they're already current, so this is fast). The `install` step still runs only on cache miss for the heavy browser bundles. No tests changed.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — clean
- [ ] Watch Actions: E2E job should now go green on cache-hit runs

https://claude.ai/code/session_014jRs5mtk4VYFwFuuAafPwS

---
_Generated by [Claude Code](https://claude.ai/code/session_014jRs5mtk4VYFwFuuAafPwS)_