### PR TITLE
chore(deploy): force Cloud Function redeploy to pick up 4 days of changes

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1,5 +1,9 @@
 'use strict';
 
+// chore(deploy): force Cloud Function redeploy 2026-04-25 — picks up the
+// last 4 days of accumulated changes that never reached the function (the
+// CI deploy job kept skipping because none of the merged PRs touched
+// api/plants/). Safe to delete on the next real backend change.
 const functions = require('@google-cloud/functions-framework');
 const { Firestore } = require('@google-cloud/firestore');
 const { Storage } = require('@google-cloud/storage');


### PR DESCRIPTION
## Summary

Force a Cloud Function redeploy. The last several merged PRs (#346 → #352) didn't touch `api/plants/`, so dorny/paths-filter has been setting `backend=false` and `deploy.yml` keeps skipping the `deploy-function` job on every main push. The deployed function is roughly 4 days behind main on accumulated backend work (tier gating from #337, etc.).

This adds a single comment block at the top of `api/plants/index.js` so the path filter sees a backend change. The `deploy-function` job will:

1. Zip the entire `api/plants/` directory at `HEAD` — already contains all the missing changes.
2. Upload to the GCS source bucket.
3. Trigger the `platform-infra` Terraform apply workflow.
4. `verify-function` polls `/health` until the new revision returns ok.

The comment is dated and called out as self-deletable on the next real backend change, so the diff stays one block of comments and a noise tag.

## Test plan

- [x] `cd api/plants && npm run lint` — clean
- [ ] Watch Actions:
  - [ ] `Deploy Cloud Function` runs (no longer skipped)
  - [ ] `Verify Cloud Function` reports `/health` ok
  - [ ] `Build & Deploy` (frontend) runs
  - [ ] `Post-deploy smoke` against production stays green

https://claude.ai/code/session_014jRs5mtk4VYFwFuuAafPwS

---
_Generated by [Claude Code](https://claude.ai/code/session_014jRs5mtk4VYFwFuuAafPwS)_