### PR TITLE
fix(#210): hemisphere-aware season labels in ML feature rows

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -647,15 +647,37 @@ app.get('/ml/status', async (req, res) => {
 
 // ── ML feature engineering ────────────────────────────────────────────────────
 
-function getSeason(dateStr) {
+// Hemisphere-aware season label for ML rows.  Northern hemisphere maps
+// Mar-May → spring etc.; southern hemisphere is shifted six months so an
+// April event in Sydney is labelled 'autumn', not 'spring'.  Falls back to
+// north when the hemisphere is unknown — preserves prior behaviour for
+// users that haven't set a location preference.
+function getSeason(dateStr, hemisphere = 'north') {
   const month = new Date(dateStr).getMonth(); // 0-indexed
-  if (month >= 2 && month <= 4) return 'spring';
-  if (month >= 5 && month <= 7) return 'summer';
-  if (month >= 8 && month <= 10) return 'autumn';
-  return 'winter';
+  const isNorth = hemisphere !== 'south';
+  if (isNorth) {
+    if (month >= 2 && month <= 4) return 'spring';
+    if (month >= 5 && month <= 7) return 'summer';
+    if (month >= 8 && month <= 10) return 'autumn';
+    return 'winter';
+  }
+  if (month >= 2 && month <= 4) return 'autumn';
+  if (month >= 5 && month <= 7) return 'winter';
+  if (month >= 8 && month <= 10) return 'spring';
+  return 'summer';
 }
 
-function buildFeatureRows(plant) {
+async function getUserHemisphere(userId) {
+  try {
+    const configDoc = await userConfig(userId).doc('preferences').get();
+    if (configDoc.exists && configDoc.data().hemisphere) {
+      return configDoc.data().hemisphere;
+    }
+  } catch { /* fall through to default */ }
+  return 'north';
+}
+
+function buildFeatureRows(plant, hemisphere = 'north') {
   const log = (plant.wateringLog || []).sort((a, b) => new Date(a.date) - new Date(b.date));
   if (log.length < 2) return [];
 
@@ -698,7 +720,7 @@ function buildFeatureRows(plant) {
       adherence_ratio: adherence,
       health_at_watering: health || '',
       health_7d_after: health7d || '',
-      season: getSeason(log[i].date),
+      season: getSeason(log[i].date, hemisphere),
       consecutive_overdue_days: consecutive,
       pot_size: plant.potSize || '',
       room: plant.room || '',
@@ -741,9 +763,10 @@ app.get('/ml/export', async (req, res) => {
     const allRows = [];
     const usersSnap = await db.collection('users').get();
     for (const userDoc of usersSnap.docs) {
+      const hemisphere = await getUserHemisphere(userDoc.id);
       const plantsSnap = await db.collection('users').doc(userDoc.id).collection('plants').get();
       for (const plantDoc of plantsSnap.docs) {
-        allRows.push(...buildFeatureRows(plantDoc.data()));
+        allRows.push(...buildFeatureRows(plantDoc.data(), hemisphere));
       }
     }
 
@@ -2479,7 +2502,8 @@ app.get('/plants/:id/watering-pattern', requireUser, requireTier('home_pro'), as
     let result;
     if (endpointId && (plant.wateringLog || []).length >= 3) {
       try {
-        const featureRows = buildFeatureRows(plant);
+        const hemisphere = await getUserHemisphere(req.userId);
+        const featureRows = buildFeatureRows(plant, hemisphere);
         if (featureRows.length > 0) {
           const predictions = await vertexai.predict(endpointId, [featureRows[featureRows.length - 1]]);
           if (predictions.length > 0 && predictions[0].pattern) {
@@ -2544,7 +2568,8 @@ app.get('/plants/:id/watering-recommendation', requireUser, requireTier('home_pr
 
     if (endpointId && (plant.wateringLog || []).length >= 5) {
       try {
-        const featureRows = buildFeatureRows(plant);
+        const hemisphere = await getUserHemisphere(req.userId);
+        const featureRows = buildFeatureRows(plant, hemisphere);
         if (featureRows.length > 0) {
           const latest = featureRows[featureRows.length - 1];
           const predictions = await vertexai.predict(endpointId, [{
@@ -2698,7 +2723,8 @@ app.get('/plants/:id/health-prediction', requireUser, requireTier('home_pro'), a
 
     if (endpointId && (plant.wateringLog || []).length >= 3) {
       try {
-        const featureRows = buildFeatureRows(plant);
+        const hemisphere = await getUserHemisphere(req.userId);
+        const featureRows = buildFeatureRows(plant, hemisphere);
         if (featureRows.length > 0) {
           const latest = featureRows[featureRows.length - 1];
           const predictions = await vertexai.predict(endpointId, [{
@@ -2741,22 +2767,7 @@ app.get('/plants/:id/health-prediction', requireUser, requireTier('home_pro'), a
 
 // ── Seasonal pattern recognition ─────────────────────────────────────────────
 
-function getSeasonForHemisphere(date, hemisphere) {
-  const month = new Date(date).getMonth(); // 0-indexed
-  const isNorth = hemisphere !== 'south';
-
-  if (isNorth) {
-    if (month >= 2 && month <= 4) return 'spring';
-    if (month >= 5 && month <= 7) return 'summer';
-    if (month >= 8 && month <= 10) return 'autumn';
-    return 'winter';
-  }
-  // Southern hemisphere: seasons are reversed
-  if (month >= 2 && month <= 4) return 'autumn';
-  if (month >= 5 && month <= 7) return 'winter';
-  if (month >= 8 && month <= 10) return 'spring';
-  return 'summer';
-}
+const getSeasonForHemisphere = (date, hemisphere) => getSeason(date, hemisphere);
 
 // Default seasonal multipliers per season (species-independent baseline)
 const SEASONAL_MULTIPLIERS = {
@@ -2805,15 +2816,7 @@ app.get('/plants/:id/seasonal-adjustment', requireUser, requireTier('home_pro'),
     if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
 
     const plant = doc.data();
-
-    // Get hemisphere from user config or default to north
-    let hemisphere = 'north';
-    try {
-      const configDoc = await userConfig(req.userId).doc('preferences').get();
-      if (configDoc.exists && configDoc.data().hemisphere) {
-        hemisphere = configDoc.data().hemisphere;
-      }
-    } catch { /* default to north */ }
+    const hemisphere = await getUserHemisphere(req.userId);
 
     const endpointId = process.env.SEASONAL_ADJUSTMENT_ENDPOINT;
     let result;
@@ -2950,7 +2953,8 @@ app.get('/plants/:id/care-score', requireUser, async (req, res) => {
 
     if (endpointId && (plant.wateringLog || []).length >= 3) {
       try {
-        const featureRows = buildFeatureRows(plant);
+        const hemisphere = await getUserHemisphere(req.userId);
+        const featureRows = buildFeatureRows(plant, hemisphere);
         if (featureRows.length > 0) {
           const predictions = await vertexai.predict(endpointId, [featureRows[featureRows.length - 1]]);
           if (predictions.length > 0 && typeof predictions[0].score === 'number') {

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -1702,6 +1702,44 @@ describe('GET /ml/export', () => {
     expect(rows.map(r => r.season)).toEqual(['spring', 'summer', 'autumn', 'winter']);
     delete process.env.ML_ADMIN_TOKEN;
   });
+
+  it('reverses season labels for southern-hemisphere users (issue #210)', async () => {
+    process.env.ML_ADMIN_TOKEN = 'test-token';
+    // Two users with the same dates but opposite hemispheres should get
+    // mirrored season labels — without this the ML training set conflates
+    // southern-hemisphere events with northern-hemisphere seasonality.
+    store['users/user-north'] = {};
+    store['users/user-north/config/preferences'] = { hemisphere: 'north' };
+    store['users/user-north/plants/p1'] = {
+      name: 'Plant', species: 'NorthSpecies', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-04-15T00:00:00.000Z' },
+        { date: '2026-07-15T00:00:00.000Z' },
+        { date: '2026-10-15T00:00:00.000Z' },
+      ],
+      healthLog: [],
+    };
+    store['users/user-south'] = {};
+    store['users/user-south/config/preferences'] = { hemisphere: 'south' };
+    store['users/user-south/plants/p1'] = {
+      name: 'Plant', species: 'SouthSpecies', frequencyDays: 7,
+      wateringLog: [
+        { date: '2026-01-01T00:00:00.000Z' },
+        { date: '2026-04-15T00:00:00.000Z' },
+        { date: '2026-07-15T00:00:00.000Z' },
+        { date: '2026-10-15T00:00:00.000Z' },
+      ],
+      healthLog: [],
+    };
+    const res = await request(app).get('/ml/export').set('x-admin-token', 'test-token');
+    const rows = res.text.trim().split('\n').map(l => JSON.parse(l));
+    const northSeasons = rows.filter(r => r.species === 'NorthSpecies').map(r => r.season);
+    const southSeasons = rows.filter(r => r.species === 'SouthSpecies').map(r => r.season);
+    expect(northSeasons).toEqual(['spring', 'summer', 'autumn']);
+    expect(southSeasons).toEqual(['autumn', 'winter', 'spring']);
+    delete process.env.ML_ADMIN_TOKEN;
+  });
 });
 
 // ── GET /plants/:id/watering-recommendation ─────────────────────────────────

--- a/src/__tests__/watering.test.js
+++ b/src/__tests__/watering.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getWateringStatus, getAdjustedWaterAmount, isOutdoor, urgencyColor, urgencyLabel, OUTDOOR_ROOMS, getSeason, SEASONAL_MULTIPLIERS, getPlantAttributeMultiplier, getSuggestedFrequency, getMoistureStatusAdjustment, getMoistureFrequencySuggestion, getMoistureDisplay, computeRainCredit, localDateStr } from '../utils/watering.js'
+import { getWateringStatus, getAdjustedWaterAmount, isOutdoor, urgencyColor, urgencyLabel, OUTDOOR_ROOMS, getSeason, getHemisphere, SEASONAL_MULTIPLIERS, getPlantAttributeMultiplier, getSuggestedFrequency, getMoistureStatusAdjustment, getMoistureFrequencySuggestion, getMoistureDisplay, computeRainCredit, localDateStr } from '../utils/watering.js'
 
 function makePlant(overrides = {}) {
   return {
@@ -263,6 +263,26 @@ describe('getSeason', () => {
 
   it('treats latitude 0 (equator) as northern hemisphere', () => {
     expect(getSeason(0, new Date('2026-07-15'))).toBe('summer')
+  })
+})
+
+// ── getHemisphere ──────────────────────────────────────────────────────────
+
+describe('getHemisphere', () => {
+  it('returns null when lat is null, undefined, or NaN', () => {
+    expect(getHemisphere(null)).toBeNull()
+    expect(getHemisphere(undefined)).toBeNull()
+    expect(getHemisphere(Number.NaN)).toBeNull()
+  })
+
+  it('returns north for non-negative latitudes', () => {
+    expect(getHemisphere(0)).toBe('north')
+    expect(getHemisphere(40)).toBe('north')
+  })
+
+  it('returns south for negative latitudes', () => {
+    expect(getHemisphere(-0.001)).toBe('south')
+    expect(getHemisphere(-33)).toBe('south')
   })
 })
 

--- a/src/utils/watering.js
+++ b/src/utils/watering.js
@@ -55,6 +55,16 @@ export function urgencyLabel(days) {
 // ── Season detection from latitude ──────────────────────────────────────────
 
 /**
+ * Returns 'north' | 'south' | null based on latitude sign.
+ * Returns null when latitude is unknown so callers can choose how to fall back
+ * (e.g. skip the season note rather than baking in a Northern-Hemisphere default).
+ */
+export function getHemisphere(lat) {
+  if (lat == null || Number.isNaN(lat)) return null
+  return lat >= 0 ? 'north' : 'south'
+}
+
+/**
  * Determine the current season based on latitude (hemisphere) and date.
  * Northern hemisphere: Spring Mar-May, Summer Jun-Aug, Autumn Sep-Nov, Winter Dec-Feb
  * Southern hemisphere: seasons are reversed.


### PR DESCRIPTION
The backend `getSeason(dateStr)` used in `buildFeatureRows` always mapped
months to Northern-Hemisphere seasons, so a Sydney user's April watering
event was tagged 'spring' instead of 'autumn' in the ML training set —
exactly the bug called out in the issue's hemisphere-aware audit.

- Backend: make `getSeason()` accept a hemisphere argument; thread the
  user's hemisphere (from `users/{userId}/config/preferences`) through
  every `buildFeatureRows` caller (`/ml/export`, `/plants/:id/watering-pattern`,
  `/plants/:id/watering-recommendation`, `/plants/:id/health-prediction`,
  `/plants/:id/care-score`).
- Backend: extract `getUserHemisphere(userId)` helper, fold the duplicated
  `getSeasonForHemisphere` into the new shared `getSeason`.
- Frontend: export a tiny `getHemisphere(lat)` helper from `watering.js`
  for callers that want hemisphere without season.
- Tests: backend asserts mirrored season labels for north vs. south users
  on identical dates; frontend covers `getHemisphere` boundaries.

The full climate-lookup endpoint (USDA / Köppen / frost dates) still
needs an external data source decision and is left for a follow-up, per
the clarification on the issue.