### PR TITLE
feat(#306): wildlife/pollinator observation log per plant

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1859,6 +1859,69 @@ app.delete('/plants/:id/harvests/:harvestId', requireUser, async (req, res) => {
   }
 });
 
+// ── Wildlife / pollinator observation log ────────────────────────────────────
+
+const WILDLIFE_CATEGORIES = new Set(['bee', 'butterfly', 'bird', 'other-insect', 'mammal', 'reptile', 'other']);
+
+app.get('/plants/:id/wildlifeObservations', requireUser, async (req, res) => {
+  try {
+    const doc = await userPlants(req.userId).doc(req.params.id).get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+    const entries = (doc.data().wildlifeObservationLog || []).sort((a, b) => new Date(b.observedAt) - new Date(a.observedAt));
+    res.status(200).json(entries);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/plants/:id/wildlifeObservations', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+
+    const { observedAt, category, species, count, notes } = req.body || {};
+    if (!category || !WILDLIFE_CATEGORIES.has(category)) {
+      return res.status(400).json({ error: `category must be one of: ${[...WILDLIFE_CATEGORIES].join(', ')}` });
+    }
+    if (count != null && (isNaN(Number(count)) || Number(count) < 1)) {
+      return res.status(400).json({ error: 'count must be a positive integer' });
+    }
+
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const entry = {
+      id,
+      observedAt: observedAt || now,
+      category,
+      species: species ? String(species).trim() : null,
+      count: count != null ? Math.round(Number(count)) : null,
+      notes: notes ? String(notes).trim() : null,
+      createdAt: now,
+    };
+    const existing = doc.data();
+    const wildlifeObservationLog = [...(existing.wildlifeObservationLog || []), entry];
+    await ref.set({ wildlifeObservationLog, updatedAt: now }, { merge: true });
+    res.status(201).json(entry);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.delete('/plants/:id/wildlifeObservations/:obsId', requireUser, async (req, res) => {
+  try {
+    const ref = userPlants(req.userId).doc(req.params.id);
+    const doc = await ref.get();
+    if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
+    const existing = doc.data();
+    const wildlifeObservationLog = (existing.wildlifeObservationLog || []).filter(e => e.id !== req.params.obsId);
+    await ref.set({ wildlifeObservationLog, updatedAt: new Date().toISOString() }, { merge: true });
+    res.status(200).json({ deleted: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Incident log (pest, disease, deficiency, environmental) ──────────────────
 
 const INCIDENT_CATEGORIES = new Set(['pest', 'disease', 'deficiency', 'environmental']);

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -3609,6 +3609,172 @@ describe('DELETE /plants/:id/harvests/:harvestId', () => {
   });
 });
 
+// ── GET /plants/:id/wildlifeObservations ──────────────────────────────────────
+
+describe('GET /plants/:id/wildlifeObservations', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/plants/p1/wildlifeObservations');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for unknown plant', async () => {
+    const res = await request(app)
+      .get('/plants/missing/wildlifeObservations')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns empty array when no observations exist', async () => {
+    store[plantPath('p1')] = { name: 'Rose' };
+    const res = await request(app)
+      .get('/plants/p1/wildlifeObservations')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('returns observations sorted newest-first', async () => {
+    store[plantPath('p1')] = {
+      name: 'Lavender',
+      wildlifeObservationLog: [
+        { id: 'w1', observedAt: '2026-01-01T10:00:00.000Z', category: 'bee' },
+        { id: 'w2', observedAt: '2026-03-01T10:00:00.000Z', category: 'butterfly' },
+      ],
+    };
+    const res = await request(app)
+      .get('/plants/p1/wildlifeObservations')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body[0].id).toBe('w2');
+    expect(res.body[1].id).toBe('w1');
+  });
+});
+
+// ── POST /plants/:id/wildlifeObservations ─────────────────────────────────────
+
+describe('POST /plants/:id/wildlifeObservations', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).post('/plants/p1/wildlifeObservations').send({ category: 'bee' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for unknown plant', async () => {
+    const res = await request(app)
+      .post('/plants/missing/wildlifeObservations')
+      .send({ category: 'bee' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when category is missing', async () => {
+    store[plantPath('p1')] = { name: 'Lavender' };
+    const res = await request(app)
+      .post('/plants/p1/wildlifeObservations')
+      .send({ species: 'Bombus terrestris' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/category/i);
+  });
+
+  it('returns 400 when category is invalid', async () => {
+    store[plantPath('p1')] = { name: 'Lavender' };
+    const res = await request(app)
+      .post('/plants/p1/wildlifeObservations')
+      .send({ category: 'dragon' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/category/i);
+  });
+
+  it('returns 400 when count is not positive', async () => {
+    store[plantPath('p1')] = { name: 'Lavender' };
+    const res = await request(app)
+      .post('/plants/p1/wildlifeObservations')
+      .send({ category: 'bee', count: 0 })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/count/i);
+  });
+
+  it('creates an observation and returns 201', async () => {
+    store[plantPath('p1')] = { name: 'Lavender' };
+    const res = await request(app)
+      .post('/plants/p1/wildlifeObservations')
+      .send({ observedAt: '2026-06-01', category: 'bee', species: 'Bombus terrestris', count: 3, notes: 'Very busy' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(201);
+    expect(res.body.category).toBe('bee');
+    expect(res.body.species).toBe('Bombus terrestris');
+    expect(res.body.count).toBe(3);
+    expect(res.body.notes).toBe('Very busy');
+    expect(res.body.id).toBeDefined();
+  });
+
+  it('persists observation to the plant document', async () => {
+    store[plantPath('p1')] = { name: 'Lavender' };
+    await request(app)
+      .post('/plants/p1/wildlifeObservations')
+      .send({ category: 'butterfly' })
+      .set('Authorization', authHeader());
+    const saved = store[plantPath('p1')];
+    expect(saved.wildlifeObservationLog).toHaveLength(1);
+    expect(saved.wildlifeObservationLog[0].category).toBe('butterfly');
+  });
+
+  it('accepts all valid categories', async () => {
+    const categories = ['bee', 'butterfly', 'bird', 'other-insect', 'mammal', 'reptile', 'other'];
+    for (const category of categories) {
+      store[plantPath('p1')] = { name: 'Plant' };
+      const res = await request(app)
+        .post('/plants/p1/wildlifeObservations')
+        .send({ category })
+        .set('Authorization', authHeader());
+      expect(res.status).toBe(201);
+    }
+  });
+});
+
+// ── DELETE /plants/:id/wildlifeObservations/:obsId ────────────────────────────
+
+describe('DELETE /plants/:id/wildlifeObservations/:obsId', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).delete('/plants/p1/wildlifeObservations/w1');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for unknown plant', async () => {
+    const res = await request(app)
+      .delete('/plants/missing/wildlifeObservations/w1')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('removes the observation and returns 200', async () => {
+    store[plantPath('p1')] = {
+      name: 'Lavender',
+      wildlifeObservationLog: [
+        { id: 'w1', category: 'bee' },
+        { id: 'w2', category: 'butterfly' },
+      ],
+    };
+    const res = await request(app)
+      .delete('/plants/p1/wildlifeObservations/w1')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(true);
+    expect(store[plantPath('p1')].wildlifeObservationLog).toHaveLength(1);
+    expect(store[plantPath('p1')].wildlifeObservationLog[0].id).toBe('w2');
+  });
+
+  it('is idempotent — deleting a non-existent id still returns 200', async () => {
+    store[plantPath('p1')] = { name: 'Lavender', wildlifeObservationLog: [] };
+    const res = await request(app)
+      .delete('/plants/p1/wildlifeObservations/nonexistent')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+  });
+});
+
 // ── QR short-code & scan routes ───────────────────────────────────────────────
 
 describe('GET /plants/:id/short-code', () => {

--- a/api/plants/package-lock.json
+++ b/api/plants/package-lock.json
@@ -7330,8 +7330,7 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
       "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@eslint/object-schema": {
       "version": "3.0.5",
@@ -8218,8 +8217,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "agent-base": {
       "version": "7.1.4",
@@ -9383,8 +9381,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "fetch-blob": {
       "version": "3.2.0",
@@ -11410,8 +11407,7 @@
     "stripe": {
       "version": "22.1.0",
       "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.0.tgz",
-      "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==",
-      "requires": {}
+      "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw=="
     },
     "strnum": {
       "version": "2.2.3",

--- a/src/__tests__/PlantModal.test.jsx
+++ b/src/__tests__/PlantModal.test.jsx
@@ -88,6 +88,11 @@ vi.mock('../api/plants.js', () => ({
     add: vi.fn().mockResolvedValue({ id: 'h1', date: '2026-04-21', quantity: 1, unit: 'kg' }),
     delete: vi.fn().mockResolvedValue({ deleted: true }),
   },
+  wildlifeApi: {
+    list: vi.fn().mockResolvedValue([]),
+    add: vi.fn().mockResolvedValue({ id: 'w1', observedAt: '2026-04-21', category: 'bee', species: null, count: null, notes: null }),
+    delete: vi.fn().mockResolvedValue({ deleted: true }),
+  },
   qrApi: {
     getShortCode: vi.fn().mockResolvedValue({ shortCode: 'hp-test1', plantId: 'plant-1' }),
     scan: vi.fn().mockResolvedValue({ plantId: 'plant-1' }),
@@ -853,7 +858,7 @@ describe('PlantModal', () => {
     renderModal({ plant: existingPlant })
     expect(screen.getByRole('tablist', { name: /plant sections/i })).toBeInTheDocument()
     const tabs = screen.getAllByRole('tab')
-    expect(tabs.map((t) => t.textContent)).toEqual(['Plant', 'Watering', 'Care', 'Growth', 'Journal', 'Blooms', 'Lifecycle', 'Soil', 'Health'])
+    expect(tabs.map((t) => t.textContent)).toEqual(['Plant', 'Watering', 'Care', 'Growth', 'Journal', 'Blooms', 'Lifecycle', 'Soil', 'Health', 'Wildlife'])
   })
 
   it('marks the active tab with aria-selected="true"', () => {
@@ -884,9 +889,9 @@ describe('PlantModal', () => {
 
   it('wraps to the first tab when ArrowRight is pressed on the last tab', () => {
     renderModal({ plant: existingPlant })
-    fireEvent.click(screen.getByText('Health'))
-    const healthTab = screen.getAllByRole('tab')[8]
-    fireEvent.keyDown(healthTab, { key: 'ArrowRight' })
+    fireEvent.click(screen.getByText('Wildlife'))
+    const wildlifeTab = screen.getAllByRole('tab')[9]
+    fireEvent.keyDown(wildlifeTab, { key: 'ArrowRight' })
     expect(screen.getAllByRole('tab')[0]).toHaveAttribute('aria-selected', 'true')
   })
 
@@ -903,8 +908,8 @@ describe('PlantModal', () => {
     fireEvent.click(screen.getByText('Watering'))
     const wateringTab = screen.getAllByRole('tab')[1]
     fireEvent.keyDown(wateringTab, { key: 'End' })
-    expect(screen.getAllByRole('tab')[8]).toHaveAttribute('aria-selected', 'true')
-    fireEvent.keyDown(screen.getAllByRole('tab')[8], { key: 'Home' })
+    expect(screen.getAllByRole('tab')[9]).toHaveAttribute('aria-selected', 'true')
+    fireEvent.keyDown(screen.getAllByRole('tab')[9], { key: 'Home' })
     expect(screen.getAllByRole('tab')[0]).toHaveAttribute('aria-selected', 'true')
   })
 })

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -237,6 +237,12 @@ export const harvestApi = {
   delete: (id, harvestId) => request(`/plants/${id}/harvests/${harvestId}`, { method: 'DELETE' }),
 }
 
+export const wildlifeApi = {
+  list: (id) => request(`/plants/${id}/wildlifeObservations`),
+  add: (id, data) => request(`/plants/${id}/wildlifeObservations`, { method: 'POST', body: JSON.stringify(data) }),
+  delete: (id, obsId) => request(`/plants/${id}/wildlifeObservations/${obsId}`, { method: 'DELETE' }),
+}
+
 export const qrApi = {
   getShortCode: (id) => request(`/plants/${id}/short-code`),
   scan: (shortCode) => request(`/scan/${encodeURIComponent(shortCode)}`),

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -6,7 +6,7 @@ import WateringSheet from './WateringSheet.jsx'
 import SoilTab from './SoilTab.jsx'
 import LifecycleTab from './LifecycleTab.jsx'
 import BloomTab from './BloomTab.jsx'
-import { imagesApi, recommendApi, plantsApi, analyseApi, measurementsApi, phenologyApi, journalApi, harvestApi, incidentApi, dormancyApi } from '../api/plants.js'
+import { imagesApi, recommendApi, plantsApi, analyseApi, measurementsApi, phenologyApi, journalApi, harvestApi, wildlifeApi, incidentApi, dormancyApi } from '../api/plants.js'
 import PlantIdentify from './PlantIdentify.jsx'
 import Chart from 'react-apexcharts'
 import { getWateringStatus, getAdjustedWaterAmount, isOutdoor, getMoistureDisplay } from '../utils/watering.js'
@@ -353,6 +353,14 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   const [harvestSaving, setHarvestSaving] = useState(false)
   const [harvestError, setHarvestError] = useState(null)
 
+  // Wildlife tab state
+  const [wildlifeEntries, setWildlifeEntries] = useState(
+    () => [...(plant?.wildlifeObservationLog || [])].sort((a, b) => new Date(b.observedAt) - new Date(a.observedAt))
+  )
+  const [newWildlife, setNewWildlife] = useState({ observedAt: new Date().toISOString().slice(0, 10), category: 'bee', species: '', count: '', notes: '' })
+  const [wildlifeSaving, setWildlifeSaving] = useState(false)
+  const [wildlifeError, setWildlifeError] = useState(null)
+
   // Health tab state (incidents)
   const [incidents, setIncidents] = useState(
     () => [...(plant?.incidents || [])].sort((a, b) => new Date(b.firstObservedAt) - new Date(a.firstObservedAt))
@@ -554,6 +562,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       ...(isEditing ? [{ id: 'soil', label: 'Soil' }] : []),
       ...(isEdiblePlant ? [{ id: 'harvest', label: 'Harvest' }] : []),
       ...(isEditing ? [{ id: 'health', label: 'Health' }] : []),
+      ...(isEditing ? [{ id: 'wildlife', label: 'Wildlife' }] : []),
     ],
     [isEdiblePlant, isEditing],
   )
@@ -739,6 +748,33 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       await harvestApi.delete(plant.id, harvestId)
       setHarvestEntries(prev => prev.filter(e => e.id !== harvestId))
     } catch (err) { console.error('Delete harvest entry failed:', err) }
+  }, [plant])
+
+  const handleAddWildlife = useCallback(async () => {
+    setWildlifeSaving(true)
+    setWildlifeError(null)
+    try {
+      const entry = await wildlifeApi.add(plant.id, {
+        observedAt: newWildlife.observedAt,
+        category: newWildlife.category,
+        species: newWildlife.species.trim() || null,
+        count: newWildlife.count ? Number(newWildlife.count) : null,
+        notes: newWildlife.notes.trim() || null,
+      })
+      setWildlifeEntries(prev => [entry, ...prev])
+      setNewWildlife({ observedAt: new Date().toISOString().slice(0, 10), category: 'bee', species: '', count: '', notes: '' })
+    } catch (err) {
+      setWildlifeError(friendlyErrorMessage(err))
+    } finally {
+      setWildlifeSaving(false)
+    }
+  }, [newWildlife, plant])
+
+  const handleDeleteWildlife = useCallback(async (obsId) => {
+    try {
+      await wildlifeApi.delete(plant.id, obsId)
+      setWildlifeEntries(prev => prev.filter(e => e.id !== obsId))
+    } catch (err) { console.error('Delete wildlife observation failed:', err) }
   }, [plant])
 
   const handleAddIncident = useCallback(async () => {
@@ -2250,6 +2286,69 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
               <Button variant="link" size="sm" className="text-danger p-0 fs-xs d-block mt-2" onClick={() => handleDeleteIncident(incident.id)}>
                 Delete
               </Button>
+            </div>
+          ))}
+        </Modal.Body>
+      )}
+
+      {/* Wildlife tab — pollinator & visitor log */}
+      {isEditing && activeTab === 'wildlife' && (
+        <Modal.Body role="tabpanel" id="plant-tabpanel-wildlife" aria-labelledby="plant-tab-wildlife" className="pt-3 pb-4">
+          <h6 className="fw-600 mb-3">Log Wildlife Observation</h6>
+          {wildlifeError && <div className="alert alert-danger py-2 fs-sm mb-3">{wildlifeError}</div>}
+          <Row className="g-2 mb-3">
+            <Col xs={6}>
+              <Form.Select size="sm" aria-label="Category" value={newWildlife.category}
+                onChange={e => setNewWildlife(p => ({ ...p, category: e.target.value }))}>
+                <option value="bee">Bee</option>
+                <option value="butterfly">Butterfly</option>
+                <option value="bird">Bird</option>
+                <option value="other-insect">Other insect</option>
+                <option value="mammal">Mammal</option>
+                <option value="reptile">Reptile</option>
+                <option value="other">Other</option>
+              </Form.Select>
+            </Col>
+            <Col xs={6}>
+              <Form.Control size="sm" placeholder="Species (optional)" aria-label="Species" value={newWildlife.species}
+                onChange={e => setNewWildlife(p => ({ ...p, species: e.target.value }))} />
+            </Col>
+            <Col xs={4}>
+              <Form.Control size="sm" type="date" aria-label="Date observed" value={newWildlife.observedAt}
+                onChange={e => setNewWildlife(p => ({ ...p, observedAt: e.target.value }))} />
+            </Col>
+            <Col xs={4}>
+              <Form.Control size="sm" type="number" min="1" placeholder="Count" aria-label="Count" value={newWildlife.count}
+                onChange={e => setNewWildlife(p => ({ ...p, count: e.target.value }))} />
+            </Col>
+            <Col xs={4}>
+              <Button size="sm" variant="primary" className="w-100" onClick={handleAddWildlife} disabled={wildlifeSaving}>
+                {wildlifeSaving ? <Spinner size="sm" /> : 'Log'}
+              </Button>
+            </Col>
+            <Col xs={12}>
+              <Form.Control size="sm" as="textarea" rows={2} placeholder="Notes (optional)" aria-label="Notes" value={newWildlife.notes}
+                onChange={e => setNewWildlife(p => ({ ...p, notes: e.target.value }))} />
+            </Col>
+          </Row>
+
+          <hr className="my-3" />
+          <h6 className="fw-600 mb-2">Observation History</h6>
+          {wildlifeEntries.length === 0 ? (
+            <p className="text-muted text-center py-3 mb-0 fs-sm">
+              No observations logged yet. Record the pollinators and wildlife visiting this plant.
+            </p>
+          ) : wildlifeEntries.map(obs => (
+            <div key={obs.id} className="border rounded p-3 mb-2">
+              <div className="d-flex align-items-center gap-2">
+                <Badge bg="success" className="fs-xs text-capitalize">{obs.category.replace('-', ' ')}</Badge>
+                {obs.species && <span className="fw-500 fs-sm">{obs.species}</span>}
+                {obs.count && <Badge bg="light" text="dark" className="fs-xs">×{obs.count}</Badge>}
+                <span className="ms-auto fs-xs text-muted">{obs.observedAt?.slice(0, 10)}</span>
+                <Button variant="link" size="sm" className="text-danger p-0 fs-xs" aria-label="Delete observation"
+                  onClick={() => handleDeleteWildlife(obs.id)}>Delete</Button>
+              </div>
+              {obs.notes && <p className="mb-0 mt-1 fs-xs text-muted">{obs.notes}</p>}
             </div>
           ))}
         </Modal.Body>


### PR DESCRIPTION
## Summary

- Adds `wildlifeObservationLog` to the plant document for recording pollinator and wildlife sightings (bee, butterfly, bird, other-insect, mammal, reptile, other)
- New `GET / POST / DELETE /plants/:id/wildlifeObservations` backend routes following the existing harvest/measurement pattern
- New **Wildlife** tab in PlantModal (after Health) with a log form and observation history list
- `wildlifeApi` exported from `src/api/plants.js`

## Test plan

- [x] 15 new backend unit tests: auth (401/404), category validation (400), count validation (400), create (201 + persistence), all-category smoke test, sort order, idempotent delete
- [x] PlantModal.test.jsx tab list snapshot updated to 10 tabs; keyboard-roving `End`/`ArrowRight` index references updated
- [x] `npm run preflight` green: 835 frontend tests + 576 backend tests, build clean

Closes #306

https://claude.ai/code/session_011qRLck5QjugbefDvVUAPrq

---
_Generated by [Claude Code](https://claude.ai/code/session_011qRLck5QjugbefDvVUAPrq)_