### PR TITLE
fix(#232): close 7 CodeQL high-sev alerts on household routes

### DIFF
--- a/api/plants/households.js
+++ b/api/plants/households.js
@@ -29,12 +29,31 @@ function roleMeetsMinimum(actual, minimum) {
 
 const SHARE_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no I/O/0/1
 function generateShareCode() {
+  // crypto.randomInt is unbiased (rejection-sampled internally) so we avoid
+  // CodeQL's modulo-on-crypto-random warning even though our 32-char alphabet
+  // would in fact divide a uint8 evenly.
   let out = '';
-  const buf = crypto.randomBytes(8);
   for (let i = 0; i < 8; i++) {
-    out += SHARE_CODE_ALPHABET[buf[i] % SHARE_CODE_ALPHABET.length];
+    out += SHARE_CODE_ALPHABET[crypto.randomInt(0, SHARE_CODE_ALPHABET.length)];
   }
   return out;
+}
+
+// Validate a string we're about to use as a dynamic object key. JWT subs and
+// path-param userIds are otherwise trusted (the gateway verifies the JWT, and
+// path params are scoped by an owner check) but using a user-controlled value
+// as a computed property name still trips CodeQL's "remote property injection"
+// rule. This belt-and-braces guard rejects anything that isn't a plain
+// identifier-shaped string and the well-known prototype-pollution keys.
+const SAFE_KEY_RE = /^[A-Za-z0-9_-]{1,128}$/;
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+function safeUserKey(id) {
+  if (typeof id !== 'string' || !SAFE_KEY_RE.test(id) || FORBIDDEN_KEYS.has(id)) {
+    const err = new Error('invalid_user_id');
+    err.code = 'invalid_user_id';
+    throw err;
+  }
+  return id;
 }
 
 function householdsRef(db) {
@@ -80,13 +99,14 @@ async function ensurePersonalHousehold(db, userId, displayName) {
   }
 
   const now = new Date().toISOString();
+  const ownerKey = safeUserKey(userId);
   const householdData = {
     name: 'My Plants',
     ownerId: userId,
     createdAt: now,
     updatedAt: now,
     members: {
-      [userId]: {
+      [ownerKey]: {
         role: 'owner',
         displayName: displayName || null,
         joinedAt: now,
@@ -229,14 +249,15 @@ async function acceptInvite(db, { code, actorUserId, actorDisplayName }) {
   // Already a member? still OK — accepting is idempotent. Otherwise
   // append to the members map with the invite's role.
   const now = new Date().toISOString();
-  const existing = household.members?.[actorUserId];
+  const memberKey = safeUserKey(actorUserId);
+  const existing = household.members?.[memberKey];
   const newMember = existing || {
     role: invite.role,
     displayName: actorDisplayName || null,
     joinedAt: now,
   };
   await householdsRef(db).doc(household.id).set({
-    members: { ...(household.members || {}), [actorUserId]: newMember },
+    members: { ...(household.members || {}), [memberKey]: newMember },
     updatedAt: now,
   }, { merge: true });
 
@@ -255,7 +276,7 @@ async function acceptInvite(db, { code, actorUserId, actorDisplayName }) {
     updatedAt: now,
   });
 
-  return { household: { ...household, members: { ...(household.members || {}), [actorUserId]: newMember } }, role: newMember.role };
+  return { household: { ...household, members: { ...(household.members || {}), [memberKey]: newMember } }, role: newMember.role };
 }
 
 async function listHouseholdsForUser(db, userId) {
@@ -273,6 +294,7 @@ module.exports = {
   ROLE_LEVELS,
   roleMeetsMinimum,
   generateShareCode,
+  safeUserKey,
   ensurePersonalHousehold,
   resolveHouseholdContext,
   requireRole,

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1335,7 +1335,7 @@ app.post('/households', requireUser, async (req, res) => {
       createdAt: now,
       updatedAt: now,
       members: {
-        [req.actorUserId]: {
+        [households.safeUserKey(req.actorUserId)]: {
           role: 'owner',
           displayName: req.actorDisplayName || null,
           joinedAt: now,
@@ -1459,11 +1459,15 @@ app.delete('/households/:id/members/:userId', requireUser, async (req, res) => {
     if (!actor || !households.roleMeetsMinimum(actor.role, 'owner')) {
       return res.status(403).json({ error: 'forbidden_role', requiredRole: 'owner', currentRole: actor?.role || null });
     }
-    const targetId = req.params.userId;
+    let targetId;
+    try { targetId = households.safeUserKey(req.params.userId); }
+    catch { return res.status(400).json({ error: 'Invalid userId' }); }
     if (targetId === hh.ownerId) {
       return res.status(400).json({ error: 'Cannot remove the household owner' });
     }
-    if (!hh.members[targetId]) return res.status(404).json({ error: 'Member not found' });
+    if (!Object.prototype.hasOwnProperty.call(hh.members || {}, targetId)) {
+      return res.status(404).json({ error: 'Member not found' });
+    }
     const newMembers = { ...hh.members };
     delete newMembers[targetId];
     await households.householdsRef(db).doc(hh.id).set({
@@ -1497,12 +1501,17 @@ app.put('/households/:id/members/:userId', requireUser, async (req, res) => {
     if (!['viewer', 'editor', 'owner'].includes(role)) {
       return res.status(400).json({ error: 'role must be one of: viewer, editor, owner' });
     }
-    const targetId = req.params.userId;
+    let targetId;
+    try { targetId = households.safeUserKey(req.params.userId); }
+    catch { return res.status(400).json({ error: 'Invalid userId' }); }
     if (targetId === hh.ownerId && role !== 'owner') {
       return res.status(400).json({ error: 'Cannot demote the household owner' });
     }
-    if (!hh.members[targetId]) return res.status(404).json({ error: 'Member not found' });
-    const newMembers = { ...hh.members, [targetId]: { ...hh.members[targetId], role } };
+    if (!Object.prototype.hasOwnProperty.call(hh.members || {}, targetId)) {
+      return res.status(404).json({ error: 'Member not found' });
+    }
+    const existingMember = hh.members[targetId];
+    const newMembers = { ...hh.members, [targetId]: { ...existingMember, role } };
     await households.householdsRef(db).doc(hh.id).set({
       members: newMembers,
       updatedAt: new Date().toISOString(),

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -5583,4 +5583,21 @@ describe('households', () => {
       .send({ role: 'viewer' });
     expect(res.status).toBe(403);
   });
+
+  it('rejects member-management calls with prototype-pollution-shaped userIds', async () => {
+    const list = await request(app).get('/households').set('Authorization', authHeader('alice'));
+    const householdId = list.body.households[0].id;
+    const remove = await request(app)
+      .delete(`/households/${householdId}/members/__proto__`)
+      .set('Authorization', authHeader('alice'));
+    expect(remove.status).toBe(400);
+    expect(remove.body.error).toBe('Invalid userId');
+
+    const role = await request(app)
+      .put(`/households/${householdId}/members/constructor`)
+      .set('Authorization', authHeader('alice'))
+      .send({ role: 'editor' });
+    expect(role.status).toBe(400);
+    expect(role.body.error).toBe('Invalid userId');
+  });
 });


### PR DESCRIPTION
## Summary

CI on #356 (households / multi-user feature) merged into main with **7 high-severity CodeQL alerts** in the new code:

| Alert | Location | Rule |
|---|---|---|
| Biased cryptographic random | `households.js:35` (`generateShareCode`) | `js/biased-cryptographic-random` |
| Remote property injection ×6 | `households.js:89, 239, 258`, `index.js:1338, 1468, 1505` | `js/remote-property-injection` |

Neither family was exploitable in practice — JWT subs come pre-verified from API Gateway, the path-param target on `/members/:userId` is gated by an owner check first, and our 32-char alphabet divides 256 evenly so the modulo wasn't actually biased — but both deserve a defense-in-depth fix and CodeQL is right to flag them.

## What changed

- **`generateShareCode`**: swapped `crypto.randomBytes(8)[i] % alphabet.length` for `crypto.randomInt(0, alphabet.length)`. `randomInt` rejection-samples internally and is CodeQL-clean even when the alphabet would divide evenly.
- **New `safeUserKey(id)` helper** in `households.js`: validates against `/^[A-Za-z0-9_-]{1,128}$/` and explicitly rejects `__proto__` / `constructor` / `prototype`. Throws `invalid_user_id` on any violation.
- **All six dynamic-key writes routed through it** — `members: { [ownerKey]: … }`, `[memberKey]: newMember`, `delete newMembers[targetId]`, and `newMembers[targetId] = { … }` — across both `households.js` (`ensurePersonalHousehold`, `acceptInvite`) and `index.js` (`POST /households`, `DELETE /households/:id/members/:userId`, `PUT /households/:id/members/:userId`).
- Member existence checks switched from `if (!hh.members[targetId])` to `Object.prototype.hasOwnProperty.call(hh.members || {}, targetId)` so a key like `toString` can't accidentally satisfy a truthiness check.
- New backend test asserts that `DELETE /households/:id/members/__proto__` and `PUT /households/:id/members/constructor` both return `400 Invalid userId` (instead of poking the members map).

No behaviour change for any well-formed JWT sub or path param — Google subs are 21-digit numerics; the test data (`alice`, `viewerbob`, `user-test-1`) all match the safe-key regex.

## Test plan

- [x] `npm run lint` (backend) — clean
- [x] `npm run preflight` — 588 backend + 835 frontend tests pass
- [x] New `rejects member-management calls with prototype-pollution-shaped userIds` test passes
- [x] All existing 11 household tests continue to pass
- [ ] CI re-runs CodeQL on the PR — expect zero alerts on the fixed code paths

Refs: #232, #212, follow-up to #356.

https://claude.ai/code/session_0155mZPnuApzFZ9cvQHj4Cwg

---
_Generated by [Claude Code](https://claude.ai/code/session_0155mZPnuApzFZ9cvQHj4Cwg)_