### PR TITLE
feat: left-rail nav for /plants/:id (PR 4/5 — hybrid plant-detail plan)

### DIFF
--- a/src/__tests__/PlantModal.test.jsx
+++ b/src/__tests__/PlantModal.test.jsx
@@ -147,6 +147,7 @@ function renderModal(props = {}) {
         onWater={props.onWater}
         onMoisture={props.onMoisture ?? vi.fn()}
         onClose={props.onClose ?? vi.fn()}
+        embedded={props.embedded ?? false}
       />
     </MemoryRouter>
   )
@@ -917,6 +918,36 @@ describe('PlantModal', () => {
     expect(lastTab()).toHaveAttribute('aria-selected', 'true')
     fireEvent.keyDown(lastTab(), { key: 'Home' })
     expect(firstTab()).toHaveAttribute('aria-selected', 'true')
+  })
+
+  // ── Embedded (page route) rail layout ─────────────────────────────────────
+
+  it('renders the tablist with vertical orientation when embedded', () => {
+    renderModal({ plant: existingPlant, embedded: true })
+    const tablist = screen.getByRole('tablist', { name: /plant sections/i })
+    expect(tablist).toHaveAttribute('aria-orientation', 'vertical')
+    expect(tablist).toHaveClass('plant-modal-rail')
+  })
+
+  it('keeps the horizontal nav-tabs class when not embedded', () => {
+    renderModal({ plant: existingPlant })
+    const tablist = screen.getByRole('tablist', { name: /plant sections/i })
+    expect(tablist).toHaveAttribute('aria-orientation', 'horizontal')
+    expect(tablist).toHaveClass('nav-tabs')
+    expect(tablist).not.toHaveClass('plant-modal-rail')
+  })
+
+  it('moves to the next tab when ArrowDown is pressed in embedded mode', () => {
+    renderModal({ plant: existingPlant, embedded: true })
+    fireEvent.keyDown(tab('Plant'), { key: 'ArrowDown' })
+    expect(tab('Watering')).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('moves to the previous tab when ArrowUp is pressed in embedded mode', () => {
+    renderModal({ plant: existingPlant, embedded: true })
+    fireEvent.click(tab('Watering'))
+    fireEvent.keyDown(tab('Watering'), { key: 'ArrowUp' })
+    expect(tab('Plant')).toHaveAttribute('aria-selected', 'true')
   })
 })
 

--- a/src/assets/sass/app/_plant-tracker.scss
+++ b/src/assets/sass/app/_plant-tracker.scss
@@ -284,3 +284,40 @@
     transition: none !important;
   }
 }
+
+/* ── /plants/:id detail shell ─────────────────────────────────────────── */
+
+/* The page route reuses PlantModal in `embedded` mode and renders a
+   left-rail nav next to the active section body on md+. CSS Grid handles
+   the layout: header and footer span both columns, the rail sits in
+   column 1, and whichever Modal.Body is active for the current tab fills
+   column 2. Multiple body candidates exist in the JSX but only one is
+   conditionally rendered at a time, so they all safely share row 2. */
+@media (min-width: 768px) {
+  .plant-detail-shell {
+    display: grid;
+    grid-template-columns: 220px minmax(0, 1fr);
+    grid-template-rows: auto 1fr auto;
+  }
+
+  .plant-detail-shell > .modal-header,
+  .plant-detail-shell > .modal-footer {
+    grid-column: 1 / -1;
+  }
+
+  .plant-detail-shell > .plant-modal-rail {
+    grid-column: 1;
+    grid-row: 2;
+    align-self: stretch;
+    border-right: 1px solid var(--bs-border-color);
+    border-bottom: 0 !important;
+    flex-direction: column !important;
+    overflow-y: auto;
+  }
+
+  .plant-detail-shell > .modal-body {
+    grid-column: 2;
+    grid-row: 2;
+    min-width: 0;
+  }
+}

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -622,10 +622,10 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   }, [])
 
   const handleTabKeyDown = useCallback((e, index) => {
-    if (e.key === 'ArrowRight') {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
       e.preventDefault()
       setActiveTab(TABS[(index + 1) % TABS.length].id)
-    } else if (e.key === 'ArrowLeft') {
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
       e.preventDefault()
       setActiveTab(TABS[(index - 1 + TABS.length) % TABS.length].id)
     } else if (e.key === 'Home') {
@@ -965,9 +965,22 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       {/* Tab nav for editing — WAI-ARIA Tabs Pattern. Using native buttons
           (rather than Nav.Link) so aria-controls / aria-selected are preserved
           exactly as set; React-Bootstrap's Nav.Link filters them when it's not
-          nested inside a Tab.Container. */}
+          nested inside a Tab.Container.
+
+          When `embedded` (page route), the nav renders as a vertical left rail
+          on md+ next to the active section body. The dialog modal keeps its
+          horizontal nav-tabs above the body. */}
       {isEditing && (
-        <ul className="nav nav-tabs px-3 pt-2" role="tablist" aria-label="Plant sections">
+        <ul
+          className={
+            embedded
+              ? 'nav nav-pills plant-modal-rail flex-row flex-md-column gap-1 p-2 mb-0 flex-nowrap overflow-auto border-bottom border-md-0'
+              : 'nav nav-tabs px-3 pt-2'
+          }
+          role="tablist"
+          aria-label="Plant sections"
+          aria-orientation={embedded ? 'vertical' : 'horizontal'}
+        >
           {TABS.map((tab, i) => {
             const selected = activeTab === tab.id
             return (
@@ -979,7 +992,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
                   aria-selected={selected}
                   aria-controls={`plant-tabpanel-${tab.id}`}
                   tabIndex={selected ? 0 : -1}
-                  className={`nav-link${selected ? ' active' : ''}`}
+                  className={`nav-link${selected ? ' active' : ''}${embedded ? ' text-start' : ''}`}
                   onClick={() => setActiveTab(tab.id)}
                   onKeyDown={(e) => handleTabKeyDown(e, i)}
                 >
@@ -2467,7 +2480,7 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   return (
     <>
     {embedded ? (
-      <div className="modal-content position-relative shadow-sm" aria-labelledby="plant-modal-title">
+      <div className="modal-content position-relative shadow-sm plant-detail-shell" aria-labelledby="plant-modal-title">
         {innerContent}
       </div>
     ) : (


### PR DESCRIPTION
## Summary

Stacked on [#358](https://github.com/lopeztech/home-plant-tracker/pull/358), [#359](https://github.com/lopeztech/home-plant-tracker/pull/359), [#360](https://github.com/lopeztech/home-plant-tracker/pull/360). Targeted at `main` for CI; once the predecessors merge the diff collapses to just this PR's increment.

The `/plants/:id` page reuses `PlantModal` in `embedded` mode. Until now the embedded variant kept the dialog modal's horizontal nav-tabs above the section body — fine for a centered modal but a poor use of horizontal real estate on a wide page. Switch the embedded rendering to a vertical left-rail on md+. The dialog modal is untouched.

## Changes

- **`src/components/PlantModal.jsx`** — swaps the tablist `<ul>`'s classes when `embedded`: `nav-pills` + `flex-md-column`, falls back to a horizontal pill scroller below the md breakpoint. Sets `aria-orientation="vertical"`. Adds the `plant-detail-shell` marker class on the embedded outer wrapper.
- **`src/components/PlantModal.jsx`** — `handleTabKeyDown` now treats `ArrowDown`/`ArrowUp` as aliases of `ArrowRight`/`ArrowLeft`, so the rail gets the keyboard semantics WAI-ARIA expects for a vertical tablist. Existing Left/Right tests keep passing.
- **`src/assets/sass/app/_plant-tracker.scss`** — new CSS-Grid rule on `.plant-detail-shell` (md+) with `grid-template-columns: 220px 1fr`. Header and footer span both columns; the rail sits in column 1, whichever `.modal-body` is currently active fills column 2. Multiple `.modal-body` candidates exist in the JSX but only one renders at a time, so they all safely share row 2.
- **`src/__tests__/PlantModal.test.jsx`** — opt-in `embedded` arg on `renderModal`. Four new assertions cover orientation, class selection (rail vs nav-tabs), ArrowDown, and ArrowUp.

## Plan re-split (recap from PR 3)

- **PR 4 (this one)** — left-rail nav.
- **PR 5** — slim the dashboard quick-modal to action buttons only.

Section-component extraction (pulling each of the 11 tab bodies into its own file) would be a structural refactor with no user-visible change. Deferred to a follow-up so PR 4 stays small and reviewable; the rail layout doesn't depend on extraction.

## Test plan

- [x] `npx vitest run src/__tests__/PlantModal.test.jsx src/__tests__/PlantDetailPage.test.jsx` — 109 pass
- [x] `npx vitest run` — full suite, 849/849 pass
- [x] `npm run preflight:fast` — clean
- [ ] Manually verify in browser:
  - [ ] `/plants/:id` on desktop shows a vertical rail on the left, body fills the rest
  - [ ] On mobile (≤768px), rail collapses to a horizontal scroller above the body
  - [ ] Clicking a rail tab updates the URL hash and the body
  - [ ] Up/Down arrows on a rail tab move focus to the prev/next tab
  - [ ] Modal variant (open quick-modal from dashboard) still uses the horizontal nav-tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)