### PR TITLE
ci: serialize deploys + drop docker dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,17 +33,6 @@ updates:
       - dependency-name: "uuid"
         update-types: ["version-update:semver-major"]
 
-  # Docker base images
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-      time: "09:00"
-      timezone: Australia/Sydney
-    labels:
-      - dependencies
-
   # GitHub Actions
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,16 @@ on:
       - main
   workflow_dispatch:
 
+# Serialise per-ref. On main, rapid-fire merges would otherwise overlap deploys,
+# leaving the post-deploy Playwright smoke loading an index.html whose lazy
+# chunks were already replaced by a newer deploy in flight (MIME=text/html on
+# the missing chunk → SPA-rewrite to index.html → "Failed to load module
+# script"). Cancel-in-progress is safe because Firebase Hosting deploys are
+# atomic; killing mid-upload just discards the unfinished version.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write  # Required for Workload Identity Federation
@@ -312,9 +322,12 @@ jobs:
         run: npx playwright install chromium webkit firefox
 
       # Give Firebase Hosting a beat to propagate the new bundle to the CDN
-      # before we start hitting it.
+      # before we start hitting it. Bumped from 20s after a chunk-mismatch
+      # smoke failure: the new deploy hadn't fully fanned out across edges,
+      # so a fresh page load could grab one edge's index.html while a lazy
+      # chunk request hit another edge serving the previous version.
       - name: Wait for deploy to propagate
-        run: sleep 20
+        run: sleep 60
 
       - name: Run Playwright smoke against production
         env:


### PR DESCRIPTION
## Summary

Two unrelated CI failure modes that share a root cause: the workflows weren't matched to how the project actually ships.

### deploy.yml — concurrency + longer propagation wait
Rapid-fire merges to main were overlapping deploys. The post-deploy Playwright smoke for an earlier deploy would load an \`index.html\` whose lazy chunks had already been replaced by a newer deploy still rolling out across Firebase Hosting edges. The missing chunk request hit the SPA rewrite, came back as \`text/html\`, and tripped strict MIME checking (\`Failed to load module script\`).

- Add workflow-level \`cancel-in-progress\` concurrency keyed on \`github.ref\` so only the freshest deploy runs. Safe because Firebase Hosting deploys are atomic — killing mid-upload just discards the unfinished version.
- Bump post-deploy propagate sleep from 20s → 60s for CDN fan-out.

Failure that motivated this: [run 24973032533](https://github.com/lopeztech/home-plant-tracker/actions/runs/24973032533) — \`/privacy\` smoke against prod, dynamic import for \`PrivacyPage-D_Ka9rFV.js\` returned text/html.

### dependabot.yml — drop docker ecosystem
Repo has no Dockerfile (project ships as Cloud Run Function zip + Firebase Hosting per CLAUDE.md). The weekly Dependabot run failed every Monday with \`No Dockerfiles nor Kubernetes YAML found in /\` ([example run](https://github.com/lopeztech/home-plant-tracker/actions/runs/24969341493)). Removed.

## Test plan
- [x] \`npm run preflight:fast\` passes locally
- [ ] CI green on this PR
- [ ] Future merge bursts: only the latest deploy's smoke runs; older are cancelled