### PR TITLE
feat(properties): multi-property management for landscapers

### DIFF
--- a/api/plants/billing.js
+++ b/api/plants/billing.js
@@ -20,7 +20,7 @@ const TIERS = {
       plants:            Infinity,
       ai_analyses:       Infinity,
       photo_storage_mb:  2048,
-      properties:        1,
+      properties:        3,
       team_members:      0,
     },
   },
@@ -123,6 +123,11 @@ async function countPlants(db, userId) {
   return snap.docs.length;
 }
 
+async function countProperties(db, userId) {
+  const snap = await db.collection('users').doc(userId).collection('properties').get();
+  return snap.docs.filter(d => !d.data().archived).length;
+}
+
 async function readAiAnalysesUsage(db, userId, key = monthKey()) {
   const ref = db.collection('users').doc(userId).collection('usage').doc(key);
   const snap = await ref.get();
@@ -210,6 +215,7 @@ module.exports = {
   tierMeetsMinimum,
   tierQuota,
   countPlants,
+  countProperties,
   readAiAnalysesUsage,
   incrementAiAnalyses,
   readStorageUsageMb,

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -174,6 +174,21 @@ function userPropagations(userId) {
   return db.collection('users').doc(userId).collection('propagations');
 }
 
+function userProperties(userId) {
+  return db.collection('users').doc(userId).collection('properties');
+}
+
+// Synthesise the implicit 'primary' property for users who pre-date multi-property.
+async function synthPrimary(userId) {
+  const ref = userProperties(userId).doc('primary');
+  const snap = await ref.get();
+  if (snap.exists) return { id: 'primary', ...snap.data() };
+  const now = new Date().toISOString();
+  const data = { name: 'My Home', type: 'residential', archived: false, createdAt: now, updatedAt: now };
+  await ref.set(data);
+  return { id: 'primary', ...data };
+}
+
 // Return a signed read URL valid for 1 hour, or null if no image.
 async function signReadUrl(urlOrPath) {
   const path = gcsPath(urlOrPath);
@@ -561,8 +576,9 @@ Rules:
 
 const { requireTier, checkQuota } = createTierGate(db);
 
-const countPlantsForReq   = (req) => billing.countPlants(db, req.userId);
-const countAiAnalysesForReq = (req) => billing.readAiAnalysesUsage(db, req.userId);
+const countPlantsForReq      = (req) => billing.countPlants(db, req.userId);
+const countAiAnalysesForReq  = (req) => billing.readAiAnalysesUsage(db, req.userId);
+const countPropertiesForReq  = (req) => billing.countProperties(db, req.userId);
 
 // ── Billing — non-webhook routes ─────────────────────────────────────────────
 // (Webhook is declared earlier, before express.json(), to keep the raw body
@@ -1840,6 +1856,110 @@ app.use((req, res, next) => {
   });
 });
 
+// ── Properties CRUD ───────────────────────────────────────────────────────────
+// Properties scope plant inventories for Landscaper Pro users.
+// Free users implicitly have one property ('primary'); home_pro up to 3.
+
+app.get('/properties', requireUser, async (req, res) => {
+  try {
+    const snap = await userProperties(req.userId).get();
+    let items = snap.docs
+      .map((d) => ({ id: d.id, ...d.data() }))
+      .filter((p) => !p.archived);
+    if (items.length === 0) {
+      const primary = await synthPrimary(req.userId);
+      items = [primary];
+    }
+    res.status(200).json({ properties: items });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/properties', requireUser, requireTier('home_pro'), checkQuota('properties', countPropertiesForReq), async (req, res) => {
+  try {
+    const { name, address, lat, lng, type, notes } = req.body;
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      return res.status(400).json({ error: 'name is required' });
+    }
+    const now = new Date().toISOString();
+    const data = {
+      name: name.trim(),
+      address: address || null,
+      lat: lat ?? null,
+      lng: lng ?? null,
+      type: type || 'residential',
+      notes: notes || '',
+      archived: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const ref = await userProperties(req.userId).add(data);
+    res.status(201).json({ id: ref.id, ...data });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/properties/:id', requireUser, async (req, res) => {
+  try {
+    const snap = await userProperties(req.userId).doc(req.params.id).get();
+    if (!snap.exists || snap.data().archived) return res.status(404).json({ error: 'not_found' });
+    res.status(200).json({ id: snap.id, ...snap.data() });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.put('/properties/:id', requireUser, requireTier('home_pro'), async (req, res) => {
+  try {
+    const ref = userProperties(req.userId).doc(req.params.id);
+    const snap = await ref.get();
+    if (!snap.exists || snap.data().archived) return res.status(404).json({ error: 'not_found' });
+    const { name, address, lat, lng, type, notes } = req.body;
+    const update = { updatedAt: new Date().toISOString() };
+    if (name !== undefined) update.name = String(name).trim();
+    if (address !== undefined) update.address = address;
+    if (lat !== undefined) update.lat = lat;
+    if (lng !== undefined) update.lng = lng;
+    if (type !== undefined) update.type = type;
+    if (notes !== undefined) update.notes = notes;
+    await ref.set(update, { merge: true });
+    const updated = await ref.get();
+    res.status(200).json({ id: updated.id, ...updated.data() });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.delete('/properties/:id', requireUser, requireTier('home_pro'), async (req, res) => {
+  try {
+    if (req.params.id === 'primary') {
+      return res.status(400).json({ error: 'cannot_delete_primary' });
+    }
+    const ref = userProperties(req.userId).doc(req.params.id);
+    const snap = await ref.get();
+    if (!snap.exists) return res.status(404).json({ error: 'not_found' });
+    await ref.set({ archived: true, updatedAt: new Date().toISOString() }, { merge: true });
+    res.status(200).json({ archived: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/properties/:id/restore', requireUser, requireTier('home_pro'), async (req, res) => {
+  try {
+    const ref = userProperties(req.userId).doc(req.params.id);
+    const snap = await ref.get();
+    if (!snap.exists) return res.status(404).json({ error: 'not_found' });
+    await ref.set({ archived: false, updatedAt: new Date().toISOString() }, { merge: true });
+    const updated = await ref.get();
+    res.status(200).json({ id: updated.id, ...updated.data() });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Plants CRUD ───────────────────────────────────────────────────────────────
 
 app.get('/plants', requireUser, async (req, res) => {
@@ -1850,6 +1970,7 @@ app.get('/plants', requireUser, async (req, res) => {
     // Without params the legacy flat array is returned for backward compat.
     const rawLimit = req.query.limit !== undefined ? Number(req.query.limit) : null;
     const after    = req.query.after || null;
+    const propertyId = req.query.propertyId || null;
     const paginated = rawLimit !== null || after !== null;
     const limit = rawLimit ? Math.min(rawLimit, 200) : 200;
 
@@ -1862,11 +1983,17 @@ app.get('/plants', requireUser, async (req, res) => {
     const nextCursor = hasMore ? docs[docs.length - 1].data().createdAt : null;
 
     const plants = await Promise.all(
-      docs.map(async (doc) => {
-        const data = { id: doc.id, ...doc.data() };
-        await signPlantData(data);
-        return data;
-      })
+      docs
+        .filter((doc) => {
+          if (!propertyId) return true;
+          const pid = doc.data().propertyId || 'primary';
+          return pid === propertyId;
+        })
+        .map(async (doc) => {
+          const data = { id: doc.id, ...doc.data() };
+          await signPlantData(data);
+          return data;
+        })
     );
 
     if (paginated) {

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -5978,3 +5978,106 @@ describe('GET /plants — propertyId filter', () => {
     expect(res.body).toHaveLength(2);
   });
 });
+
+describe('GET /properties/:id', () => {
+  it('returns a single property by id', async () => {
+    store[propDocPath('prop-detail')] = { name: 'Garden Flat', archived: false, type: 'residential' };
+    const res = await request(app)
+      .get('/properties/prop-detail')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('prop-detail');
+    expect(res.body.name).toBe('Garden Flat');
+  });
+
+  it('returns 404 for an unknown id', async () => {
+    const res = await request(app)
+      .get('/properties/does-not-exist')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for an archived property', async () => {
+    store[propDocPath('archived')] = { name: 'Old Place', archived: true };
+    const res = await request(app)
+      .get('/properties/archived')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).get('/properties/any');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PUT /properties/:id', () => {
+  beforeEach(() => {
+    process.env.BILLING_ENABLED = 'true';
+    store[`users/${USER_SUB}/subscription/current`] = { tier: 'home_pro', status: 'active' };
+    store[propDocPath('p-edit')] = { name: 'Old Name', type: 'residential', archived: false };
+  });
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('updates a property name', async () => {
+    const res = await request(app)
+      .put('/properties/p-edit')
+      .set('Authorization', authHeader())
+      .send({ name: 'New Name' });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('New Name');
+  });
+
+  it('updates type and notes', async () => {
+    const res = await request(app)
+      .put('/properties/p-edit')
+      .set('Authorization', authHeader())
+      .send({ type: 'commercial', notes: 'Big client' });
+    expect(res.status).toBe(200);
+    expect(res.body.type).toBe('commercial');
+    expect(res.body.notes).toBe('Big client');
+  });
+
+  it('returns 404 for unknown property', async () => {
+    const res = await request(app)
+      .put('/properties/no-such-prop')
+      .set('Authorization', authHeader())
+      .send({ name: 'X' });
+    expect(res.status).toBe(404);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).put('/properties/p-edit').send({ name: 'X' });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /properties/:id/restore', () => {
+  beforeEach(() => {
+    process.env.BILLING_ENABLED = 'true';
+    store[`users/${USER_SUB}/subscription/current`] = { tier: 'home_pro', status: 'active' };
+    store[propDocPath('p-archived')] = { name: 'Restored Garden', archived: true };
+  });
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('restores an archived property', async () => {
+    const res = await request(app)
+      .post('/properties/p-archived/restore')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.archived).toBe(false);
+    expect(store[propDocPath('p-archived')].archived).toBe(false);
+  });
+
+  it('returns 404 for unknown property', async () => {
+    const res = await request(app)
+      .post('/properties/no-such/restore')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).post('/properties/p-archived/restore');
+    expect(res.status).toBe(401);
+  });
+});

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -5788,3 +5788,193 @@ describe('GET /config/beds/:roomId/compatibility', () => {
     expect(res.status).toBe(401);
   });
 });
+
+// ── Properties CRUD (#159) ────────────────────────────────────────────────────
+
+const propDocPath = (id) => `users/${USER_SUB}/properties/${id}`;
+
+describe('GET /properties — lazy primary synthesis', () => {
+  it('returns primary property when none exist', async () => {
+    const res = await request(app).get('/properties').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.properties).toHaveLength(1);
+    expect(res.body.properties[0].id).toBe('primary');
+    expect(res.body.properties[0].name).toBe('My Home');
+    expect(res.body.properties[0].archived).toBe(false);
+  });
+
+  it('persists the synthesised primary to Firestore', async () => {
+    await request(app).get('/properties').set('Authorization', authHeader());
+    expect(store[propDocPath('primary')]).toBeDefined();
+    expect(store[propDocPath('primary')].name).toBe('My Home');
+  });
+
+  it('returns existing properties without duplication', async () => {
+    store[propDocPath('primary')] = { name: 'My Home', archived: false, createdAt: '2026-01-01' };
+    store[propDocPath('p2')] = { name: 'Beach House', archived: false, createdAt: '2026-02-01' };
+    const res = await request(app).get('/properties').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.properties).toHaveLength(2);
+  });
+
+  it('excludes archived properties', async () => {
+    store[propDocPath('primary')] = { name: 'My Home', archived: false, createdAt: '2026-01-01' };
+    store[propDocPath('archived-one')] = { name: 'Old Property', archived: true, createdAt: '2026-01-15' };
+    const res = await request(app).get('/properties').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.properties).toHaveLength(1);
+    expect(res.body.properties[0].id).toBe('primary');
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).get('/properties');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /properties — create', () => {
+  beforeEach(() => {
+    process.env.BILLING_ENABLED = 'true';
+    store[`users/${USER_SUB}/subscription/current`] = { tier: 'home_pro', status: 'active' };
+  });
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('creates a new property and returns 201', async () => {
+    const res = await request(app)
+      .post('/properties')
+      .set('Authorization', authHeader())
+      .send({ name: 'Beach House', type: 'residential' });
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Beach House');
+    expect(res.body.archived).toBe(false);
+    expect(res.body.id).toBeDefined();
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const res = await request(app)
+      .post('/properties')
+      .set('Authorization', authHeader())
+      .send({ type: 'commercial' });
+    expect(res.status).toBe(400);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).post('/properties').send({ name: 'Test' });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /properties — quota enforcement (home_pro limit = 3)', () => {
+  beforeEach(() => {
+    process.env.BILLING_ENABLED = 'true';
+    store[`users/${USER_SUB}/subscription/current`] = { tier: 'home_pro', status: 'active' };
+  });
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('allows up to 3 properties for home_pro', async () => {
+    store[propDocPath('primary')] = { name: 'My Home', archived: false };
+    store[propDocPath('p2')] = { name: 'Second', archived: false };
+    const res = await request(app)
+      .post('/properties')
+      .set('Authorization', authHeader())
+      .send({ name: 'Third' });
+    expect(res.status).toBe(201);
+  });
+
+  it('blocks a 4th property for home_pro with 429 quota_exceeded', async () => {
+    store[propDocPath('primary')] = { name: 'My Home', archived: false };
+    store[propDocPath('p2')] = { name: 'Second', archived: false };
+    store[propDocPath('p3')] = { name: 'Third', archived: false };
+    const res = await request(app)
+      .post('/properties')
+      .set('Authorization', authHeader())
+      .send({ name: 'Fourth' });
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe('quota_exceeded');
+    expect(res.body.quotaType).toBe('properties');
+    expect(res.body.limit).toBe(3);
+  });
+
+  it('landscaper_pro user has unlimited properties', async () => {
+    store[`users/${USER_SUB}/subscription/current`] = { tier: 'landscaper_pro', status: 'active' };
+    for (let i = 0; i < 5; i++) {
+      store[propDocPath(`p${i}`)] = { name: `Property ${i}`, archived: false };
+    }
+    const res = await request(app)
+      .post('/properties')
+      .set('Authorization', authHeader())
+      .send({ name: 'Sixth Property' });
+    expect(res.status).toBe(201);
+  });
+});
+
+describe('DELETE /properties/:id — soft delete', () => {
+  beforeEach(() => {
+    process.env.BILLING_ENABLED = 'true';
+    store[`users/${USER_SUB}/subscription/current`] = { tier: 'home_pro', status: 'active' };
+    store[propDocPath('p-to-archive')] = { name: 'Old Garden', archived: false };
+  });
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('soft-deletes a property (sets archived: true)', async () => {
+    const res = await request(app)
+      .delete('/properties/p-to-archive')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.archived).toBe(true);
+    expect(store[propDocPath('p-to-archive')].archived).toBe(true);
+  });
+
+  it('prevents deleting the primary property', async () => {
+    store[propDocPath('primary')] = { name: 'My Home', archived: false };
+    const res = await request(app)
+      .delete('/properties/primary')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('cannot_delete_primary');
+  });
+
+  it('archived property is excluded from GET /properties', async () => {
+    await request(app).delete('/properties/p-to-archive').set('Authorization', authHeader());
+    store[propDocPath('primary')] = { name: 'My Home', archived: false };
+    const listRes = await request(app).get('/properties').set('Authorization', authHeader());
+    const ids = listRes.body.properties.map((p) => p.id);
+    expect(ids).not.toContain('p-to-archive');
+  });
+});
+
+describe('GET /plants — propertyId filter', () => {
+  it('returns only plants for the given propertyId', async () => {
+    store[plantPath('p-a1')] = { name: 'Monstera', propertyId: 'prop-a', createdAt: '2026-01-03' };
+    store[plantPath('p-a2')] = { name: 'Fern', propertyId: 'prop-a', createdAt: '2026-01-02' };
+    store[plantPath('p-b1')] = { name: 'Cactus', propertyId: 'prop-b', createdAt: '2026-01-01' };
+    const res = await request(app)
+      .get('/plants?propertyId=prop-a')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    const names = res.body.map((p) => p.name);
+    expect(names).toContain('Monstera');
+    expect(names).toContain('Fern');
+    expect(names).not.toContain('Cactus');
+  });
+
+  it('treats plants without propertyId as primary', async () => {
+    store[plantPath('no-prop')] = { name: 'Legacy Plant', createdAt: '2026-01-01' };
+    const res = await request(app)
+      .get('/plants?propertyId=primary')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    const names = res.body.map((p) => p.name);
+    expect(names).toContain('Legacy Plant');
+  });
+
+  it('returns all plants when no propertyId is provided', async () => {
+    store[plantPath('pa')] = { name: 'A', propertyId: 'prop-a', createdAt: '2026-01-02' };
+    store[plantPath('pb')] = { name: 'B', propertyId: 'prop-b', createdAt: '2026-01-01' };
+    const res = await request(app)
+      .get('/plants')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+  });
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { AuthProvider } from './contexts/AuthContext.jsx'
 import { LayoutProvider } from './context/LayoutContext.jsx'
 import { SubscriptionProvider } from './context/SubscriptionContext.jsx'
 import { HouseholdProvider } from './context/HouseholdContext.jsx'
+import { PropertyProvider } from './context/PropertyContext.jsx'
 import { ToastProvider } from './components/Toast.jsx'
 import ConsentBanner from './components/ConsentBanner.jsx'
 
@@ -19,10 +20,12 @@ export default function App() {
         <LayoutProvider>
           <SubscriptionProvider>
             <HouseholdProvider>
+            <PropertyProvider>
               <ToastProvider>
                 <Outlet />
                 <ConsentBanner />
               </ToastProvider>
+            </PropertyProvider>
             </HouseholdProvider>
           </SubscriptionProvider>
         </LayoutProvider>

--- a/src/__tests__/Sidebar.test.jsx
+++ b/src/__tests__/Sidebar.test.jsx
@@ -28,6 +28,9 @@ vi.mock('../context/TourContext.jsx', () => ({
     { id: 'floorplan', label: 'Using the floorplan' },
   ],
 }))
+vi.mock('../context/PropertyContext.jsx', () => ({
+  useProperty: () => ({ properties: [], activePropertyId: 'primary', switchTo: vi.fn() }),
+}))
 
 import Sidebar from '../layouts/components/Sidebar.jsx'
 

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -286,6 +286,15 @@ export const soilApi = {
   insight: (plantId) => request(`/plants/${plantId}/soil-insight`),
 }
 
+export const propertiesApi = {
+  list: () => request('/properties'),
+  create: (data) => request('/properties', { method: 'POST', body: JSON.stringify(data) }),
+  get: (id) => request(`/properties/${id}`),
+  update: (id, data) => request(`/properties/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  archive: (id) => request(`/properties/${id}`, { method: 'DELETE' }),
+  restore: (id) => request(`/properties/${id}/restore`, { method: 'POST', body: JSON.stringify({}) }),
+}
+
 export const accountApi = {
   deleteAccount: () => request('/account', { method: 'DELETE' }),
   exportData: () => request('/account/export'),

--- a/src/context/PropertyContext.jsx
+++ b/src/context/PropertyContext.jsx
@@ -1,0 +1,71 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { propertiesApi } from '../api/plants.js'
+import { useAuth } from '../contexts/AuthContext.jsx'
+
+const STORAGE_KEY = 'plantTracker_activePropertyId'
+
+const PropertyContext = createContext(null)
+
+export function useProperty() {
+  const ctx = useContext(PropertyContext)
+  if (!ctx) throw new Error('useProperty must be used within PropertyProvider')
+  return ctx
+}
+
+export function PropertyProvider({ children }) {
+  const { isAuthenticated, isGuest } = useAuth()
+  const [properties, setProperties] = useState([])
+  const [activePropertyId, setActivePropertyId] = useState(
+    () => localStorage.getItem(STORAGE_KEY) || 'primary',
+  )
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const refresh = useCallback(async () => {
+    if (!isAuthenticated || isGuest) {
+      setProperties([])
+      return
+    }
+    setLoading(true)
+    try {
+      const data = await propertiesApi.list()
+      const list = data.properties || []
+      setProperties(list)
+      // Reset active ID if it no longer exists
+      if (list.length > 0 && !list.find((p) => p.id === activePropertyId)) {
+        const fallback = list[0].id
+        setActivePropertyId(fallback)
+        localStorage.setItem(STORAGE_KEY, fallback)
+      }
+      setError(null)
+    } catch (err) {
+      setError(err.message || 'Failed to load properties')
+    } finally {
+      setLoading(false)
+    }
+  }, [isAuthenticated, isGuest, activePropertyId])
+
+  useEffect(() => { refresh() }, [isAuthenticated, isGuest]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const switchTo = useCallback((id) => {
+    setActivePropertyId(id)
+    localStorage.setItem(STORAGE_KEY, id)
+  }, [])
+
+  const activeProperty = useMemo(
+    () => properties.find((p) => p.id === activePropertyId) || properties[0] || null,
+    [properties, activePropertyId],
+  )
+
+  const value = useMemo(() => ({
+    properties,
+    activePropertyId: activeProperty?.id || 'primary',
+    activeProperty,
+    loading,
+    error,
+    refresh,
+    switchTo,
+  }), [properties, activeProperty, loading, error, refresh, switchTo])
+
+  return <PropertyContext.Provider value={value}>{children}</PropertyContext.Provider>
+}

--- a/src/layouts/components/Sidebar.jsx
+++ b/src/layouts/components/Sidebar.jsx
@@ -5,6 +5,7 @@ import { useLayoutContext } from '../../context/LayoutContext.jsx'
 import { usePlantContext } from '../../context/PlantContext.jsx'
 import { useHelp } from '../../context/HelpContext.jsx'
 import { useTour, TOURS } from '../../context/TourContext.jsx'
+import { useProperty } from '../../context/PropertyContext.jsx'
 import SidebarMenu from './SidebarMenu.jsx'
 import WeatherStrip from '../../components/WeatherStrip.jsx'
 import OfflineIndicator from '../../components/OfflineIndicator.jsx'
@@ -13,6 +14,7 @@ import { buildWaterTasks } from '../../utils/todayTasks.js'
 
 export default function Sidebar() {
   const { user, logout } = useAuth()
+  const { properties, activePropertyId, switchTo } = useProperty()
   const { navMinified, toggleSetting } = useLayoutContext()
   const { weather, location, plants, floors } = usePlantContext()
   const { open: openHelp } = useHelp()
@@ -59,6 +61,22 @@ export default function Sidebar() {
           </>
         )}
       </div>
+
+      {properties.length > 1 && (
+        <div className="px-4 pb-2">
+          <select
+            className="form-select form-select-sm bg-transparent text-white border-white border-opacity-25"
+            value={activePropertyId}
+            onChange={(e) => switchTo(e.target.value)}
+            aria-label="Switch property"
+            style={{ fontSize: '0.78rem' }}
+          >
+            {properties.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+        </div>
+      )}
 
       <OfflineIndicator />
 

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -11,8 +11,9 @@ import { TIMEZONE_GROUPS } from '../hooks/useTimezone.js'
 import { SUPPORTED_LANGUAGES } from '../i18n/index.js'
 import { useTranslation } from 'react-i18next'
 import i18n from '../i18n/index.js'
-import { accountApi, exportApi, apiKeysApi, brandingApi, imagesApi, householdsApi } from '../api/plants.js'
+import { accountApi, exportApi, apiKeysApi, brandingApi, imagesApi, householdsApi, propertiesApi } from '../api/plants.js'
 import { useHousehold } from '../context/HouseholdContext.jsx'
+import { useProperty } from '../context/PropertyContext.jsx'
 
 const TABS = [
   { id: 'property', label: 'Property', icon: 'layers', tags: 'floors zones floorplan rooms upload property' },
@@ -20,6 +21,7 @@ const TABS = [
   { id: 'household', label: 'Household', icon: 'users', tags: 'household share invite member family roommate partner role viewer editor owner code' },
   { id: 'data', label: 'Data & export', icon: 'download', tags: 'export csv download backup data' },
   { id: 'api-keys', label: 'API Keys', icon: 'key', tags: 'api keys rest integration home assistant automation developer' },
+  { id: 'client-properties', label: 'Properties', icon: 'home', tags: 'properties clients landscaper multi-property client management' },
   { id: 'branding', label: 'Branding', icon: 'star', tags: 'branding logo colour color business name landscaper white label report pdf' },
   { id: 'advanced', label: 'Advanced', icon: 'tool', tags: 'reset onboarding developer version advanced' },
 ]
@@ -1353,6 +1355,94 @@ function AdvancedTab({ search }) {
   )
 }
 
+function ClientPropertiesTab({ search }) {
+  const { properties, refresh } = useProperty()
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [newType, setNewType] = useState('residential')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return
+    setSaving(true)
+    setError(null)
+    try {
+      await propertiesApi.create({ name: newName.trim(), type: newType })
+      setNewName('')
+      setCreating(false)
+      await refresh()
+    } catch (err) {
+      setError(err.message || 'Failed to create property')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleArchive = async (id) => {
+    try {
+      await propertiesApi.archive(id)
+      await refresh()
+    } catch (err) {
+      setError(err.message || 'Failed to archive property')
+    }
+  }
+
+  return (
+    <SettingSection id="client-properties" title="Client Properties" icon="home" search={search}>
+      <div className="p-0">
+        <Table hover responsive className="mb-0">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Type</th>
+              <th style={{ width: 80 }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {properties.map((p) => (
+              <tr key={p.id}>
+                <td className="fw-medium">{p.name}</td>
+                <td className="text-capitalize text-muted fs-sm">{p.type || 'residential'}</td>
+                <td>
+                  {p.id !== 'primary' && (
+                    <Button variant="outline-danger" size="sm" onClick={() => handleArchive(p.id)} aria-label={`Archive ${p.name}`}>
+                      <svg className="sa-icon" style={{ width: 12, height: 12 }} aria-hidden="true"><use href="/icons/sprite.svg#trash"></use></svg>
+                    </Button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+
+        {error && <p className="text-danger fs-sm px-3 pt-2 mb-0">{error}</p>}
+
+        {creating ? (
+          <div className="d-flex gap-2 p-3 border-top">
+            <Form.Control size="sm" placeholder="Property name" value={newName} onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleCreate()} aria-label="New property name" autoFocus />
+            <Form.Select size="sm" value={newType} onChange={(e) => setNewType(e.target.value)} style={{ maxWidth: 140 }} aria-label="Property type">
+              <option value="residential">Residential</option>
+              <option value="commercial">Commercial</option>
+              <option value="strata">Strata</option>
+            </Form.Select>
+            <Button size="sm" variant="primary" onClick={handleCreate} disabled={saving || !newName.trim()}>Save</Button>
+            <Button size="sm" variant="outline-secondary" onClick={() => setCreating(false)}>Cancel</Button>
+          </div>
+        ) : (
+          <div className="p-3 border-top">
+            <Button size="sm" variant="outline-primary" onClick={() => setCreating(true)}>
+              <svg className="sa-icon me-1" style={{ width: 12, height: 12 }} aria-hidden="true"><use href="/icons/sprite.svg#plus"></use></svg>
+              Add property
+            </Button>
+          </div>
+        )}
+      </div>
+    </SettingSection>
+  )
+}
+
 const VALID_TABS = TABS.map((t) => t.id)
 
 export default function SettingsPage() {
@@ -1425,6 +1515,7 @@ export default function SettingsPage() {
         {tab === 'household' && <HouseholdTab search={search} />}
         {tab === 'data' && <DataTab search={search} />}
         {tab === 'api-keys' && <ApiKeysTab search={search} />}
+        {tab === 'client-properties' && <ClientPropertiesTab search={search} />}
         {tab === 'branding' && <BrandingTab search={search} />}
         {tab === 'advanced' && <AdvancedTab search={search} />}
       </div>


### PR DESCRIPTION
## Summary

Implements the first-PR scope from issue #159 (April 26 clarification comment). Plants remain at `users/{uid}/plants/{plantId}` and gain a `propertyId` field for filtering. A synthetic `'primary'` property is created lazily on first access so existing users see no change.

- **Backend** (`api/plants/`): 6 new `/properties` routes (list, create, get, update, soft-delete, restore); `?propertyId=` filter on `GET /plants`; `countProperties` quota function; home_pro property quota bumped from 1 → 3.
- **Frontend** (`src/`): `propertiesApi` client, `PropertyContext` (active property + localStorage persistence), `PropertyProvider` wired in `App.jsx`, Settings → Properties tab, sidebar property switcher (visible only when >1 property).
- **Tests**: 16 new backend tests covering lazy synthesis, quota enforcement (home_pro=3, landscaper=unlimited), soft-delete, archived exclusion, and `propertyId` plant filter.

## Test plan

- [ ] All 623 backend tests pass (`cd api/plants && npm test`)
- [ ] All 872 frontend tests pass (`npm test`)
- [ ] Frontend build succeeds (`npm run build`)
- [ ] `GET /properties` on a fresh user returns `[{ id: 'primary', name: 'My Home', archived: false }]`
- [ ] `POST /properties` (home_pro, BILLING_ENABLED=true) creates a property; 4th attempt returns 429
- [ ] `GET /plants?propertyId=<id>` returns only plants belonging to that property
- [ ] Settings → Properties tab lists properties and allows archiving
- [ ] Sidebar property switcher appears when user has >1 active property

Closes #159

https://claude.ai/code/session_0119Nj5MiqRLH3oLHZ6LCjTj

---
_Generated by [Claude Code](https://claude.ai/code/session_0119Nj5MiqRLH3oLHZ6LCjTj)_