### PR TITLE
feat(#263,#160,#264,#162,#163,#164): voice OAuth + care reports + cuttings board + notifications + team RBAC + visit scheduling

### DIFF
--- a/api/plants/email.js
+++ b/api/plants/email.js
@@ -1,0 +1,28 @@
+'use strict';
+
+// SendGrid transactional email helper.
+// Falls back to a no-op when SENDGRID_API_KEY is not set or @sendgrid/mail is unavailable.
+
+const SENDER = process.env.SENDGRID_FROM_EMAIL || 'notifications@plants.lopezcloud.dev';
+
+const TEMPLATES = {
+  dailyDigest: 'd-daily-digest-template-id',
+  weeklyDigest: 'd-weekly-digest-template-id',
+  plantAlert: 'd-plant-alert-template-id',
+};
+
+let _sgMail;
+try { _sgMail = require('@sendgrid/mail'); } catch { _sgMail = null; }
+
+async function sendEmail({ to, template, dynamicData }) {
+  if (!_sgMail) return { skipped: true, reason: 'sendgrid_unavailable' };
+  const apiKey = process.env.SENDGRID_API_KEY;
+  if (!apiKey) return { skipped: true, reason: 'no_api_key' };
+  _sgMail.setApiKey(apiKey);
+  const templateId = TEMPLATES[template];
+  if (!templateId) throw new Error(`Unknown email template: ${template}`);
+  await _sgMail.send({ to, from: SENDER, templateId, dynamicTemplateData: dynamicData || {} });
+  return { sent: true };
+}
+
+module.exports = { sendEmail, TEMPLATES };

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -6722,4 +6722,387 @@ app.get('/rebates/matches', requireUser, (req, res) => {
   res.status(200).json({ rebates: matches, total: matches.length });
 });
 
+// ── OAuth 2.0 authorisation server (RFC 6749 + RFC 7009) ─────────────────────
+// Lets third-party voice assistants (Alexa, Google Home, Apple Shortcuts) link
+// a user's account and call /voice/* endpoints using standard Bearer tokens.
+// No external SDK needed — the flow is straightforward enough to implement
+// directly using the crypto + jwt tooling already present in this file.
+
+const OAUTH_SECRET = process.env.OAUTH_JWT_SECRET || 'oauth-dev-secret';
+const ACCESS_TOKEN_TTL  = 60 * 60;              // 1 hour (seconds)
+const REFRESH_TOKEN_TTL = 30 * 24 * 60 * 60;   // 30 days (seconds)
+const AUTH_CODE_TTL     = 10 * 60 * 1000;       // 10 minutes (ms)
+
+// Pre-issued clients. Redirect URIs match each platform's account-linking spec.
+const OAUTH_CLIENTS = {
+  'alexa.lopezcloud.dev': {
+    name: 'Amazon Alexa',
+    redirectUris: ['https://pitangui.amazon.com/api/skill/link/M1IIGQ9IEV36MY', 'https://layla.amazon.com/api/skill/link/M1IIGQ9IEV36MY'],
+    scopes: ['voice'],
+  },
+  'google-home.lopezcloud.dev': {
+    name: 'Google Home',
+    redirectUris: ['https://oauth-redirect.googleusercontent.com/r/home-plant-tracker-lcd', 'https://oauth-redirect-sandbox.googleusercontent.com/r/home-plant-tracker-lcd'],
+    scopes: ['voice'],
+  },
+  'apple-shortcuts.lopezcloud.dev': {
+    name: 'Apple Shortcuts',
+    redirectUris: ['planttracker://oauth/callback', 'https://plants.lopezcloud.dev/oauth/callback'],
+    scopes: ['voice'],
+  },
+};
+
+function userOauthGrants(userId) {
+  return db.collection('users').doc(userId).collection('oauthGrants');
+}
+
+function hashToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+function issueAccessToken(userId, clientId, scopes) {
+  if (!jwt) throw new Error('jwt_unavailable');
+  return jwt.sign(
+    { sub: userId, client_id: clientId, scopes, type: 'oauth_access' },
+    OAUTH_SECRET,
+    { expiresIn: ACCESS_TOKEN_TTL },
+  );
+}
+
+function verifyAccessToken(token) {
+  if (!jwt) throw new Error('jwt_unavailable');
+  const payload = jwt.verify(token, OAUTH_SECRET);
+  if (payload.type !== 'oauth_access') throw new Error('wrong_token_type');
+  return payload;
+}
+
+// Middleware: authenticate /voice/* endpoints using OAuth Bearer tokens.
+async function requireOauthBearer(req, res, next) {
+  const auth = req.headers['authorization'];
+  if (!auth || !auth.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'missing_token' });
+  }
+  let payload;
+  try {
+    payload = verifyAccessToken(auth.slice(7));
+  } catch {
+    return res.status(401).json({ error: 'invalid_token' });
+  }
+  req.userId = payload.sub;
+  req.oauthClientId = payload.client_id;
+  req.oauthScopes = payload.scopes || [];
+  next();
+}
+
+// GET /oauth/authorize — redirect-based authorisation; requires the user to
+// already hold a valid Google Bearer token (the app session). The assistant
+// platform opens this URL in a webview during account linking.
+app.get('/oauth/authorize', requireUser, async (req, res) => {
+  try {
+    const { client_id, redirect_uri, state, response_type, scope } = req.query;
+    if (response_type !== 'code') {
+      return res.status(400).json({ error: 'unsupported_response_type' });
+    }
+    const client = OAUTH_CLIENTS[client_id];
+    if (!client) return res.status(400).json({ error: 'invalid_client' });
+    if (!client.redirectUris.includes(redirect_uri)) {
+      return res.status(400).json({ error: 'invalid_redirect_uri' });
+    }
+    const scopes = (scope || 'voice').split(/[\s,]+/).filter(Boolean);
+    const invalidScope = scopes.find((s) => !client.scopes.includes(s));
+    if (invalidScope) return res.status(400).json({ error: 'invalid_scope' });
+
+    // Issue a one-time short-lived authorisation code stored in a global
+    // top-level collection so the token endpoint can resolve it without
+    // knowing the userId in advance.
+    const code = crypto.randomBytes(24).toString('hex');
+    const expiresAt = Date.now() + AUTH_CODE_TTL;
+    await db.collection('oauthCodes').doc(code).set({
+      userId: req.userId, clientId: client_id, redirectUri: redirect_uri, scopes, expiresAt, used: false,
+    });
+
+    const dest = new URL(redirect_uri);
+    dest.searchParams.set('code', code);
+    if (state) dest.searchParams.set('state', state);
+    res.redirect(302, dest.toString());
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /oauth/token — token endpoint (authorization_code + refresh_token grants)
+app.post('/oauth/token', async (req, res) => {
+  try {
+    if (!jwt) return res.status(503).json({ error: 'jwt_unavailable' });
+    const { grant_type, code, redirect_uri, client_id, refresh_token } = req.body || {};
+
+    const client = OAUTH_CLIENTS[client_id];
+    if (!client) return res.status(401).json({ error: 'invalid_client' });
+
+    if (grant_type === 'authorization_code') {
+      if (!code) return res.status(400).json({ error: 'missing_code' });
+
+      // Find the code across all users (scan by top-level hash is impractical;
+      // instead the code itself is stored at users/{uid}/oauthCodes/{code} and
+      // the uid is encoded in the code via a signed prefix).
+      // Simpler approach: the code contains the userId as a prefix separated by '.'.
+      // The authorize endpoint embeds the uid so we can resolve it directly.
+      // Re-derive from the token store by scanning is a security risk; instead we
+      // use a top-level cross-user lookup collection.
+      const globalRef = db.collection('oauthCodes').doc(code);
+      const globalSnap = await globalRef.get();
+      if (!globalSnap.exists) return res.status(400).json({ error: 'invalid_code' });
+      const { userId, clientId, redirectUri, scopes, expiresAt, used } = globalSnap.data();
+
+      if (used) return res.status(400).json({ error: 'code_already_used' });
+      if (Date.now() > expiresAt) return res.status(400).json({ error: 'code_expired' });
+      if (clientId !== client_id) return res.status(400).json({ error: 'client_mismatch' });
+      if (redirectUri !== redirect_uri) return res.status(400).json({ error: 'redirect_uri_mismatch' });
+
+      // Mark code as used (consume it)
+      await globalRef.set({ used: true }, { merge: true });
+
+      const accessToken = issueAccessToken(userId, client_id, scopes);
+      const rawRefresh = crypto.randomBytes(32).toString('hex');
+      const refreshHash = hashToken(rawRefresh);
+      const now = new Date().toISOString();
+      const expiry = new Date(Date.now() + REFRESH_TOKEN_TTL * 1000).toISOString();
+
+      const grantRef = await userOauthGrants(userId).add({
+        clientId: client_id, scopes, refreshTokenHash: refreshHash,
+        expiresAt: expiry, revokedAt: null, createdAt: now,
+      });
+      // Global hash index lets the refresh_token grant look up userId + grantId
+      await db.collection('oauthRefreshHashes').doc(refreshHash).set({
+        userId, grantId: grantRef.id, revokedAt: null, createdAt: now,
+      });
+
+      return res.status(200).json({
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: ACCESS_TOKEN_TTL,
+        refresh_token: rawRefresh,
+        scope: scopes.join(' '),
+      });
+    }
+
+    if (grant_type === 'refresh_token') {
+      if (!refresh_token) return res.status(400).json({ error: 'missing_refresh_token' });
+      const refreshHash = hashToken(refresh_token);
+
+      // Scan grants for matching hash (a user will have at most a handful)
+      // We store grants per-user so we need the userId. Use a top-level hash index.
+      const hashRef = db.collection('oauthRefreshHashes').doc(refreshHash);
+      const hashSnap = await hashRef.get();
+      if (!hashSnap.exists) return res.status(401).json({ error: 'invalid_refresh_token' });
+      const { userId, grantId } = hashSnap.data();
+
+      const grantSnap = await userOauthGrants(userId).doc(grantId).get();
+      if (!grantSnap.exists) return res.status(401).json({ error: 'invalid_refresh_token' });
+      const grant = grantSnap.data();
+      if (grant.revokedAt) return res.status(401).json({ error: 'token_revoked' });
+      if (grant.clientId !== client_id) return res.status(401).json({ error: 'client_mismatch' });
+      if (new Date(grant.expiresAt) < new Date()) return res.status(401).json({ error: 'refresh_token_expired' });
+
+      const accessToken = issueAccessToken(userId, client_id, grant.scopes);
+      return res.status(200).json({
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: ACCESS_TOKEN_TTL,
+        scope: grant.scopes.join(' '),
+      });
+    }
+
+    return res.status(400).json({ error: 'unsupported_grant_type' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /oauth/revoke — RFC 7009 token revocation
+app.post('/oauth/revoke', async (req, res) => {
+  try {
+    const { token } = req.body || {};
+    if (!token) return res.status(400).json({ error: 'missing_token' });
+
+    // Try to interpret as a refresh token (most common revocation target)
+    const refreshHash = hashToken(token);
+    const hashRef = db.collection('oauthRefreshHashes').doc(refreshHash);
+    const hashSnap = await hashRef.get();
+    if (hashSnap.exists && !hashSnap.data().revokedAt) {
+      const { userId, grantId } = hashSnap.data();
+      const now = new Date().toISOString();
+      await userOauthGrants(userId).doc(grantId).set({ revokedAt: now }, { merge: true });
+      await hashRef.set({ revokedAt: now }, { merge: true });
+    }
+    // RFC 7009 §2.2: always return 200 regardless of whether the token was found
+    res.status(200).json({ revoked: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /oauth/grants — list active linked devices for the authenticated user
+app.get('/oauth/grants', requireUser, requireTier('home_pro'), async (req, res) => {
+  try {
+    const snap = await userOauthGrants(req.userId).get();
+    const grants = snap.docs
+      .filter((d) => !d.data().revokedAt && new Date(d.data().expiresAt) > new Date())
+      .map((d) => {
+        const g = d.data();
+        const client = OAUTH_CLIENTS[g.clientId] || {};
+        return {
+          id: d.id,
+          clientId: g.clientId,
+          clientName: client.name || g.clientId,
+          scopes: g.scopes,
+          createdAt: g.createdAt,
+          expiresAt: g.expiresAt,
+        };
+      });
+    res.status(200).json({ grants });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// DELETE /oauth/grants/:id — revoke a specific grant (user-facing revocation)
+app.delete('/oauth/grants/:id', requireUser, async (req, res) => {
+  try {
+    const ref = userOauthGrants(req.userId).doc(req.params.id);
+    const snap = await ref.get();
+    if (!snap.exists) return res.status(404).json({ error: 'grant_not_found' });
+    if (snap.data().revokedAt) return res.status(409).json({ error: 'already_revoked' });
+    const now = new Date().toISOString();
+    await ref.set({ revokedAt: now }, { merge: true });
+    // Also revoke the hash index so refresh tokens stop working immediately
+    const { refreshTokenHash } = snap.data();
+    if (refreshTokenHash) {
+      await db.collection('oauthRefreshHashes').doc(refreshTokenHash).set({ revokedAt: now }, { merge: true });
+    }
+    res.status(200).json({ revoked: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ── Voice intent endpoints ─────────────────────────────────────────────────────
+// These endpoints are designed for SSML-ready voice assistant responses.
+// All require a valid OAuth Bearer access token (home_pro+).
+
+// Fuzzy plant name resolver — returns the best match or null
+async function resolveVoicePlant(userId, nameParam) {
+  const snap = await userPlants(userId).get();
+  const plants = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+  const query = nameParam.toLowerCase();
+  // Exact match first, then substring
+  const exact = plants.find((p) => (p.name || '').toLowerCase() === query);
+  if (exact) return exact;
+  const sub = plants.find(
+    (p) => (p.name || '').toLowerCase().includes(query) || query.includes((p.name || '').toLowerCase()),
+  );
+  return sub || null;
+}
+
+// GET /voice/today — today's watering + feeding tasks (SSML-friendly summary)
+app.get('/voice/today', requireOauthBearer, requireTier('home_pro'), async (req, res) => {
+  try {
+    const snap = await userPlants(req.userId).get();
+    const now = new Date();
+    const due = [];
+    for (const d of snap.docs) {
+      const p = { id: d.id, ...d.data() };
+      if (!p.frequencyDays || !p.lastWatered) continue;
+      const next = new Date(new Date(p.lastWatered).getTime() + p.frequencyDays * 86400000);
+      if (next <= now) due.push(p.name || p.species || 'Unknown plant');
+    }
+    const count = due.length;
+    let summary;
+    if (count === 0) {
+      summary = 'All plants are up to date. No watering needed today.';
+    } else if (count === 1) {
+      summary = `One plant needs watering today: ${due[0]}.`;
+    } else {
+      const list = due.length <= 5 ? due.slice(0, -1).join(', ') + ' and ' + due[due.length - 1] : due.slice(0, 5).join(', ') + ` and ${count - 5} more`;
+      summary = `${count} plants need watering today: ${list}.`;
+    }
+    res.status(200).json({ summary, count, plants: due });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /voice/plants/:nameOrFuzzy/status — plant health + last watered
+app.get('/voice/plants/:nameOrFuzzy/status', requireOauthBearer, requireTier('home_pro'), async (req, res) => {
+  try {
+    const plant = await resolveVoicePlant(req.userId, req.params.nameOrFuzzy);
+    if (!plant) {
+      return res.status(404).json({
+        error: 'plant_not_found',
+        summary: `I couldn't find a plant called ${req.params.nameOrFuzzy} in your collection.`,
+      });
+    }
+    const name = plant.name || plant.species || 'your plant';
+    let waterSentence = '';
+    if (plant.lastWatered) {
+      const daysAgo = Math.floor((Date.now() - new Date(plant.lastWatered).getTime()) / 86400000);
+      waterSentence = daysAgo === 0
+        ? ` It was watered today.`
+        : ` It was last watered ${daysAgo} day${daysAgo !== 1 ? 's' : ''} ago.`;
+    }
+    const health = plant.health ? ` Its health is ${plant.health.toLowerCase()}.` : '';
+    const summary = `Your ${name} is in ${plant.room || 'an unknown location'}.${health}${waterSentence}`;
+    res.status(200).json({ summary, plant: { id: plant.id, name: plant.name, health: plant.health, lastWatered: plant.lastWatered, room: plant.room } });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /voice/plants/:nameOrFuzzy/water — log a watering via voice
+app.post('/voice/plants/:nameOrFuzzy/water', requireOauthBearer, requireTier('home_pro'), async (req, res) => {
+  try {
+    const plant = await resolveVoicePlant(req.userId, req.params.nameOrFuzzy);
+    if (!plant) {
+      return res.status(404).json({
+        error: 'plant_not_found',
+        summary: `I couldn't find a plant called ${req.params.nameOrFuzzy} in your collection.`,
+      });
+    }
+    const now = new Date().toISOString();
+    const waterEntry = { date: now, method: 'manual', source: 'voice' };
+    await userPlants(req.userId).doc(plant.id).set({
+      lastWatered: now,
+      wateringLog: [...(plant.wateringLog || []).slice(-49), waterEntry],
+      updatedAt: now,
+    }, { merge: true });
+    const name = plant.name || plant.species || 'your plant';
+    res.status(201).json({ summary: `Logged watering for ${name}.`, wateredAt: now, plantId: plant.id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /voice/weather — weather summary with plant care impact
+app.get('/voice/weather', requireOauthBearer, requireTier('home_pro'), async (req, res) => {
+  try {
+    const configRef = db.collection('users').doc(req.userId).collection('config').doc('preferences');
+    const configSnap = await configRef.get();
+    const prefs = configSnap.exists ? configSnap.data() : {};
+    const location = prefs.location || null;
+    if (!location) {
+      return res.status(200).json({
+        summary: 'No location is set for your garden. Please set your location in Settings to get weather updates.',
+        location: null,
+      });
+    }
+    // Return the stored location; actual weather is fetched by the frontend
+    res.status(200).json({
+      summary: `Weather data for ${location} is available in the app. Check the forecast for any frost or heat alerts affecting your plants.`,
+      location,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 functions.http('plantsApi', app);

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -6722,6 +6722,126 @@ app.get('/rebates/matches', requireUser, (req, res) => {
   res.status(200).json({ rebates: matches, total: matches.length });
 });
 
+// ── Plant care report generation (#160) ──────────────────────────────────────
+// Generates per-property PDF care reports using @react-pdf/renderer.
+// Tier gate: home_pro (own household / primary property); landscaper_pro (any property).
+
+const { generatePdfBuffer } = require('./reports/plantCareReport');
+
+function userReports(userId) {
+  return db.collection('users').doc(userId).collection('reports');
+}
+
+app.post('/reports/generate', requireUser, requireTier('home_pro'), async (req, res) => {
+  try {
+    const { propertyId = 'primary', dateRange, includeSections } = req.body || {};
+
+    // Default date range: last 30 days
+    const to   = dateRange?.to   ? new Date(dateRange.to)   : new Date();
+    const from = dateRange?.from ? new Date(dateRange.from) : new Date(to.getTime() - 30 * 86400000);
+    if (isNaN(from.getTime()) || isNaN(to.getTime())) {
+      return res.status(400).json({ error: 'invalid_date_range' });
+    }
+    if (from > to) {
+      return res.status(400).json({ error: 'date_range_from_must_be_before_to' });
+    }
+
+    // Load property name
+    let propertyName = 'My Garden';
+    const propSnap = await userProperties(req.userId).doc(propertyId).get();
+    if (propSnap.exists) propertyName = propSnap.data().name || propertyName;
+
+    // Load plants (optionally filtered by propertyId)
+    const plantsSnap = await userPlants(req.userId).get();
+    const plants = plantsSnap.docs
+      .map((d) => ({ id: d.id, ...d.data() }))
+      .filter((p) => (p.propertyId || 'primary') === propertyId);
+
+    // Load branding (landscaper_pro users only; home_pro gets default)
+    let branding = null;
+    const brandingDoc = await db.collection('users').doc(req.userId).collection('config').doc('branding').get();
+    if (brandingDoc.exists) branding = brandingDoc.data();
+
+    // Fetch logo bytes so the renderer can embed it
+    if (branding?.logoUrl) {
+      try {
+        const logoRes = await globalThis.fetch(branding.logoUrl);
+        if (!logoRes.ok) throw new Error('logo_fetch_failed');
+        const buf = Buffer.from(await logoRes.arrayBuffer());
+        branding = { ...branding, logoUrl: buf };
+      } catch {
+        branding = { ...branding, logoUrl: null };
+      }
+    }
+
+    const pdfBuffer = await generatePdfBuffer({
+      plants,
+      branding,
+      dateRange: { from: from.toISOString(), to: to.toISOString() },
+      propertyName,
+      includeSections,
+    });
+
+    // Persist to GCS
+    const reportId = `${Date.now()}-${crypto.randomBytes(6).toString('hex')}`;
+    const gcsFilePath = `reports/${req.userId}/${reportId}.pdf`;
+    await storage.bucket(IMAGES_BUCKET).file(gcsFilePath).save(pdfBuffer, { contentType: 'application/pdf' });
+    const [signedUrl] = await storage.bucket(IMAGES_BUCKET).file(gcsFilePath).getSignedUrl({
+      version: 'v4',
+      action: 'read',
+      expires: Date.now() + 30 * 24 * 60 * 60 * 1000, // 30 days
+    });
+
+    const now = new Date().toISOString();
+    const meta = {
+      reportId,
+      propertyId,
+      propertyName,
+      dateRange: { from: from.toISOString(), to: to.toISOString() },
+      includeSections: includeSections || {},
+      gcsPath: gcsFilePath,
+      createdAt: now,
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+    await userReports(req.userId).doc(reportId).set(meta);
+
+    res.status(201).json({ reportId, downloadUrl: signedUrl, ...meta });
+  } catch (err) {
+    log.error('report_generate_failed', { error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/reports', requireUser, requireTier('home_pro'), async (req, res) => {
+  try {
+    const snap = await userReports(req.userId).orderBy('createdAt', 'desc').limit(20).get();
+    const now = new Date();
+    const reports = snap.docs
+      .map((d) => d.data())
+      .filter((r) => new Date(r.expiresAt) > now);
+    res.status(200).json({ reports });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/reports/:reportId/download', requireUser, requireTier('home_pro'), async (req, res) => {
+  try {
+    const snap = await userReports(req.userId).doc(req.params.reportId).get();
+    if (!snap.exists) return res.status(404).json({ error: 'report_not_found' });
+    const { gcsPath, expiresAt } = snap.data();
+    if (new Date(expiresAt) < new Date()) return res.status(410).json({ error: 'report_expired' });
+    const [signedUrl] = await storage.bucket(IMAGES_BUCKET).file(gcsPath).getSignedUrl({
+      version: 'v4',
+      action: 'read',
+      expires: Date.now() + 60 * 60 * 1000, // 1 hour
+    });
+    res.redirect(302, signedUrl);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── OAuth 2.0 authorisation server (RFC 6749 + RFC 7009) ─────────────────────
 // Lets third-party voice assistants (Alexa, Google Home, Apple Shortcuts) link
 // a user's account and call /voice/* endpoints using standard Bearer tokens.

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -6722,6 +6722,307 @@ app.get('/rebates/matches', requireUser, (req, res) => {
   res.status(200).json({ rebates: matches, total: matches.length });
 });
 
+// ── Plant-swap marketplace (#264) ────────────────────────────────────────────
+// UK-only, free listings, postcode-prefix geosearch via postcodes.io.
+// No payments, no in-app chat — users exchange contact via profile fields.
+
+const MARKETPLACE_BLOCKED_WORDS = ['spam', 'scam', 'buy now', 'click here'];
+
+// Haversine distance in km between two lat/lng points
+function haversineKm(lat1, lng1, lat2, lng2) {
+  const R = 6371;
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLng = (lng2 - lng1) * Math.PI / 180;
+  const a = Math.sin(dLat / 2) ** 2
+    + Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+// Lookup outward code (e.g. "SW1A") → { lat, lng } via postcodes.io, cached in Firestore
+async function resolvePostcodeCentroid(outwardCode) {
+  const key = outwardCode.toUpperCase().replace(/\s/g, '');
+  const cacheRef = db.collection('postcodeCentroids').doc(key);
+  const cached = await cacheRef.get();
+  if (cached.exists) return cached.data();
+  const response = await globalThis.fetch(`https://api.postcodes.io/outcodes/${encodeURIComponent(key)}`);
+  if (!response.ok) throw new Error(`postcodes.io lookup failed for ${key}`);
+  const { result } = await response.json();
+  if (!result?.latitude) throw new Error(`No centroid for postcode ${key}`);
+  const coords = { lat: result.latitude, lng: result.longitude };
+  await cacheRef.set(coords);
+  return coords;
+}
+
+// Gemini one-shot check: is this a genuine plant listing?
+async function checkIsPlantListing(text) {
+  try {
+    const prompt = `You are a content moderator for a plant-swap marketplace. Read the following listing description and decide if it is a genuine plant cutting, division, seed, or plant offering. Reply with only valid JSON in this format: {"isPlantListing":true|false,"reason":"brief reason"}\n\nListing: ${text.slice(0, 500)}`;
+    const result = await geminiWithRetry({ contents: [{ parts: [{ text: prompt }] }] });
+    const parsed = parseGeminiJson(result.response.text());
+    return parsed;
+  } catch {
+    return { isPlantListing: true, reason: 'check_unavailable' };
+  }
+}
+
+function hasBlockedWords(text) {
+  const lower = (text || '').toLowerCase();
+  return MARKETPLACE_BLOCKED_WORDS.some((w) => lower.includes(w));
+}
+
+// GET /marketplace/listings — browse with optional filtering
+app.get('/marketplace/listings', async (req, res) => {
+  try {
+    const { outwardCode, radiusKm, species, kind, sort = 'newest' } = req.query;
+    const snap = await db.collection('marketplaceListings')
+      .orderBy('createdAt', 'desc').limit(100).get();
+    let listings = snap.docs
+      .map((d) => ({ id: d.id, ...d.data() }))
+      .filter((l) => l.status === 'active');
+
+    // Geographic filter
+    if (outwardCode) {
+      try {
+        const { lat, lng } = await resolvePostcodeCentroid(outwardCode);
+        const radius = Math.min(Number(radiusKm) || 15, 100);
+        listings = listings.filter((l) => {
+          if (!l.lat || !l.lng) return false;
+          return haversineKm(lat, lng, l.lat, l.lng) <= radius;
+        });
+        if (sort === 'nearest') {
+          listings.sort((a, b) => haversineKm(lat, lng, a.lat, a.lng) - haversineKm(lat, lng, b.lat, b.lng));
+        }
+      } catch {
+        // If postcode lookup fails, return unfiltered
+      }
+    }
+
+    if (species) {
+      const q = species.toLowerCase();
+      listings = listings.filter((l) => (l.species || '').toLowerCase().includes(q));
+    }
+    if (kind) listings = listings.filter((l) => l.kind === kind);
+
+    // Omit sensitive contact info from public listing list
+    listings = listings.map(({ contactEmail: _e, contactPhone: _p, ownerUid: _u, ...safe }) => safe);
+    res.status(200).json({ listings });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /marketplace/listings/:id — single listing detail (shows contact info to auth users)
+app.get('/marketplace/listings/:id', softAuth, async (req, res) => {
+  try {
+    const snap = await db.collection('marketplaceListings').doc(req.params.id).get();
+    if (!snap.exists || snap.data().status === 'removed') {
+      return res.status(404).json({ error: 'listing_not_found' });
+    }
+    const listing = { id: snap.id, ...snap.data() };
+    // Only reveal contact info to authenticated users
+    if (!req.userId) {
+      const { contactEmail: _e, contactPhone: _p, ownerUid: _u, ...safe } = listing;
+      return res.status(200).json(safe);
+    }
+    res.status(200).json(listing);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /marketplace/listings — create a listing
+app.post('/marketplace/listings', requireUser, async (req, res) => {
+  try {
+    const { species, kind, description, outwardCode, contactEmail, contactPhone, suggestedDonation, imageUrls } = req.body || {};
+    if (!species || !kind || !outwardCode) {
+      return res.status(400).json({ error: 'species, kind, and outwardCode are required' });
+    }
+    const VALID_KINDS = ['cutting', 'division', 'seed', 'mature', 'surplus'];
+    if (!VALID_KINDS.includes(kind)) {
+      return res.status(400).json({ error: `kind must be one of: ${VALID_KINDS.join(', ')}` });
+    }
+    if (!contactEmail && !contactPhone) {
+      return res.status(400).json({ error: 'contactEmail or contactPhone is required' });
+    }
+    if (hasBlockedWords(description)) {
+      return res.status(422).json({ error: 'listing_contains_prohibited_content' });
+    }
+
+    const check = await checkIsPlantListing(`${species} ${description || ''}`);
+    if (!check.isPlantListing) {
+      return res.status(422).json({ error: 'listing_not_recognised_as_plant_offering', reason: check.reason });
+    }
+
+    let lat = null, lng = null;
+    try {
+      const centroid = await resolvePostcodeCentroid(outwardCode);
+      lat = centroid.lat;
+      lng = centroid.lng;
+    } catch {
+      return res.status(400).json({ error: 'invalid_outward_code' });
+    }
+
+    // Load lister's display name
+    const profileRef = db.collection('users').doc(req.userId).collection('marketplaceProfile').doc('profile');
+    const profileSnap = await profileRef.get();
+    const displayName = profileSnap.exists ? profileSnap.data().displayName : null;
+
+    const now = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 14 * 86400000).toISOString();
+    const data = {
+      ownerUid: req.userId,
+      ownerDisplayName: displayName || 'Anonymous',
+      species: String(species).trim(),
+      kind,
+      description: description ? String(description).trim() : '',
+      outwardCode: outwardCode.toUpperCase().trim(),
+      lat,
+      lng,
+      contactEmail: contactEmail || null,
+      contactPhone: contactPhone || null,
+      suggestedDonation: suggestedDonation || null,
+      imageUrls: Array.isArray(imageUrls) ? imageUrls.slice(0, 3) : [],
+      status: 'active',
+      reportCount: 0,
+      createdAt: now,
+      expiresAt,
+    };
+    const docRef = await db.collection('marketplaceListings').add(data);
+    res.status(201).json({ id: docRef.id, ...data });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// PUT /marketplace/listings/:id — update (owner only)
+app.put('/marketplace/listings/:id', requireUser, async (req, res) => {
+  try {
+    const ref = db.collection('marketplaceListings').doc(req.params.id);
+    const snap = await ref.get();
+    if (!snap.exists) return res.status(404).json({ error: 'listing_not_found' });
+    if (snap.data().ownerUid !== req.userId) return res.status(403).json({ error: 'not_owner' });
+    const { description, contactEmail, contactPhone, suggestedDonation, status } = req.body || {};
+    const update = { updatedAt: new Date().toISOString() };
+    if (description !== undefined) update.description = String(description).trim();
+    if (contactEmail !== undefined) update.contactEmail = contactEmail;
+    if (contactPhone !== undefined) update.contactPhone = contactPhone;
+    if (suggestedDonation !== undefined) update.suggestedDonation = suggestedDonation;
+    if (status === 'claimed' || status === 'active') update.status = status;
+    await ref.set(update, { merge: true });
+    const updated = await ref.get();
+    res.status(200).json({ id: updated.id, ...updated.data() });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /marketplace/listings/:id/claim — mark as claimed
+app.post('/marketplace/listings/:id/claim', requireUser, async (req, res) => {
+  try {
+    const ref = db.collection('marketplaceListings').doc(req.params.id);
+    const snap = await ref.get();
+    if (!snap.exists || snap.data().status === 'removed') return res.status(404).json({ error: 'listing_not_found' });
+    if (snap.data().ownerUid === req.userId) return res.status(400).json({ error: 'cannot_claim_own_listing' });
+    await ref.set({ status: 'claimed', claimedByUid: req.userId, claimedAt: new Date().toISOString() }, { merge: true });
+    res.status(200).json({ claimed: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /marketplace/listings/:id/confirm-handover — owner confirms listing complete
+app.post('/marketplace/listings/:id/confirm-handover', requireUser, async (req, res) => {
+  try {
+    const ref = db.collection('marketplaceListings').doc(req.params.id);
+    const snap = await ref.get();
+    if (!snap.exists) return res.status(404).json({ error: 'listing_not_found' });
+    if (snap.data().ownerUid !== req.userId) return res.status(403).json({ error: 'not_owner' });
+    const now = new Date().toISOString();
+    await ref.set({ status: 'completed', completedAt: now }, { merge: true });
+    // Award +1 karma to lister
+    const karmaRef = db.collection('users').doc(req.userId).collection('marketplaceProfile').doc('profile');
+    const kSnap = await karmaRef.get();
+    const current = kSnap.exists ? (kSnap.data().karma || 0) : 0;
+    await karmaRef.set({ karma: current + 1, updatedAt: now }, { merge: true });
+    res.status(200).json({ completed: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /marketplace/listings/:id/report — report a listing
+app.post('/marketplace/listings/:id/report', requireUser, async (req, res) => {
+  try {
+    const { reason } = req.body || {};
+    const listingRef = db.collection('marketplaceListings').doc(req.params.id);
+    const snap = await listingRef.get();
+    if (!snap.exists || snap.data().status === 'removed') return res.status(404).json({ error: 'listing_not_found' });
+
+    const reportId = `${Date.now()}-${req.userId}`;
+    await db.collection('marketplaceReports').doc(reportId).set({
+      listingId: req.params.id, reporterUid: req.userId,
+      reason: reason || 'unspecified', status: 'pending', createdAt: new Date().toISOString(),
+    });
+
+    // Auto-hide at 3 reports
+    const newCount = (snap.data().reportCount || 0) + 1;
+    const update = { reportCount: newCount };
+    if (newCount >= 3) update.status = 'hidden';
+    await listingRef.set(update, { merge: true });
+
+    res.status(201).json({ reported: true, autoHidden: newCount >= 3 });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /marketplace/profile/:userId — public profile
+app.get('/marketplace/profile/:userId', async (req, res) => {
+  try {
+    const profileRef = db.collection('users').doc(req.params.userId).collection('marketplaceProfile').doc('profile');
+    const profileSnap = await profileRef.get();
+    const profile = profileSnap.exists ? profileSnap.data() : { karma: 0, badges: [] };
+
+    const listingsSnap = await db.collection('marketplaceListings').orderBy('createdAt', 'desc').limit(20).get();
+    const listings = listingsSnap.docs
+      .map((d) => ({ id: d.id, ...d.data() }))
+      .filter((l) => l.ownerUid === req.params.userId && l.status !== 'removed')
+      .map(({ contactEmail: _e, contactPhone: _p, ownerUid: _u, ...safe }) => safe);
+
+    res.status(200).json({ profile: { userId: req.params.userId, ...profile }, listings });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET/PUT /marketplace/me — authenticated user's own profile
+app.get('/marketplace/me', requireUser, async (req, res) => {
+  try {
+    const ref = db.collection('users').doc(req.userId).collection('marketplaceProfile').doc('profile');
+    const snap = await ref.get();
+    res.status(200).json(snap.exists ? snap.data() : { karma: 0, badges: [], displayName: null, contactEmail: null, contactPhone: null });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.put('/marketplace/me', requireUser, async (req, res) => {
+  try {
+    const { displayName, contactEmail, contactPhone } = req.body || {};
+    const ref = db.collection('users').doc(req.userId).collection('marketplaceProfile').doc('profile');
+    const now = new Date().toISOString();
+    const update = { updatedAt: now };
+    if (displayName !== undefined) update.displayName = String(displayName).trim().slice(0, 64);
+    if (contactEmail !== undefined) update.contactEmail = contactEmail;
+    if (contactPhone !== undefined) update.contactPhone = contactPhone;
+    await ref.set(update, { merge: true });
+    const updated = await ref.get();
+    res.status(200).json(updated.data());
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Plant care report generation (#160) ──────────────────────────────────────
 // Generates per-property PDF care reports using @react-pdf/renderer.
 // Tier gate: home_pro (own household / primary property); landscaper_pro (any property).

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -18,6 +18,8 @@ const cors = require('cors');
 const rateLimit = require('express-rate-limit');
 let jwt;
 try { jwt = require('jsonwebtoken'); } catch { jwt = null; }
+let webPush;
+try { webPush = require('web-push'); } catch { webPush = null; }
 
 // ── Gemini API fetch patch ────────────────────────────────────────────────────
 // The Gemini API sometimes embeds generated text that contains raw control
@@ -7521,6 +7523,175 @@ app.get('/voice/weather', requireOauthBearer, requireTier('home_pro'), async (re
       summary: `Weather data for ${location} is available in the app. Check the forecast for any frost or heat alerts affecting your plants.`,
       location,
     });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ── Push/email notifications (#162) ──────────────────────────────────────────
+
+const { sendEmail } = require('./email');
+
+// Initialise web-push VAPID once if credentials are available
+if (webPush && process.env.VAPID_PUBLIC_KEY && process.env.VAPID_PRIVATE_KEY) {
+  webPush.setVapidDetails(
+    'mailto:notifications@plants.lopezcloud.dev',
+    process.env.VAPID_PUBLIC_KEY,
+    process.env.VAPID_PRIVATE_KEY,
+  );
+}
+
+async function sendPushNotification(subscription, payload) {
+  if (!webPush || !process.env.VAPID_PUBLIC_KEY) return { skipped: true, reason: 'vapid_unavailable' };
+  try {
+    await webPush.sendNotification(subscription, JSON.stringify(payload));
+    return { sent: true };
+  } catch (err) {
+    if (err.statusCode === 410 || err.statusCode === 404) return { expired: true };
+    throw err;
+  }
+}
+
+function userNotificationPrefs(userId) {
+  return db.collection('users').doc(userId).collection('preferences').doc('notifications');
+}
+
+// GET /preferences/notifications
+app.get('/preferences/notifications', requireUser, async (req, res) => {
+  try {
+    const snap = await userNotificationPrefs(req.userId).get();
+    const defaults = {
+      pushEnabled: false, emailEnabled: true, perPlantAlerts: false,
+      dailyDigest: true, weeklyDigest: false,
+      quietHoursStart: '08:00', quietHoursEnd: '20:00', fcmTokens: [],
+    };
+    res.status(200).json(snap.exists ? { ...defaults, ...snap.data() } : defaults);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// PUT /preferences/notifications
+app.put('/preferences/notifications', requireUser, async (req, res) => {
+  try {
+    const allowed = ['pushEnabled', 'emailEnabled', 'perPlantAlerts', 'dailyDigest', 'weeklyDigest', 'quietHoursStart', 'quietHoursEnd'];
+    const update = {};
+    for (const key of allowed) {
+      if (req.body && req.body[key] !== undefined) update[key] = req.body[key];
+    }
+    if (Object.keys(update).length === 0) return res.status(400).json({ error: 'no_valid_fields' });
+    await userNotificationPrefs(req.userId).set(update, { merge: true });
+    const snap = await userNotificationPrefs(req.userId).get();
+    res.status(200).json(snap.data());
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /preferences/notifications/fcm-tokens — register a push subscription
+app.post('/preferences/notifications/fcm-tokens', requireUser, async (req, res) => {
+  try {
+    const { token, deviceLabel, subscription } = req.body || {};
+    if (!token && !subscription) return res.status(400).json({ error: 'token or subscription is required' });
+    const ref = userNotificationPrefs(req.userId);
+    const snap = await ref.get();
+    const existing = snap.exists ? (snap.data().fcmTokens || []) : [];
+    const entry = { token: token || null, subscription: subscription || null, deviceLabel: deviceLabel || 'Unknown device', lastSeen: new Date().toISOString() };
+    const filtered = existing.filter((t) => t.token !== token);
+    await ref.set({ fcmTokens: [...filtered, entry] }, { merge: true });
+    res.status(201).json({ registered: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// DELETE /preferences/notifications/fcm-tokens/:token — revoke a push subscription
+app.delete('/preferences/notifications/fcm-tokens/:token', requireUser, async (req, res) => {
+  try {
+    const ref = userNotificationPrefs(req.userId);
+    const snap = await ref.get();
+    const existing = snap.exists ? (snap.data().fcmTokens || []) : [];
+    const filtered = existing.filter((t) => t.token !== decodeURIComponent(req.params.token));
+    await ref.set({ fcmTokens: filtered }, { merge: true });
+    res.status(200).json({ removed: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /notifications/dispatch — Cloud Scheduler OIDC target; processes all users
+app.post('/notifications/dispatch', async (req, res) => {
+  if (process.env.NOTIFICATIONS_ENABLED !== 'true') {
+    return res.status(200).json({ status: 'notifications_disabled' });
+  }
+  try {
+    const usersSnap = await db.collection('users').get();
+    let sent = 0, skipped = 0;
+    const now = new Date();
+    const todayKey = now.toISOString().slice(0, 10);
+
+    for (const userDoc of usersSnap.docs) {
+      const userId = userDoc.id;
+      const prefSnap = await userNotificationPrefs(userId).get();
+      if (!prefSnap.exists) { skipped++; continue; }
+      const prefs = prefSnap.data();
+      if (!prefs.dailyDigest && !prefs.perPlantAlerts) { skipped++; continue; }
+
+      // Idempotency check: skip if already dispatched today
+      const logRef = db.collection('users').doc(userId).collection('notificationLog').doc(todayKey);
+      const logSnap = await logRef.get();
+      if (logSnap.exists && logSnap.data().dailyDispatched) { skipped++; continue; }
+
+      // Quiet-hours check (UTC approximation)
+      const [startH] = (prefs.quietHoursStart || '08:00').split(':').map(Number);
+      const [endH] = (prefs.quietHoursEnd || '20:00').split(':').map(Number);
+      const currentH = now.getUTCHours();
+      if (currentH < startH || currentH >= endH) { skipped++; continue; }
+
+      // Aggregate today's tasks
+      const plantsSnap = await userPlants(userId).get();
+      const due = [];
+      const overdue = [];
+      for (const d of plantsSnap.docs) {
+        const p = { id: d.id, ...d.data() };
+        if (!p.frequencyDays || !p.lastWatered) continue;
+        const next = new Date(new Date(p.lastWatered).getTime() + p.frequencyDays * 86400000);
+        const daysLate = Math.floor((now - next) / 86400000);
+        if (daysLate === 0) due.push(p.name || p.species || 'A plant');
+        if (daysLate >= 1) overdue.push({ name: p.name || p.species || 'A plant', daysLate });
+      }
+
+      // Send push
+      if (prefs.pushEnabled && (prefs.fcmTokens || []).length > 0) {
+        const payload = {
+          title: 'Plant Tracker',
+          body: due.length > 0 ? `${due.length} plant${due.length !== 1 ? 's' : ''} need watering today` : `${overdue.length} plant${overdue.length !== 1 ? 's' : ''} overdue`,
+          icon: '/icons/icon-192x192.png',
+        };
+        for (const t of prefs.fcmTokens) {
+          if (t.subscription) {
+            await sendPushNotification(t.subscription, payload).catch(() => {});
+          }
+        }
+      }
+
+      // Send email digest
+      if (prefs.emailEnabled && prefs.dailyDigest) {
+        const userPrefsSnap = await db.collection('users').doc(userId).collection('config').doc('preferences').get();
+        const email = userPrefsSnap.exists ? userPrefsSnap.data().email : null;
+        if (email) {
+          await sendEmail({
+            to: email,
+            template: 'dailyDigest',
+            dynamicData: { dueCount: due.length, overdueCount: overdue.length, duePlants: due.slice(0, 5), overduePlants: overdue.slice(0, 5) },
+          }).catch(() => {});
+        }
+      }
+
+      await logRef.set({ dailyDispatched: true, dispatchedAt: now.toISOString() }, { merge: true });
+      sent++;
+    }
+    res.status(200).json({ status: 'ok', sent, skipped });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -6863,6 +6863,58 @@ describe('POST /materials', () => {
   });
 });
 
+// ── OAuth 2.0 authorisation server ───────────────────────────────────────────
+
+const VALID_CLIENT_ID  = 'alexa.lopezcloud.dev';
+const VALID_REDIRECT   = 'https://pitangui.amazon.com/api/skill/link/M1IIGQ9IEV36MY';
+
+describe('GET /oauth/authorize', () => {
+  it('redirects with code when all params valid', async () => {
+    const res = await request(app)
+      .get('/oauth/authorize')
+      .query({ response_type: 'code', client_id: VALID_CLIENT_ID, redirect_uri: VALID_REDIRECT, scope: 'voice', state: 'abc123' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(302);
+    const location = res.headers['location'];
+    expect(location).toMatch(/code=/);
+    expect(location).toMatch(/state=abc123/);
+  });
+
+  it('rejects unknown client_id', async () => {
+    const res = await request(app)
+      .get('/oauth/authorize')
+      .query({ response_type: 'code', client_id: 'unknown.bad', redirect_uri: VALID_REDIRECT, scope: 'voice' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_client');
+  });
+
+  it('rejects mismatched redirect_uri', async () => {
+    const res = await request(app)
+      .get('/oauth/authorize')
+      .query({ response_type: 'code', client_id: VALID_CLIENT_ID, redirect_uri: 'https://evil.example.com', scope: 'voice' })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_redirect_uri');
+  });
+
+  it('rejects unsupported response_type', async () => {
+    const res = await request(app)
+      .get('/oauth/authorize')
+      .query({ response_type: 'token', client_id: VALID_CLIENT_ID, redirect_uri: VALID_REDIRECT })
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('unsupported_response_type');
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app)
+      .get('/oauth/authorize')
+      .query({ response_type: 'code', client_id: VALID_CLIENT_ID, redirect_uri: VALID_REDIRECT, scope: 'voice' });
+    expect(res.status).toBe(401);
+  });
+});
+
 describe('POST /gifts/purchase', () => {
   it('returns 503 when billing is disabled', async () => {
     const res = await request(app)
@@ -7387,5 +7439,266 @@ describe('GET /rebates/matches', () => {
   it('requires auth', async () => {
     const res = await request(app).get('/rebates/matches?lat=34.05&lng=-118.24');
     expect(res.status).toBe(401);
+  });
+});
+
+// Helper: complete the authorize → token round-trip and return tokens
+async function oauthFullFlow() {
+  const authRes = await request(app)
+    .get('/oauth/authorize')
+    .query({ response_type: 'code', client_id: VALID_CLIENT_ID, redirect_uri: VALID_REDIRECT, scope: 'voice', state: 'st' })
+    .set('Authorization', authHeader());
+  expect(authRes.status).toBe(302);
+  const url = new URL(authRes.headers['location']);
+  const code = url.searchParams.get('code');
+
+  const tokenRes = await request(app)
+    .post('/oauth/token')
+    .send({ grant_type: 'authorization_code', code, redirect_uri: VALID_REDIRECT, client_id: VALID_CLIENT_ID });
+  expect(tokenRes.status).toBe(200);
+  return tokenRes.body; // { access_token, refresh_token, ... }
+}
+
+describe('POST /oauth/token — authorization_code', () => {
+  it('exchanges a valid code for access + refresh tokens', async () => {
+    const tokens = await oauthFullFlow();
+    expect(tokens.access_token).toBeTruthy();
+    expect(tokens.refresh_token).toBeTruthy();
+    expect(tokens.token_type).toBe('Bearer');
+    expect(tokens.expires_in).toBe(3600);
+    expect(tokens.scope).toBe('voice');
+  });
+
+  it('rejects a code that has already been used', async () => {
+    // Get a fresh code
+    const authRes = await request(app)
+      .get('/oauth/authorize')
+      .query({ response_type: 'code', client_id: VALID_CLIENT_ID, redirect_uri: VALID_REDIRECT, scope: 'voice' })
+      .set('Authorization', authHeader());
+    const url = new URL(authRes.headers['location']);
+    const code = url.searchParams.get('code');
+
+    // First exchange succeeds
+    await request(app).post('/oauth/token').send({ grant_type: 'authorization_code', code, redirect_uri: VALID_REDIRECT, client_id: VALID_CLIENT_ID });
+
+    // Second exchange fails
+    const res = await request(app).post('/oauth/token').send({ grant_type: 'authorization_code', code, redirect_uri: VALID_REDIRECT, client_id: VALID_CLIENT_ID });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('code_already_used');
+  });
+
+  it('rejects an unknown code', async () => {
+    const res = await request(app)
+      .post('/oauth/token')
+      .send({ grant_type: 'authorization_code', code: 'notavalidcode', redirect_uri: VALID_REDIRECT, client_id: VALID_CLIENT_ID });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_code');
+  });
+
+  it('rejects unsupported grant_type', async () => {
+    const res = await request(app)
+      .post('/oauth/token')
+      .send({ grant_type: 'client_credentials', client_id: VALID_CLIENT_ID });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('unsupported_grant_type');
+  });
+});
+
+describe('POST /oauth/token — refresh_token', () => {
+  it('issues a new access token given a valid refresh token', async () => {
+    const { refresh_token } = await oauthFullFlow();
+
+    const res = await request(app)
+      .post('/oauth/token')
+      .send({ grant_type: 'refresh_token', refresh_token, client_id: VALID_CLIENT_ID });
+    expect(res.status).toBe(200);
+    expect(res.body.access_token).toBeTruthy();
+    expect(res.body.token_type).toBe('Bearer');
+  });
+
+  it('rejects an unknown refresh token', async () => {
+    const res = await request(app)
+      .post('/oauth/token')
+      .send({ grant_type: 'refresh_token', refresh_token: 'notreal', client_id: VALID_CLIENT_ID });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('invalid_refresh_token');
+  });
+});
+
+describe('POST /oauth/revoke', () => {
+  it('revokes a refresh token and invalidates it for further use', async () => {
+    const { refresh_token } = await oauthFullFlow();
+
+    const revokeRes = await request(app).post('/oauth/revoke').send({ token: refresh_token });
+    expect(revokeRes.status).toBe(200);
+    expect(revokeRes.body.revoked).toBe(true);
+
+    // Subsequent refresh attempt must fail
+    const refreshRes = await request(app)
+      .post('/oauth/token')
+      .send({ grant_type: 'refresh_token', refresh_token, client_id: VALID_CLIENT_ID });
+    expect(refreshRes.status).toBe(401);
+    expect(refreshRes.body.error).toBe('token_revoked');
+  });
+
+  it('returns 200 for an unknown token (RFC 7009 §2.2)', async () => {
+    const res = await request(app).post('/oauth/revoke').send({ token: 'unknowntokenvalue' });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('GET /oauth/grants', () => {
+  beforeEach(() => {
+    process.env.BILLING_ENABLED = 'true';
+    store[`users/${USER_SUB}/subscription/current`] = { tier: 'home_pro', status: 'active' };
+  });
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('returns active grants', async () => {
+    await oauthFullFlow();
+    const res = await request(app).get('/oauth/grants').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.grants).toHaveLength(1);
+    expect(res.body.grants[0].clientName).toBe('Amazon Alexa');
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).get('/oauth/grants');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('DELETE /oauth/grants/:id', () => {
+  beforeEach(() => {
+    process.env.BILLING_ENABLED = 'true';
+    store[`users/${USER_SUB}/subscription/current`] = { tier: 'home_pro', status: 'active' };
+  });
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('revokes a grant and removes it from the list', async () => {
+    await oauthFullFlow();
+    const listRes = await request(app).get('/oauth/grants').set('Authorization', authHeader());
+    const grantId = listRes.body.grants[0].id;
+
+    const revokeRes = await request(app)
+      .delete(`/oauth/grants/${grantId}`)
+      .set('Authorization', authHeader());
+    expect(revokeRes.status).toBe(200);
+    expect(revokeRes.body.revoked).toBe(true);
+
+    const listAfter = await request(app).get('/oauth/grants').set('Authorization', authHeader());
+    expect(listAfter.body.grants).toHaveLength(0);
+  });
+
+  it('returns 404 for unknown grant', async () => {
+    const res = await request(app)
+      .delete('/oauth/grants/no-such-id')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).delete('/oauth/grants/some-id');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── Voice intent endpoints ────────────────────────────────────────────────────
+
+async function makeVoiceBearer() {
+  // Get tokens via full OAuth flow (billing must be enabled + home_pro for /voice/*)
+  process.env.BILLING_ENABLED = 'true';
+  store[`users/${USER_SUB}/subscription/current`] = { tier: 'home_pro', status: 'active' };
+  const { access_token } = await oauthFullFlow();
+  return `Bearer ${access_token}`;
+}
+
+describe('GET /voice/today', () => {
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('returns a due-plants summary', async () => {
+    const bearer = await makeVoiceBearer();
+    // Plant overdue by 10 days
+    store[plantPath('p-water')] = { name: 'Monstera', frequencyDays: 7, lastWatered: new Date(Date.now() - 10 * 86400000).toISOString() };
+    const res = await request(app).get('/voice/today').set('Authorization', bearer);
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.plants[0]).toBe('Monstera');
+    expect(res.body.summary).toMatch(/Monstera/);
+  });
+
+  it('returns all-up-to-date message when nothing is due', async () => {
+    const bearer = await makeVoiceBearer();
+    store[plantPath('p-fresh')] = { name: 'Snake plant', frequencyDays: 14, lastWatered: new Date().toISOString() };
+    const res = await request(app).get('/voice/today').set('Authorization', bearer);
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(0);
+    expect(res.body.summary).toMatch(/up to date/i);
+  });
+
+  it('rejects missing Bearer token', async () => {
+    const res = await request(app).get('/voice/today');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /voice/plants/:nameOrFuzzy/status', () => {
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('returns status for an exact plant name match', async () => {
+    const bearer = await makeVoiceBearer();
+    const lastWatered = new Date(Date.now() - 2 * 86400000).toISOString();
+    store[plantPath('p-status')] = { name: 'Fiddle leaf fig', health: 'Good', room: 'Living Room', lastWatered };
+    const res = await request(app).get('/voice/plants/Fiddle leaf fig/status').set('Authorization', bearer);
+    expect(res.status).toBe(200);
+    expect(res.body.summary).toMatch(/Fiddle leaf fig/);
+    expect(res.body.summary).toMatch(/2 days? ago/i);
+  });
+
+  it('returns 404 for unknown plant', async () => {
+    const bearer = await makeVoiceBearer();
+    const res = await request(app).get('/voice/plants/unicornplant/status').set('Authorization', bearer);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('plant_not_found');
+  });
+});
+
+describe('POST /voice/plants/:nameOrFuzzy/water', () => {
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('logs a watering and returns confirmation', async () => {
+    const bearer = await makeVoiceBearer();
+    store[plantPath('p-voice-water')] = { name: 'Pothos', wateringLog: [] };
+    const res = await request(app).post('/voice/plants/Pothos/water').set('Authorization', bearer);
+    expect(res.status).toBe(201);
+    expect(res.body.summary).toMatch(/Pothos/);
+    expect(res.body.wateredAt).toBeTruthy();
+    expect(store[plantPath('p-voice-water')].lastWatered).toBeTruthy();
+  });
+
+  it('returns 404 for unknown plant', async () => {
+    const bearer = await makeVoiceBearer();
+    const res = await request(app).post('/voice/plants/NoSuchPlant/water').set('Authorization', bearer);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('plant_not_found');
+  });
+});
+
+describe('GET /voice/weather', () => {
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('returns no-location message when location not set', async () => {
+    const bearer = await makeVoiceBearer();
+    const res = await request(app).get('/voice/weather').set('Authorization', bearer);
+    expect(res.status).toBe(200);
+    expect(res.body.summary).toMatch(/No location/i);
+  });
+
+  it('returns location name when preferences are set', async () => {
+    const bearer = await makeVoiceBearer();
+    store[`users/${USER_SUB}/config/preferences`] = { location: 'London, UK' };
+    const res = await request(app).get('/voice/weather').set('Authorization', bearer);
+    expect(res.status).toBe(200);
+    expect(res.body.location).toBe('London, UK');
   });
 });

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -166,6 +166,14 @@ beforeAll(() => {
     './reports/plantCareReport': {
       generatePdfBuffer: async () => Buffer.from('%PDF-1.4 mock-pdf-content'),
     },
+    './email': {
+      sendEmail: async () => ({ sent: true }),
+      TEMPLATES: { dailyDigest: 'd-1', weeklyDigest: 'd-2', plantAlert: 'd-3' },
+    },
+    'web-push': {
+      setVapidDetails: () => {},
+      sendNotification: async () => ({ statusCode: 201 }),
+    },
   });
 });
 
@@ -8122,5 +8130,117 @@ describe('GET /voice/plants/:nameOrFuzzy/status — watered today branch', () =>
     const res = await request(app).get('/voice/plants/Jade plant/status').set('Authorization', bearer);
     expect(res.status).toBe(200);
     expect(res.body.summary).toMatch(/watered today/i);
+  });
+});
+
+// ── Notification preferences and dispatch (#162) ─────────────────────────────
+
+describe('GET /preferences/notifications', () => {
+  it('returns default preferences for new user', async () => {
+    const res = await request(app).get('/preferences/notifications').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.emailEnabled).toBe(true);
+    expect(res.body.pushEnabled).toBe(false);
+    expect(res.body.dailyDigest).toBe(true);
+  });
+
+  it('returns stored preferences when they exist', async () => {
+    store[`users/${USER_SUB}/preferences/notifications`] = { pushEnabled: true, emailEnabled: false, dailyDigest: false, weeklyDigest: true, quietHoursStart: '09:00', quietHoursEnd: '21:00', fcmTokens: [] };
+    const res = await request(app).get('/preferences/notifications').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.pushEnabled).toBe(true);
+    expect(res.body.weeklyDigest).toBe(true);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).get('/preferences/notifications');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PUT /preferences/notifications', () => {
+  it('updates preferences and returns merged result', async () => {
+    const res = await request(app)
+      .put('/preferences/notifications')
+      .set('Authorization', authHeader())
+      .send({ emailEnabled: false, weeklyDigest: true, quietHoursStart: '07:00' });
+    expect(res.status).toBe(200);
+    expect(store[`users/${USER_SUB}/preferences/notifications`].weeklyDigest).toBe(true);
+  });
+
+  it('returns 400 when no valid fields provided', async () => {
+    const res = await request(app)
+      .put('/preferences/notifications')
+      .set('Authorization', authHeader())
+      .send({ unknownField: 'value' });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /preferences/notifications/fcm-tokens', () => {
+  it('registers a push subscription token', async () => {
+    const res = await request(app)
+      .post('/preferences/notifications/fcm-tokens')
+      .set('Authorization', authHeader())
+      .send({ token: 'fcm-token-abc', deviceLabel: 'Chrome on MacBook' });
+    expect(res.status).toBe(201);
+    expect(res.body.registered).toBe(true);
+    const stored = store[`users/${USER_SUB}/preferences/notifications`];
+    expect(stored.fcmTokens.some((t) => t.token === 'fcm-token-abc')).toBe(true);
+  });
+
+  it('returns 400 when neither token nor subscription provided', async () => {
+    const res = await request(app)
+      .post('/preferences/notifications/fcm-tokens')
+      .set('Authorization', authHeader())
+      .send({});
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /preferences/notifications/fcm-tokens/:token', () => {
+  it('removes a token', async () => {
+    store[`users/${USER_SUB}/preferences/notifications`] = { fcmTokens: [{ token: 'tok-del', deviceLabel: 'Phone' }] };
+    const res = await request(app)
+      .delete('/preferences/notifications/fcm-tokens/tok-del')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(store[`users/${USER_SUB}/preferences/notifications`].fcmTokens).toHaveLength(0);
+  });
+});
+
+describe('POST /notifications/dispatch', () => {
+  it('returns disabled status when NOTIFICATIONS_ENABLED is not set', async () => {
+    const res = await request(app).post('/notifications/dispatch');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('notifications_disabled');
+  });
+
+  it('processes users and sends digest when NOTIFICATIONS_ENABLED=true', async () => {
+    process.env.NOTIFICATIONS_ENABLED = 'true';
+    // Seed a user doc so collection().get() finds it
+    store[`users/${USER_SUB}`] = { createdAt: new Date().toISOString() };
+    store[`users/${USER_SUB}/preferences/notifications`] = {
+      emailEnabled: true, pushEnabled: false, dailyDigest: true,
+      quietHoursStart: '00:00', quietHoursEnd: '23:59', fcmTokens: [],
+    };
+    store[`users/${USER_SUB}/config/preferences`] = { email: 'test@example.com' };
+    store[plantPath('dispatch-p1')] = { name: 'Fern', frequencyDays: 7, lastWatered: new Date(Date.now() - 8 * 86400000).toISOString() };
+    const res = await request(app).post('/notifications/dispatch');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(typeof res.body.sent).toBe('number');
+    delete process.env.NOTIFICATIONS_ENABLED;
+  });
+
+  it('skips users with no notification preferences', async () => {
+    process.env.NOTIFICATIONS_ENABLED = 'true';
+    // Seed a user doc with no preferences — should be skipped
+    store[`users/${USER_SUB}`] = { createdAt: new Date().toISOString() };
+    const res = await request(app).post('/notifications/dispatch');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.skipped).toBeGreaterThanOrEqual(1);
+    delete process.env.NOTIFICATIONS_ENABLED;
   });
 });

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -7833,3 +7833,294 @@ describe('GET /reports/:reportId/download', () => {
     expect(res.status).toBe(401);
   });
 });
+
+// ── Marketplace (#264) ────────────────────────────────────────────────────────
+
+// Seed a postcodes.io cache entry so tests don't need to hit the network
+const POSTCODE_CACHE_KEY = 'SW1A';
+
+beforeEach(() => {
+  store[`postcodeCentroids/${POSTCODE_CACHE_KEY}`] = { lat: 51.5, lng: -0.13 };
+});
+
+describe('POST /marketplace/listings', () => {
+  it('creates a listing and returns 201', async () => {
+    geminiGenerateFn = async () => ({ response: { text: () => '{"isPlantListing":true,"reason":"plant offering"}' } });
+    const res = await request(app)
+      .post('/marketplace/listings')
+      .set('Authorization', authHeader())
+      .send({ species: 'Monstera deliciosa', kind: 'cutting', outwardCode: 'SW1A', contactEmail: 'test@test.com', description: 'Healthy cutting' });
+    expect(res.status).toBe(201);
+    expect(res.body.species).toBe('Monstera deliciosa');
+    expect(res.body.kind).toBe('cutting');
+    expect(res.body.outwardCode).toBe('SW1A');
+    expect(res.body.status).toBe('active');
+    expect(res.body.lat).toBe(51.5);
+  });
+
+  it('returns 422 when Gemini rejects as non-plant listing', async () => {
+    geminiGenerateFn = async () => ({ response: { text: () => '{"isPlantListing":false,"reason":"unrelated content"}' } });
+    const res = await request(app)
+      .post('/marketplace/listings')
+      .set('Authorization', authHeader())
+      .send({ species: 'Not a plant', kind: 'cutting', outwardCode: 'SW1A', contactEmail: 'x@x.com' });
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('listing_not_recognised_as_plant_offering');
+  });
+
+  it('returns 422 for blocked word in description', async () => {
+    const res = await request(app)
+      .post('/marketplace/listings')
+      .set('Authorization', authHeader())
+      .send({ species: 'Pothos', kind: 'cutting', outwardCode: 'SW1A', contactEmail: 'x@x.com', description: 'click here to buy now' });
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('listing_contains_prohibited_content');
+  });
+
+  it('returns 400 when required fields missing', async () => {
+    const res = await request(app)
+      .post('/marketplace/listings')
+      .set('Authorization', authHeader())
+      .send({ kind: 'cutting' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when no contact info provided', async () => {
+    geminiGenerateFn = async () => ({ response: { text: () => '{"isPlantListing":true}' } });
+    const res = await request(app)
+      .post('/marketplace/listings')
+      .set('Authorization', authHeader())
+      .send({ species: 'Fern', kind: 'cutting', outwardCode: 'SW1A' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/contact/i);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).post('/marketplace/listings').send({ species: 'x', kind: 'cutting', outwardCode: 'SW1A' });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /marketplace/listings', () => {
+  beforeEach(() => {
+    store['marketplaceListings/l1'] = { species: 'Monstera', kind: 'cutting', outwardCode: 'SW1A', lat: 51.5, lng: -0.13, status: 'active', contactEmail: 'secret@x.com', ownerUid: 'other-user', createdAt: new Date().toISOString() };
+    store['marketplaceListings/l2'] = { species: 'Pothos', kind: 'seed', outwardCode: 'EC1A', lat: 51.52, lng: -0.10, status: 'active', contactEmail: 'secret2@x.com', ownerUid: 'other-user', createdAt: new Date().toISOString() };
+  });
+
+  it('returns active listings without contact info', async () => {
+    const res = await request(app).get('/marketplace/listings');
+    expect(res.status).toBe(200);
+    expect(res.body.listings).toHaveLength(2);
+    expect(res.body.listings[0].contactEmail).toBeUndefined();
+    expect(res.body.listings[0].ownerUid).toBeUndefined();
+  });
+
+  it('filters by kind', async () => {
+    const res = await request(app).get('/marketplace/listings?kind=cutting');
+    expect(res.status).toBe(200);
+    expect(res.body.listings.every((l) => l.kind === 'cutting')).toBe(true);
+  });
+
+  it('filters by species (case-insensitive)', async () => {
+    const res = await request(app).get('/marketplace/listings?species=monstera');
+    expect(res.status).toBe(200);
+    expect(res.body.listings).toHaveLength(1);
+    expect(res.body.listings[0].species).toBe('Monstera');
+  });
+});
+
+describe('POST /marketplace/listings/:id/report — auto-hide at 3 reports', () => {
+  beforeEach(() => {
+    store['marketplaceListings/r-list'] = { species: 'Fern', kind: 'cutting', outwardCode: 'SW1A', status: 'active', reportCount: 0, ownerUid: 'not-me', createdAt: new Date().toISOString() };
+  });
+
+  it('increments reportCount', async () => {
+    const res = await request(app).post('/marketplace/listings/r-list/report').set('Authorization', authHeader()).send({ reason: 'spam' });
+    expect(res.status).toBe(201);
+    expect(store['marketplaceListings/r-list'].reportCount).toBe(1);
+    expect(res.body.autoHidden).toBe(false);
+  });
+
+  it('auto-hides listing when reportCount reaches 3', async () => {
+    store['marketplaceListings/r-list'].reportCount = 2;
+    const res = await request(app).post('/marketplace/listings/r-list/report').set('Authorization', authHeader()).send({ reason: 'spam' });
+    expect(res.status).toBe(201);
+    expect(res.body.autoHidden).toBe(true);
+    expect(store['marketplaceListings/r-list'].status).toBe('hidden');
+  });
+});
+
+describe('GET /marketplace/profile/:userId', () => {
+  it('returns public profile and listings', async () => {
+    store[`users/pub-user/marketplaceProfile/profile`] = { displayName: 'GardenFan', karma: 3, badges: [] };
+    store['marketplaceListings/pub-l'] = { species: 'Cactus', kind: 'cutting', outwardCode: 'N1', status: 'active', ownerUid: 'pub-user', contactEmail: 'x@x.com', createdAt: new Date().toISOString() };
+    const res = await request(app).get('/marketplace/profile/pub-user');
+    expect(res.status).toBe(200);
+    expect(res.body.profile.karma).toBe(3);
+    expect(res.body.listings.some((l) => l.species === 'Cactus')).toBe(true);
+    expect(res.body.listings[0].contactEmail).toBeUndefined();
+  });
+});
+
+describe('GET /marketplace/me and PUT /marketplace/me', () => {
+  it('returns empty profile for new user', async () => {
+    const res = await request(app).get('/marketplace/me').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.karma).toBe(0);
+  });
+
+  it('updates display name', async () => {
+    const res = await request(app).put('/marketplace/me').set('Authorization', authHeader()).send({ displayName: 'LeafLover', contactEmail: 'leaf@x.com' });
+    expect(res.status).toBe(200);
+    expect(store[`users/${USER_SUB}/marketplaceProfile/profile`].displayName).toBe('LeafLover');
+  });
+});
+
+describe('GET /marketplace/listings/:id — single listing', () => {
+  beforeEach(() => {
+    store['marketplaceListings/detail-1'] = {
+      species: 'Aloe vera', kind: 'cutting', outwardCode: 'N1',
+      status: 'active', contactEmail: 'owner@example.com', ownerUid: 'other-user',
+      createdAt: new Date().toISOString(),
+    };
+  });
+
+  it('hides contact info for unauthenticated request', async () => {
+    const res = await request(app).get('/marketplace/listings/detail-1');
+    expect(res.status).toBe(200);
+    expect(res.body.species).toBe('Aloe vera');
+    expect(res.body.contactEmail).toBeUndefined();
+    expect(res.body.ownerUid).toBeUndefined();
+  });
+
+  it('reveals contact info for authenticated request', async () => {
+    const res = await request(app).get('/marketplace/listings/detail-1').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.contactEmail).toBe('owner@example.com');
+  });
+
+  it('returns 404 for unknown listing', async () => {
+    const res = await request(app).get('/marketplace/listings/no-such-listing');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('PUT /marketplace/listings/:id — owner update', () => {
+  beforeEach(() => {
+    store['marketplaceListings/edit-1'] = {
+      species: 'Ficus', kind: 'cutting', outwardCode: 'SW1A',
+      status: 'active', contactEmail: 'owner@example.com',
+      ownerUid: USER_SUB, createdAt: new Date().toISOString(),
+    };
+  });
+
+  it('owner can update description and status', async () => {
+    const res = await request(app)
+      .put('/marketplace/listings/edit-1')
+      .set('Authorization', authHeader())
+      .send({ description: 'Updated description', status: 'claimed' });
+    expect(res.status).toBe(200);
+    expect(res.body.description).toBe('Updated description');
+    expect(res.body.status).toBe('claimed');
+  });
+
+  it('returns 403 when not the owner', async () => {
+    const res = await request(app)
+      .put('/marketplace/listings/edit-1')
+      .set('Authorization', authHeader('other-person'))
+      .send({ description: 'Nope' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('not_owner');
+  });
+
+  it('returns 404 when listing does not exist', async () => {
+    const res = await request(app)
+      .put('/marketplace/listings/nonexistent')
+      .set('Authorization', authHeader())
+      .send({ description: 'Test' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /marketplace/listings/:id/claim', () => {
+  beforeEach(() => {
+    store['marketplaceListings/claim-1'] = {
+      species: 'Succulent', kind: 'cutting', outwardCode: 'EC1A',
+      status: 'active', contactEmail: 'x@x.com', ownerUid: 'another-owner',
+      createdAt: new Date().toISOString(),
+    };
+  });
+
+  it('marks listing as claimed', async () => {
+    const res = await request(app)
+      .post('/marketplace/listings/claim-1/claim')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.claimed).toBe(true);
+    expect(store['marketplaceListings/claim-1'].status).toBe('claimed');
+    expect(store['marketplaceListings/claim-1'].claimedByUid).toBe(USER_SUB);
+  });
+
+  it('returns 400 when owner tries to claim own listing', async () => {
+    store['marketplaceListings/claim-1'].ownerUid = USER_SUB;
+    const res = await request(app)
+      .post('/marketplace/listings/claim-1/claim')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('cannot_claim_own_listing');
+  });
+
+  it('returns 404 for removed listing', async () => {
+    store['marketplaceListings/claim-1'].status = 'removed';
+    const res = await request(app)
+      .post('/marketplace/listings/claim-1/claim')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /marketplace/listings/:id/confirm-handover', () => {
+  beforeEach(() => {
+    store['marketplaceListings/handover-1'] = {
+      species: 'Begonia', kind: 'division', outwardCode: 'W1A',
+      status: 'claimed', contactEmail: 'x@x.com', ownerUid: USER_SUB,
+      createdAt: new Date().toISOString(),
+    };
+  });
+
+  it('owner confirms handover and receives +1 karma', async () => {
+    const res = await request(app)
+      .post('/marketplace/listings/handover-1/confirm-handover')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.completed).toBe(true);
+    expect(store['marketplaceListings/handover-1'].status).toBe('completed');
+    expect(store[`users/${USER_SUB}/marketplaceProfile/profile`].karma).toBe(1);
+  });
+
+  it('returns 403 when not the owner', async () => {
+    const res = await request(app)
+      .post('/marketplace/listings/handover-1/confirm-handover')
+      .set('Authorization', authHeader('not-owner'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for unknown listing', async () => {
+    const res = await request(app)
+      .post('/marketplace/listings/no-such/confirm-handover')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /voice/plants/:nameOrFuzzy/status — watered today branch', () => {
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('reports watered today when daysAgo is 0', async () => {
+    const bearer = await makeVoiceBearer();
+    store[plantPath('p-today')] = { name: 'Jade plant', health: 'Excellent', room: 'Kitchen', lastWatered: new Date().toISOString() };
+    const res = await request(app).get('/voice/plants/Jade plant/status').set('Authorization', bearer);
+    expect(res.status).toBe(200);
+    expect(res.body.summary).toMatch(/watered today/i);
+  });
+});

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -163,6 +163,9 @@ beforeAll(() => {
         return JSON.parse(Buffer.from(token.slice(6), 'hex').toString());
       },
     },
+    './reports/plantCareReport': {
+      generatePdfBuffer: async () => Buffer.from('%PDF-1.4 mock-pdf-content'),
+    },
   });
 });
 
@@ -7700,5 +7703,133 @@ describe('GET /voice/weather', () => {
     const res = await request(app).get('/voice/weather').set('Authorization', bearer);
     expect(res.status).toBe(200);
     expect(res.body.location).toBe('London, UK');
+  });
+});
+
+// ── Plant care report generation (#160) ──────────────────────────────────────
+
+describe('POST /reports/generate', () => {
+  beforeEach(() => {
+    process.env.BILLING_ENABLED = 'true';
+    store[`users/${USER_SUB}/subscription/current`] = { tier: 'home_pro', status: 'active' };
+    // Pre-seed a property and a plant
+    store[`users/${USER_SUB}/properties/primary`] = { name: 'My Home', type: 'residential', archived: false };
+    store[plantPath('plant-1')] = { name: 'Monstera', propertyId: 'primary', frequencyDays: 7, lastWatered: new Date(Date.now() - 5 * 86400000).toISOString(), health: 'Good', wateringLog: [], feedingLog: [] };
+  });
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('generates a PDF and returns a signed download URL', async () => {
+    const res = await request(app)
+      .post('/reports/generate')
+      .set('Authorization', authHeader())
+      .send({ propertyId: 'primary' });
+    expect(res.status).toBe(201);
+    expect(res.body.downloadUrl).toBeTruthy();
+    expect(res.body.reportId).toBeTruthy();
+    expect(res.body.propertyName).toBe('My Home');
+    // PDF buffer should have been saved to GCS
+    expect(storageSavedFiles.some((f) => f.path.startsWith('reports/'))).toBe(true);
+  });
+
+  it('respects a custom dateRange', async () => {
+    const res = await request(app)
+      .post('/reports/generate')
+      .set('Authorization', authHeader())
+      .send({ propertyId: 'primary', dateRange: { from: '2026-01-01T00:00:00.000Z', to: '2026-01-31T23:59:59.999Z' } });
+    expect(res.status).toBe(201);
+    expect(res.body.dateRange.from).toMatch(/2026-01-01/);
+  });
+
+  it('returns 400 for invalid date range (from > to)', async () => {
+    const res = await request(app)
+      .post('/reports/generate')
+      .set('Authorization', authHeader())
+      .send({ propertyId: 'primary', dateRange: { from: '2026-12-31T00:00:00.000Z', to: '2026-01-01T00:00:00.000Z' } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('date_range_from_must_be_before_to');
+  });
+
+  it('requires home_pro tier', async () => {
+    store[`users/${USER_SUB}/subscription/current`] = { tier: 'free', status: 'active' };
+    const res = await request(app)
+      .post('/reports/generate')
+      .set('Authorization', authHeader())
+      .send({ propertyId: 'primary' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('upgrade_required');
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).post('/reports/generate').send({ propertyId: 'primary' });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /reports', () => {
+  beforeEach(() => {
+    process.env.BILLING_ENABLED = 'true';
+    store[`users/${USER_SUB}/subscription/current`] = { tier: 'home_pro', status: 'active' };
+  });
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('returns an empty list when no reports exist', async () => {
+    const res = await request(app).get('/reports').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.reports).toEqual([]);
+  });
+
+  it('returns generated reports', async () => {
+    // Generate a report first
+    store[plantPath('p2')] = { name: 'Snake plant', propertyId: 'primary', health: 'Good', wateringLog: [], feedingLog: [] };
+    await request(app)
+      .post('/reports/generate')
+      .set('Authorization', authHeader())
+      .send({ propertyId: 'primary' });
+
+    const res = await request(app).get('/reports').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.reports).toHaveLength(1);
+    expect(res.body.reports[0].propertyId).toBe('primary');
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).get('/reports');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /reports/:reportId/download', () => {
+  beforeEach(() => {
+    process.env.BILLING_ENABLED = 'true';
+    store[`users/${USER_SUB}/subscription/current`] = { tier: 'home_pro', status: 'active' };
+  });
+  afterEach(() => { delete process.env.BILLING_ENABLED; });
+
+  it('redirects to a signed URL for a valid report', async () => {
+    store[plantPath('p3')] = { name: 'Pothos', propertyId: 'primary', health: 'Good', wateringLog: [], feedingLog: [] };
+    const genRes = await request(app)
+      .post('/reports/generate')
+      .set('Authorization', authHeader())
+      .send({ propertyId: 'primary' });
+    expect(genRes.status).toBe(201);
+    const { reportId } = genRes.body;
+
+    const res = await request(app)
+      .get(`/reports/${reportId}/download`)
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(302);
+    expect(res.headers['location']).toBeTruthy();
+  });
+
+  it('returns 404 for unknown report', async () => {
+    const res = await request(app)
+      .get('/reports/no-such-report/download')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(404);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).get('/reports/any/download');
+    expect(res.status).toBe(401);
   });
 });

--- a/api/plants/package-lock.json
+++ b/api/plants/package-lock.json
@@ -13,6 +13,7 @@
         "@google-cloud/functions-framework": "^3.0.0",
         "@google-cloud/storage": "^7.19.0",
         "@google/generative-ai": "^0.24.1",
+        "@react-pdf/renderer": "^4.5.1",
         "cors": "^2.8.5",
         "csv-parse": "^6.2.1",
         "exceljs": "^4.4.0",
@@ -78,6 +79,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -783,11 +793,22 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -894,6 +915,177 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.8.tgz",
+      "integrity": "sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/types": "^2.11.1",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.0.tgz",
+      "integrity": "sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/svg": "^1.1.0",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.6.1.tgz",
+      "integrity": "sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.0",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-5.1.1.tgz",
+      "integrity": "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "browserify-zlib": "^0.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^2.0.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.3.0.tgz",
+      "integrity": "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.5.1.tgz",
+      "integrity": "sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.5.1.tgz",
+      "integrity": "sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/layout": "^4.6.1",
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.5.1",
+        "@react-pdf/types": "^2.11.1",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.2.1.tgz",
+      "integrity": "sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.11.1",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.0.tgz",
+      "integrity": "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/primitives": "^4.3.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.3.0.tgz",
+      "integrity": "sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.11.1.tgz",
+      "integrity": "sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1"
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
@@ -1148,6 +1340,15 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -1469,6 +1670,12 @@
       "engines": {
         "node": ">=6.5"
       }
+    },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -1805,6 +2012,15 @@
         }
       ]
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -1881,6 +2097,24 @@
       "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/buffer": {
@@ -2091,6 +2325,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cloudevents": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-8.0.3.tgz",
@@ -2122,6 +2365,27 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2367,6 +2631,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2452,6 +2722,12 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -2865,6 +3141,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/exceljs": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
@@ -3213,6 +3498,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3312,6 +3603,23 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -3899,6 +4207,21 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -4017,6 +4340,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+      "license": "ISC"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -4257,6 +4586,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4320,6 +4655,21 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
+    },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4751,6 +5101,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -4862,6 +5231,18 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -4911,6 +5292,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -5118,6 +5505,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5268,6 +5664,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -5367,6 +5769,14 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -5403,6 +5813,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5426,6 +5842,17 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
     },
     "node_modules/proto3-json-serializer": {
       "version": "3.0.4",
@@ -5509,6 +5936,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -5530,6 +5966,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
@@ -5637,6 +6079,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -5793,6 +6241,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -6332,6 +6786,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -6419,6 +6879,12 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6495,9 +6961,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6536,6 +7000,32 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -6728,6 +7218,20 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/vitest": {
@@ -7091,6 +7595,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
+    },
     "node_modules/zip-stream": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
@@ -7200,6 +7710,11 @@
       "requires": {
         "@babel/types": "^7.29.0"
       }
+    },
+    "@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
     },
     "@babel/types": {
       "version": "7.29.0",
@@ -7345,8 +7860,7 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
       "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@eslint/object-schema": {
       "version": "3.0.5",
@@ -7716,11 +8230,15 @@
         "@tybys/wasm-util": "^0.10.1"
       }
     },
+    "@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="
+    },
     "@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
     },
     "@nodable/entities": {
       "version": "2.1.0",
@@ -7806,6 +8324,158 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w=="
+    },
+    "@react-pdf/font": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.8.tgz",
+      "integrity": "sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==",
+      "requires": {
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/types": "^2.11.1",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "@react-pdf/image": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.0.tgz",
+      "integrity": "sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==",
+      "requires": {
+        "@react-pdf/svg": "^1.1.0",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "@react-pdf/layout": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.6.1.tgz",
+      "integrity": "sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==",
+      "requires": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.0",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "@react-pdf/pdfkit": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-5.1.1.tgz",
+      "integrity": "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==",
+      "requires": {
+        "@babel/runtime": "^7.20.13",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "browserify-zlib": "^0.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^2.0.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "@react-pdf/primitives": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.3.0.tgz",
+      "integrity": "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A=="
+    },
+    "@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      }
+    },
+    "@react-pdf/render": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.5.1.tgz",
+      "integrity": "sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==",
+      "requires": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "@react-pdf/renderer": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.5.1.tgz",
+      "integrity": "sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==",
+      "requires": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/layout": "^4.6.1",
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.5.1",
+        "@react-pdf/types": "^2.11.1",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      }
+    },
+    "@react-pdf/stylesheet": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.2.1.tgz",
+      "integrity": "sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==",
+      "requires": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.11.1",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "@react-pdf/svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.0.tgz",
+      "integrity": "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==",
+      "requires": {
+        "@react-pdf/primitives": "^4.3.0"
+      }
+    },
+    "@react-pdf/textkit": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.3.0.tgz",
+      "integrity": "sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==",
+      "requires": {
+        "@react-pdf/fns": "3.1.3",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "@react-pdf/types": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.11.1.tgz",
+      "integrity": "sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==",
+      "requires": {
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1"
+      }
     },
     "@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
@@ -7928,6 +8598,14 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true
+    },
+    "@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "requires": {
+        "tslib": "^2.8.0"
+      }
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -8199,6 +8877,11 @@
         "event-target-shim": "^5.0.0"
       }
     },
+    "abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA=="
+    },
     "accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -8233,8 +8916,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "agent-base": {
       "version": "7.1.4",
@@ -8437,6 +9119,14 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
+    "bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "requires": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -8496,6 +9186,22 @@
       "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "requires": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "requires": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "requires": {
+        "pako": "~1.0.5"
       }
     },
     "buffer": {
@@ -8633,6 +9339,11 @@
         }
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+    },
     "cloudevents": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-8.0.3.tgz",
@@ -8658,6 +9369,21 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "requires": {
+        "color-name": "^2.0.0"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+          "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="
+        }
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -8829,6 +9555,11 @@
         "wrappy": "1"
       }
     },
+    "dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
+    },
     "dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -8909,6 +9640,11 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="
     },
     "encodeurl": {
       "version": "2.0.0",
@@ -9185,6 +9921,11 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
     "exceljs": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
@@ -9399,8 +10140,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "fetch-blob": {
       "version": "3.2.0",
@@ -9410,6 +10150,11 @@
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
       }
+    },
+    "fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
     },
     "file-entry-cache": {
       "version": "8.0.0",
@@ -9482,6 +10227,22 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
+    },
+    "fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "requires": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "for-each": {
       "version": "0.3.5",
@@ -9894,6 +10655,19 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
+    "hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "requires": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg=="
+    },
     "html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -9973,6 +10747,11 @@
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
+    },
+    "hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -10122,6 +10901,11 @@
         "which-typed-array": "^1.1.16"
       }
     },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -10167,6 +10951,19 @@
         "@isaacs/cliui": "^8.0.2",
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "requires": {
+        "restructure": "^3.0.0"
+      }
+    },
+    "js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -10428,6 +11225,22 @@
       "dev": true,
       "optional": true
     },
+    "linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "requires": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+          "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="
+        }
+      }
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -10521,6 +11334,14 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -10559,6 +11380,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -10683,6 +11509,14 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
+    "normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "requires": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -10786,6 +11620,11 @@
         "lines-and-columns": "^1.1.6"
       }
     },
+    "parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -10847,6 +11686,14 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true
     },
+    "png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "requires": {
+        "fflate": "^0.8.2"
+      }
+    },
     "possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -10863,6 +11710,11 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10878,6 +11730,16 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
     },
     "proto3-json-serializer": {
       "version": "3.0.4",
@@ -10940,6 +11802,14 @@
         "side-channel": "^1.1.0"
       }
     },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "requires": {
+        "inherits": "~2.0.3"
+      }
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -10955,6 +11825,11 @@
         "iconv-lite": "~0.4.24",
         "unpipe": "~1.0.0"
       }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -11031,6 +11906,11 @@
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
+    },
+    "restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="
     },
     "retry": {
       "version": "0.13.1",
@@ -11134,6 +12014,11 @@
       "requires": {
         "xmlchars": "^2.2.0"
       }
+    },
+    "scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA=="
     },
     "semver": {
       "version": "7.7.4",
@@ -11426,8 +12311,7 @@
     "stripe": {
       "version": "22.1.0",
       "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.0.tgz",
-      "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==",
-      "requires": {}
+      "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw=="
     },
     "strnum": {
       "version": "2.2.3",
@@ -11517,6 +12401,11 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
+    "svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="
+    },
     "tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -11578,6 +12467,11 @@
         }
       }
     },
+    "tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+    },
     "tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -11629,9 +12523,7 @@
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -11660,6 +12552,31 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
+    },
+    "unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "requires": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+        }
+      }
     },
     "unpipe": {
       "version": "1.0.0",
@@ -11774,6 +12691,16 @@
         "postcss": "^8.5.10",
         "rolldown": "1.0.0-rc.17",
         "tinyglobby": "^0.2.16"
+      }
+    },
+    "vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "vitest": {
@@ -11992,6 +12919,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
     },
     "zip-stream": {
       "version": "4.1.1",

--- a/api/plants/package-lock.json
+++ b/api/plants/package-lock.json
@@ -14,13 +14,15 @@
         "@google-cloud/storage": "^7.19.0",
         "@google/generative-ai": "^0.24.1",
         "@react-pdf/renderer": "^4.5.1",
+        "@sendgrid/mail": "^8.1.6",
         "cors": "^2.8.5",
         "csv-parse": "^6.2.1",
         "exceljs": "^4.4.0",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.1",
         "jsonrepair": "^3.14.0",
-        "stripe": "^22.1.0"
+        "stripe": "^22.1.0",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1335,6 +1337,44 @@
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true
     },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
+      "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.6.tgz",
+      "integrity": "sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.5",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1927,6 +1967,18 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1986,6 +2038,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {
@@ -2066,6 +2145,12 @@
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
       "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -2570,6 +2655,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -3604,6 +3698,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fontkit": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
@@ -4243,6 +4357,15 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -5353,6 +5476,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -5901,6 +6030,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxyquire": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
@@ -5965,6 +6103,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -7323,6 +7471,25 @@
         }
       }
     },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -7860,7 +8027,8 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
       "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@eslint/object-schema": {
       "version": "3.0.5",
@@ -8593,6 +8761,32 @@
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true
     },
+    "@sendgrid/client": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
+      "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
+      "requires": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.12.0"
+      }
+    },
+    "@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "requires": {
+        "deepmerge": "^4.2.2"
+      }
+    },
+    "@sendgrid/mail": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.6.tgz",
+      "integrity": "sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==",
+      "requires": {
+        "@sendgrid/client": "^8.1.5",
+        "@sendgrid/helpers": "^8.0.0"
+      }
+    },
     "@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -8916,7 +9110,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "7.1.4",
@@ -9058,6 +9253,17 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -9107,6 +9313,30 @@
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "requires": {
         "possible-typed-array-names": "^1.0.0"
+      }
+    },
+    "axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "requires": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+          "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "balanced-match": {
@@ -9160,6 +9390,11 @@
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
       "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
+    },
+    "bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
     },
     "body-parser": {
       "version": "1.20.4",
@@ -9513,6 +9748,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
     },
     "define-data-property": {
       "version": "1.1.4",
@@ -10140,7 +10380,8 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "fetch-blob": {
       "version": "3.2.0",
@@ -10227,6 +10468,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "fontkit": {
       "version": "2.0.4",
@@ -10678,6 +10924,11 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA=="
     },
     "http-errors": {
       "version": "2.0.1",
@@ -11419,6 +11670,11 @@
         "mime-db": "1.52.0"
       }
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -11777,6 +12033,11 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
+    },
     "proxyquire": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
@@ -11825,6 +12086,12 @@
         "iconv-lite": "~0.4.24",
         "unpipe": "~1.0.0"
       }
+    },
+    "react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "peer": true
     },
     "react-is": {
       "version": "16.13.1",
@@ -12311,7 +12578,8 @@
     "stripe": {
       "version": "22.1.0",
       "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.0.tgz",
-      "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw=="
+      "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==",
+      "requires": {}
     },
     "strnum": {
       "version": "2.2.3",
@@ -12729,6 +12997,18 @@
         "tinyrainbow": "^3.1.0",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
+      }
+    },
+    "web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "requires": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
       }
     },
     "web-streams-polyfill": {

--- a/api/plants/package.json
+++ b/api/plants/package.json
@@ -20,13 +20,15 @@
     "@google-cloud/storage": "^7.19.0",
     "@google/generative-ai": "^0.24.1",
     "@react-pdf/renderer": "^4.5.1",
+    "@sendgrid/mail": "^8.1.6",
     "cors": "^2.8.5",
     "csv-parse": "^6.2.1",
     "exceljs": "^4.4.0",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.1",
     "jsonrepair": "^3.14.0",
-    "stripe": "^22.1.0"
+    "stripe": "^22.1.0",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/api/plants/package.json
+++ b/api/plants/package.json
@@ -19,6 +19,7 @@
     "@google-cloud/functions-framework": "^3.0.0",
     "@google-cloud/storage": "^7.19.0",
     "@google/generative-ai": "^0.24.1",
+    "@react-pdf/renderer": "^4.5.1",
     "cors": "^2.8.5",
     "csv-parse": "^6.2.1",
     "exceljs": "^4.4.0",

--- a/api/plants/reports/plantCareReport.js
+++ b/api/plants/reports/plantCareReport.js
@@ -1,0 +1,259 @@
+'use strict';
+
+// Plant care report PDF template using @react-pdf/renderer.
+// Deliberately uses React.createElement (not JSX) so the backend stays plain
+// CommonJS with no Babel/transpile step.
+
+const React = require('react');
+const {
+  Document, Page, Text, View, Image, StyleSheet, renderToBuffer,
+} = require('@react-pdf/renderer');
+
+const el = React.createElement;
+
+const COLOR = {
+  brand:       '#2d6a4f',
+  brandLight:  '#e8f5e9',
+  text:        '#1a1a1a',
+  muted:       '#666666',
+  border:      '#e0e0e0',
+  excellent:   '#2d6a4f',
+  good:        '#52b788',
+  fair:        '#f4a261',
+  poor:        '#e63946',
+};
+
+const HEALTH_COLOR = {
+  Excellent: COLOR.excellent,
+  Good:      COLOR.good,
+  Fair:      COLOR.fair,
+  Poor:      COLOR.poor,
+};
+
+const styles = StyleSheet.create({
+  page:          { padding: 40, fontFamily: 'Helvetica', fontSize: 10, color: COLOR.text },
+  headerRow:     { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 20, paddingBottom: 14, borderBottom: `2pt solid ${COLOR.brand}` },
+  logo:          { width: 60, height: 60, objectFit: 'contain' },
+  headerText:    { flex: 1, paddingLeft: 10 },
+  title:         { fontSize: 18, fontFamily: 'Helvetica-Bold', color: COLOR.brand },
+  subtitle:      { fontSize: 10, color: COLOR.muted, marginTop: 3 },
+  metaRow:       { flexDirection: 'row', gap: 16, marginBottom: 16 },
+  metaItem:      { flex: 1, padding: 10, backgroundColor: COLOR.brandLight, borderRadius: 4 },
+  metaLabel:     { fontSize: 8, color: COLOR.muted, marginBottom: 2 },
+  metaValue:     { fontSize: 12, fontFamily: 'Helvetica-Bold', color: COLOR.brand },
+  sectionTitle:  { fontSize: 13, fontFamily: 'Helvetica-Bold', marginBottom: 8, marginTop: 14, paddingBottom: 4, borderBottom: `1pt solid ${COLOR.border}` },
+  plantCard:     { flexDirection: 'row', alignItems: 'flex-start', marginBottom: 6, padding: 8, border: `1pt solid ${COLOR.border}`, borderRadius: 4 },
+  plantThumb:    { width: 40, height: 40, borderRadius: 3, objectFit: 'cover', marginRight: 10 },
+  plantInfo:     { flex: 1 },
+  plantName:     { fontSize: 11, fontFamily: 'Helvetica-Bold', marginBottom: 2 },
+  plantMeta:     { fontSize: 9, color: COLOR.muted },
+  healthBadge:   { fontSize: 8, fontFamily: 'Helvetica-Bold', padding: '2 6', borderRadius: 3, color: '#fff', alignSelf: 'flex-start' },
+  logRow:        { flexDirection: 'row', borderBottom: `0.5pt solid ${COLOR.border}`, paddingVertical: 4 },
+  logDate:       { width: 80, fontSize: 9, color: COLOR.muted },
+  logPlant:      { flex: 1, fontSize: 9 },
+  logNote:       { flex: 2, fontSize: 9, color: COLOR.muted },
+  footer:        { position: 'absolute', bottom: 30, left: 40, right: 40, textAlign: 'center', color: COLOR.muted, fontSize: 8 },
+  pageNum:       { position: 'absolute', bottom: 30, right: 40, color: COLOR.muted, fontSize: 8 },
+});
+
+function formatDate(isoString) {
+  if (!isoString) return 'N/A';
+  return new Date(isoString).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function daysAgo(isoString) {
+  if (!isoString) return null;
+  const d = Math.floor((Date.now() - new Date(isoString).getTime()) / 86400000);
+  if (d === 0) return 'today';
+  if (d === 1) return '1 day ago';
+  return `${d} days ago`;
+}
+
+function HealthBadge({ health }) {
+  const bg = HEALTH_COLOR[health] || COLOR.muted;
+  return el(Text, { style: { ...styles.healthBadge, backgroundColor: bg } }, health || 'Unknown');
+}
+
+function PlantCard({ plant, withPhoto }) {
+  return el(View, { style: styles.plantCard },
+    withPhoto && plant.imageUrl
+      ? el(Image, { style: styles.plantThumb, src: plant.imageUrl })
+      : null,
+    el(View, { style: styles.plantInfo },
+      el(Text, { style: styles.plantName }, plant.name || plant.species || 'Unnamed plant'),
+      el(Text, { style: styles.plantMeta },
+        [plant.room, plant.species].filter(Boolean).join(' · ') || 'No location',
+      ),
+      plant.lastWatered
+        ? el(Text, { style: { ...styles.plantMeta, marginTop: 2 } }, `Last watered: ${formatDate(plant.lastWatered)} (${daysAgo(plant.lastWatered)})`)
+        : null,
+    ),
+    el(HealthBadge, { health: plant.health }),
+  );
+}
+
+function WaterLogSection({ plants, dateRange }) {
+  const from = new Date(dateRange.from);
+  const to   = new Date(dateRange.to);
+
+  const rows = [];
+  for (const plant of plants) {
+    for (const entry of (plant.wateringLog || [])) {
+      const d = new Date(entry.date);
+      if (d >= from && d <= to) {
+        rows.push({ plant, entry, date: d });
+      }
+    }
+  }
+  rows.sort((a, b) => b.date - a.date);
+
+  if (rows.length === 0) return el(Text, { style: { color: COLOR.muted, fontSize: 9 } }, 'No watering events in this period.');
+
+  return el(View, null,
+    el(View, { style: { ...styles.logRow, borderBottom: `1pt solid ${COLOR.border}` } },
+      el(Text, { style: { ...styles.logDate, fontFamily: 'Helvetica-Bold' } }, 'Date'),
+      el(Text, { style: { ...styles.logPlant, fontFamily: 'Helvetica-Bold' } }, 'Plant'),
+      el(Text, { style: { ...styles.logNote, fontFamily: 'Helvetica-Bold' } }, 'Method / Notes'),
+    ),
+    ...rows.map((r, i) =>
+      el(View, { key: i, style: styles.logRow },
+        el(Text, { style: styles.logDate }, formatDate(r.entry.date)),
+        el(Text, { style: styles.logPlant }, r.plant.name || 'Unnamed'),
+        el(Text, { style: styles.logNote }, r.entry.method || 'manual'),
+      ),
+    ),
+  );
+}
+
+function FeedingLogSection({ plants, dateRange }) {
+  const from = new Date(dateRange.from);
+  const to   = new Date(dateRange.to);
+
+  const rows = [];
+  for (const plant of plants) {
+    for (const entry of (plant.feedingLog || [])) {
+      const d = new Date(entry.date);
+      if (d >= from && d <= to) {
+        rows.push({ plant, entry, date: d });
+      }
+    }
+  }
+  rows.sort((a, b) => b.date - a.date);
+
+  if (rows.length === 0) return el(Text, { style: { color: COLOR.muted, fontSize: 9 } }, 'No feeding events in this period.');
+
+  return el(View, null,
+    el(View, { style: { ...styles.logRow, borderBottom: `1pt solid ${COLOR.border}` } },
+      el(Text, { style: { ...styles.logDate, fontFamily: 'Helvetica-Bold' } }, 'Date'),
+      el(Text, { style: { ...styles.logPlant, fontFamily: 'Helvetica-Bold' } }, 'Plant'),
+      el(Text, { style: { ...styles.logNote, fontFamily: 'Helvetica-Bold' } }, 'Type'),
+    ),
+    ...rows.map((r, i) =>
+      el(View, { key: i, style: styles.logRow },
+        el(Text, { style: styles.logDate }, formatDate(r.entry.date)),
+        el(Text, { style: styles.logPlant }, r.plant.name || 'Unnamed'),
+        el(Text, { style: styles.logNote }, r.entry.type || 'general'),
+      ),
+    ),
+  );
+}
+
+/**
+ * Generate a PDF buffer for a plant care report.
+ *
+ * @param {object} opts
+ * @param {object[]} opts.plants  - array of plant objects (with wateringLog, feedingLog, etc.)
+ * @param {object}   opts.branding - { businessName, primaryColor, logoUrl } or null
+ * @param {object}   opts.dateRange - { from: ISO, to: ISO }
+ * @param {string}   opts.propertyName - display name for the property
+ * @param {object}   opts.includeSections - { health, watering, feeding, photos }
+ * @returns {Promise<Buffer>}
+ */
+async function generatePdfBuffer({ plants, branding, dateRange, propertyName, includeSections = {} }) {
+  const {
+    health  = true,
+    watering = true,
+    feeding  = true,
+    photos   = true,
+  } = includeSections;
+
+  const primaryColor = branding?.primaryColor || COLOR.brand;
+  const businessName = branding?.businessName || 'Plant Tracker';
+  const reportTitle  = `Plant Care Report — ${propertyName || 'My Garden'}`;
+
+  // Health summary counts
+  const healthCounts = { Excellent: 0, Good: 0, Fair: 0, Poor: 0, Unknown: 0 };
+  for (const p of plants) {
+    const k = p.health && healthCounts[p.health] !== undefined ? p.health : 'Unknown';
+    healthCounts[k]++;
+  }
+  const dueForWater = plants.filter((p) => {
+    if (!p.frequencyDays || !p.lastWatered) return false;
+    const next = new Date(new Date(p.lastWatered).getTime() + p.frequencyDays * 86400000);
+    return next <= new Date();
+  }).length;
+
+  const doc = el(Document, { title: reportTitle, author: businessName },
+    el(Page, { size: 'A4', style: { ...styles.page, '--primary': primaryColor } },
+      // ── Header ──────────────────────────────────────────────────────────────
+      el(View, { style: styles.headerRow },
+        branding?.logoUrl
+          ? el(Image, { style: styles.logo, src: branding.logoUrl })
+          : null,
+        el(View, { style: styles.headerText },
+          el(Text, { style: { ...styles.title, color: primaryColor } }, reportTitle),
+          el(Text, { style: styles.subtitle }, `${businessName} · Generated ${formatDate(new Date().toISOString())}`),
+          el(Text, { style: styles.subtitle }, `Period: ${formatDate(dateRange.from)} – ${formatDate(dateRange.to)}`),
+        ),
+      ),
+
+      // ── Summary metrics ──────────────────────────────────────────────────────
+      el(View, { style: styles.metaRow },
+        el(View, { style: styles.metaItem },
+          el(Text, { style: styles.metaLabel }, 'TOTAL PLANTS'),
+          el(Text, { style: { ...styles.metaValue, color: primaryColor } }, String(plants.length)),
+        ),
+        el(View, { style: styles.metaItem },
+          el(Text, { style: styles.metaLabel }, 'HEALTHY (GOOD+)'),
+          el(Text, { style: { ...styles.metaValue, color: primaryColor } }, String(healthCounts.Excellent + healthCounts.Good)),
+        ),
+        el(View, { style: styles.metaItem },
+          el(Text, { style: styles.metaLabel }, 'NEED ATTENTION'),
+          el(Text, { style: { ...styles.metaValue, color: healthCounts.Poor > 0 ? COLOR.poor : primaryColor } }, String(healthCounts.Fair + healthCounts.Poor)),
+        ),
+        el(View, { style: styles.metaItem },
+          el(Text, { style: styles.metaLabel }, 'DUE FOR WATER'),
+          el(Text, { style: { ...styles.metaValue, color: dueForWater > 0 ? COLOR.fair : primaryColor } }, String(dueForWater)),
+        ),
+      ),
+
+      // ── Plant health section ─────────────────────────────────────────────────
+      health ? el(View, null,
+        el(Text, { style: styles.sectionTitle }, 'Plant Health Overview'),
+        ...plants.map((p, i) => el(PlantCard, { key: i, plant: p, withPhoto: photos })),
+      ) : null,
+
+      // ── Watering log ─────────────────────────────────────────────────────────
+      watering ? el(View, null,
+        el(Text, { style: styles.sectionTitle }, 'Watering Log'),
+        el(WaterLogSection, { plants, dateRange }),
+      ) : null,
+
+      // ── Feeding log ──────────────────────────────────────────────────────────
+      feeding ? el(View, null,
+        el(Text, { style: styles.sectionTitle }, 'Fertiliser Log'),
+        el(FeedingLogSection, { plants, dateRange }),
+      ) : null,
+
+      // ── Footer ───────────────────────────────────────────────────────────────
+      el(Text, { style: styles.footer },
+        branding?.businessEmail ? `${branding.businessEmail}` : 'Generated by Plant Tracker',
+      ),
+      el(Text, { style: styles.pageNum, render: ({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}` }),
+    ),
+  );
+
+  return renderToBuffer(doc);
+}
+
+module.exports = { generatePdfBuffer };

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -508,6 +508,12 @@ export const rebatesApi = {
   matches: (lat, lng) => request(`/rebates/matches?lat=${lat}&lng=${lng}`),
 }
 
+export const reportsApi = {
+  generate: (body) => request('/reports/generate', { method: 'POST', body: JSON.stringify(body) }),
+  list: () => request('/reports'),
+  downloadUrl: (reportId) => `${import.meta.env.VITE_API_BASE_URL || ''}/reports/${reportId}/download`,
+}
+
 export const oauthApi = {
   getAuthorizeUrl: (clientId, redirectUri, state) => {
     const base = import.meta.env.VITE_API_BASE_URL || ''

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -508,6 +508,22 @@ export const rebatesApi = {
   matches: (lat, lng) => request(`/rebates/matches?lat=${lat}&lng=${lng}`),
 }
 
+export const oauthApi = {
+  getAuthorizeUrl: (clientId, redirectUri, state) => {
+    const base = import.meta.env.VITE_API_BASE_URL || ''
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      scope: 'voice',
+      state: state || '',
+    })
+    return `${base}/oauth/authorize?${params}`
+  },
+  listGrants: () => request('/oauth/grants'),
+  revokeGrant: (id) => request(`/oauth/grants/${id}`, { method: 'DELETE' }),
+}
+
 export const imagesApi = {
   async upload(file, prefix = 'plants') {
     const ext = file.name.split('.').pop()

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -508,6 +508,22 @@ export const rebatesApi = {
   matches: (lat, lng) => request(`/rebates/matches?lat=${lat}&lng=${lng}`),
 }
 
+export const marketplaceApi = {
+  listListings: (params = {}) => {
+    const q = new URLSearchParams(Object.entries(params).filter(([, v]) => v != null)).toString()
+    return request(`/marketplace/listings${q ? '?' + q : ''}`)
+  },
+  getListing: (id) => request(`/marketplace/listings/${id}`),
+  createListing: (data) => request('/marketplace/listings', { method: 'POST', body: JSON.stringify(data) }),
+  updateListing: (id, data) => request(`/marketplace/listings/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  claimListing: (id) => request(`/marketplace/listings/${id}/claim`, { method: 'POST', body: JSON.stringify({}) }),
+  confirmHandover: (id) => request(`/marketplace/listings/${id}/confirm-handover`, { method: 'POST', body: JSON.stringify({}) }),
+  reportListing: (id, reason) => request(`/marketplace/listings/${id}/report`, { method: 'POST', body: JSON.stringify({ reason }) }),
+  getProfile: (userId) => request(`/marketplace/profile/${userId}`),
+  getMyProfile: () => request('/marketplace/me'),
+  updateMyProfile: (data) => request('/marketplace/me', { method: 'PUT', body: JSON.stringify(data) }),
+}
+
 export const reportsApi = {
   generate: (body) => request('/reports/generate', { method: 'POST', body: JSON.stringify(body) }),
   list: () => request('/reports'),

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -609,3 +609,10 @@ export const templatesApi = {
   apply: (id, data) =>
     request(`/templates/${id}/apply`, { method: 'POST', body: JSON.stringify(data) }),
 }
+
+export const notificationsApi = {
+  getPreferences: () => request('/preferences/notifications'),
+  updatePreferences: (data) => request('/preferences/notifications', { method: 'PUT', body: JSON.stringify(data) }),
+  registerToken: (data) => request('/preferences/notifications/fcm-tokens', { method: 'POST', body: JSON.stringify(data) }),
+  revokeToken: (token) => request(`/preferences/notifications/fcm-tokens/${encodeURIComponent(token)}`, { method: 'DELETE' }),
+}

--- a/src/components/NotificationBanner.jsx
+++ b/src/components/NotificationBanner.jsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from 'react'
+import { Button } from 'react-bootstrap'
+import { notificationsApi } from '../api/plants.js'
+import { useAuth } from '../contexts/AuthContext.jsx'
+
+const DISMISSED_KEY = 'plantTracker_notifBannerDismissed'
+const SHOWN_KEY = 'plantTracker_notifBannerFirstShown'
+const SOFT_DELAY_DAYS = 7
+
+export default function NotificationBanner() {
+  const { isGuest } = useAuth()
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (isGuest) return
+    if (!('Notification' in window)) return
+    if (Notification.permission !== 'default') return
+    if (localStorage.getItem(DISMISSED_KEY)) return
+
+    const first = localStorage.getItem(SHOWN_KEY)
+    if (!first) {
+      localStorage.setItem(SHOWN_KEY, Date.now().toString())
+      return
+    }
+    const daysSince = (Date.now() - Number(first)) / 86400000
+    if (daysSince >= SOFT_DELAY_DAYS) setVisible(true)
+  }, [isGuest])
+
+  const handleEnable = async () => {
+    setVisible(false)
+    if (!('Notification' in window)) return
+    const permission = await Notification.requestPermission()
+    if (permission !== 'granted') return
+    if ('serviceWorker' in navigator) {
+      try {
+        const reg = await navigator.serviceWorker.ready
+        const vapidKey = import.meta.env.VITE_VAPID_PUBLIC_KEY
+        if (!vapidKey) return
+        const sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: vapidKey })
+        await notificationsApi.registerToken({ subscription: JSON.parse(JSON.stringify(sub)), deviceLabel: navigator.userAgent.slice(0, 60) })
+        await notificationsApi.updatePreferences({ pushEnabled: true })
+      } catch {}
+    }
+  }
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, '1')
+    setVisible(false)
+  }
+
+  if (!visible) return null
+
+  return (
+    <div className="alert alert-info d-flex align-items-center justify-content-between py-2 mb-3" role="status">
+      <div className="fs-sm">
+        <svg className="sa-icon me-2" style={{ width: 14, height: 14 }} aria-hidden="true"><use href="/icons/sprite.svg#bell"></use></svg>
+        Get reminders when your plants need watering.
+      </div>
+      <div className="d-flex gap-2">
+        <Button size="sm" variant="primary" onClick={handleEnable}>Enable</Button>
+        <Button size="sm" variant="link" className="text-muted p-0 fs-xs" onClick={handleDismiss}>Not now</Button>
+      </div>
+    </div>
+  )
+}

--- a/src/layouts/components/menuData.js
+++ b/src/layouts/components/menuData.js
@@ -48,6 +48,15 @@ export const menuItems = [
     ],
   },
   {
+    key: 'community',
+    label: 'Community',
+    isSection: true,
+    collapsible: true,
+    children: [
+      { key: 'community-board', label: 'Cuttings Board', icon: '/icons/sprite.svg#package', url: '/community' },
+    ],
+  },
+  {
     key: 'manage',
     label: 'Manage',
     isSection: true,

--- a/src/pages/CommunityGuidelinesPage.jsx
+++ b/src/pages/CommunityGuidelinesPage.jsx
@@ -1,0 +1,33 @@
+export default function CommunityGuidelinesPage() {
+  return (
+    <div className="content-wrapper" style={{ maxWidth: 720 }}>
+      <h1 className="mb-4">Community Guidelines</h1>
+      <p className="text-muted">Last updated: April 2026</p>
+
+      <h2 className="h5 mt-4">What this space is for</h2>
+      <p>The Plant Tracker Cuttings Board is a place for gardeners in the UK to share surplus plant cuttings, divisions, seeds, and mature plants with their local community. It is free to use and free to list.</p>
+
+      <h2 className="h5 mt-4">Rules</h2>
+      <ul>
+        <li><strong>Plants only.</strong> Listings must be for genuine plant material — cuttings, divisions, seeds, seedlings, or mature plants. Off-topic listings will be removed.</li>
+        <li><strong>Free or cash-in-person only.</strong> No payment links, no Stripe, no PayPal. Suggested donation strings (e.g. "£2 for postage") are allowed.</li>
+        <li><strong>No full postcodes.</strong> Only share the outward code (first part, e.g. "SW1A"). Never post your full address publicly.</li>
+        <li><strong>Honest descriptions.</strong> Describe the plant accurately — health, size, age, and any known pests or diseases.</li>
+        <li><strong>One listing per plant per period.</strong> Don't create duplicate listings for the same cutting.</li>
+        <li><strong>Coordinate off-platform or via email.</strong> There is no in-app chat; share a contact email or phone number to arrange collection.</li>
+      </ul>
+
+      <h2 className="h5 mt-4">Moderation</h2>
+      <p>Listings are reviewed by our AI moderation system before going live. Listings that receive 3 or more community reports are automatically hidden pending manual review. Repeated violations result in account suspension.</p>
+
+      <h2 className="h5 mt-4">Reporting</h2>
+      <p>Use the "Report" button on any listing to flag it. Please include a brief reason. We aim to review all reports within 48 hours.</p>
+
+      <h2 className="h5 mt-4">Karma</h2>
+      <p>After a successful handover, the lister receives +1 karma. Karma is visible on your public profile and builds trust within the community.</p>
+
+      <h2 className="h5 mt-4">Contact</h2>
+      <p>For questions about the marketplace, email <a href="mailto:community@lopezcloud.dev">community@lopezcloud.dev</a>.</p>
+    </div>
+  )
+}

--- a/src/pages/CommunityPage.jsx
+++ b/src/pages/CommunityPage.jsx
@@ -1,0 +1,263 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Button, Form, Badge, InputGroup, FormControl, Modal } from 'react-bootstrap'
+import { useAuth } from '../contexts/AuthContext.jsx'
+import { marketplaceApi } from '../api/plants.js'
+
+const KIND_LABELS = { cutting: 'Cutting', division: 'Division', seed: 'Seed', mature: 'Mature plant', surplus: 'Surplus' }
+const KIND_COLORS = { cutting: 'success', division: 'info', seed: 'warning', mature: 'primary', surplus: 'secondary' }
+
+function ListingCard({ listing, onClaim, onReport }) {
+  const [claimed, setClaimed] = useState(listing.status === 'claimed')
+  const [reporting, setReporting] = useState(false)
+  const [reportReason, setReportReason] = useState('')
+  const [reportSent, setReportSent] = useState(false)
+
+  const handleClaim = async () => {
+    try { await onClaim(listing.id); setClaimed(true) } catch {}
+  }
+
+  const handleReport = async () => {
+    try { await onReport(listing.id, reportReason); setReportSent(true); setReporting(false) } catch {}
+  }
+
+  return (
+    <div className="card h-100" data-testid={`listing-${listing.id}`}>
+      {listing.imageUrls?.[0] && (
+        <img src={listing.imageUrls[0]} className="card-img-top" alt={listing.species} style={{ height: 160, objectFit: 'cover' }} />
+      )}
+      <div className="card-body d-flex flex-column gap-2">
+        <div className="d-flex justify-content-between align-items-start">
+          <h6 className="mb-0 fw-semibold">{listing.species}</h6>
+          <Badge bg={KIND_COLORS[listing.kind] || 'secondary'} className="fs-xs">{KIND_LABELS[listing.kind] || listing.kind}</Badge>
+        </div>
+        {listing.description && <p className="text-muted fs-sm mb-0">{listing.description}</p>}
+        <div className="text-muted fs-xs">
+          <svg className="sa-icon me-1" style={{ width: 10, height: 10 }} aria-hidden="true"><use href="/icons/sprite.svg#map-pin"></use></svg>
+          {listing.outwardCode}
+          {listing.ownerDisplayName && <span className="ms-2">· {listing.ownerDisplayName}</span>}
+        </div>
+        {listing.suggestedDonation && (
+          <div className="fs-xs text-success fw-medium">Suggested donation: {listing.suggestedDonation}</div>
+        )}
+        <div className="d-flex gap-1 mt-auto">
+          {!claimed ? (
+            <Button size="sm" variant="primary" onClick={handleClaim} disabled={claimed} className="flex-grow-1">
+              I&apos;m interested
+            </Button>
+          ) : (
+            <span className="text-muted fs-sm">Claimed</span>
+          )}
+          {!reportSent && (
+            <Button size="sm" variant="link" className="text-muted p-0 fs-xs" onClick={() => setReporting(true)}>
+              Report
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {reporting && (
+        <Modal show onHide={() => setReporting(false)} size="sm">
+          <Modal.Header closeButton><Modal.Title className="fs-sm">Report listing</Modal.Title></Modal.Header>
+          <Modal.Body>
+            <Form.Control as="textarea" rows={3} placeholder="Reason for report" value={reportReason}
+              onChange={(e) => setReportReason(e.target.value)} className="fs-sm" />
+          </Modal.Body>
+          <Modal.Footer>
+            <Button size="sm" variant="secondary" onClick={() => setReporting(false)}>Cancel</Button>
+            <Button size="sm" variant="danger" onClick={handleReport} disabled={!reportReason.trim()}>Submit report</Button>
+          </Modal.Footer>
+        </Modal>
+      )}
+    </div>
+  )
+}
+
+const EMPTY_FORM = { species: '', kind: 'cutting', description: '', outwardCode: '', contactEmail: '', suggestedDonation: '' }
+
+function CreateListingModal({ onClose, onCreated }) {
+  const [form, setForm] = useState(EMPTY_FORM)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+
+  const set = (k, v) => setForm((f) => ({ ...f, [k]: v }))
+
+  const handleSubmit = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const result = await marketplaceApi.createListing({
+        species: form.species,
+        kind: form.kind,
+        description: form.description,
+        outwardCode: form.outwardCode,
+        contactEmail: form.contactEmail || undefined,
+        suggestedDonation: form.suggestedDonation || undefined,
+      })
+      onCreated(result)
+      onClose()
+    } catch (err) {
+      setError(err.message || 'Failed to create listing')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const valid = form.species.trim() && form.outwardCode.trim() && form.contactEmail.trim()
+
+  return (
+    <Modal show onHide={onClose}>
+      <Modal.Header closeButton><Modal.Title>Offer a cutting or plant</Modal.Title></Modal.Header>
+      <Modal.Body>
+        {error && <div className="alert alert-danger py-2 fs-sm mb-3">{error}</div>}
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-sm fw-semibold">Plant / species *</Form.Label>
+          <Form.Control size="sm" value={form.species} onChange={(e) => set('species', e.target.value)} placeholder="e.g. Monstera deliciosa" />
+        </Form.Group>
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-sm fw-semibold">What are you offering? *</Form.Label>
+          <Form.Select size="sm" value={form.kind} onChange={(e) => set('kind', e.target.value)}>
+            {Object.entries(KIND_LABELS).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
+          </Form.Select>
+        </Form.Group>
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-sm fw-semibold">Description</Form.Label>
+          <Form.Control as="textarea" rows={3} size="sm" value={form.description}
+            onChange={(e) => set('description', e.target.value)} placeholder="Age, size, condition, care notes..." />
+        </Form.Group>
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-sm fw-semibold">Your postcode outward code (e.g. SW1A) *</Form.Label>
+          <Form.Control size="sm" value={form.outwardCode} onChange={(e) => set('outwardCode', e.target.value.toUpperCase())} placeholder="SW1A" maxLength={4} />
+          <Form.Text className="text-muted fs-xs">Only the first part of your postcode is shown — your full address is never published.</Form.Text>
+        </Form.Group>
+        <Form.Group className="mb-3">
+          <Form.Label className="fs-sm fw-semibold">Contact email *</Form.Label>
+          <Form.Control type="email" size="sm" value={form.contactEmail} onChange={(e) => set('contactEmail', e.target.value)} placeholder="you@example.com" />
+        </Form.Group>
+        <Form.Group className="mb-0">
+          <Form.Label className="fs-sm fw-semibold">Suggested donation (optional)</Form.Label>
+          <Form.Control size="sm" value={form.suggestedDonation} onChange={(e) => set('suggestedDonation', e.target.value)} placeholder="e.g. £2 for postage" />
+        </Form.Group>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" size="sm" onClick={onClose}>Cancel</Button>
+        <Button variant="primary" size="sm" onClick={handleSubmit} disabled={saving || !valid}>
+          {saving ? 'Submitting…' : 'List it'}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}
+
+export default function CommunityPage() {
+  const { isGuest, user } = useAuth()
+  const [listings, setListings] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [postcode, setPostcode] = useState('')
+  const [species, setSpecies] = useState('')
+  const [kind, setKind] = useState('')
+  const [showCreate, setShowCreate] = useState(false)
+
+  const loadListings = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const params = {}
+      if (postcode.trim()) params.outwardCode = postcode.trim()
+      if (species.trim()) params.species = species.trim()
+      if (kind) params.kind = kind
+      const { listings: list } = await marketplaceApi.listListings(params)
+      setListings(list)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [postcode, species, kind])
+
+  useEffect(() => { loadListings() }, [loadListings])
+
+  const handleClaim = async (id) => {
+    if (isGuest || !user) { setError('Sign in to claim listings'); return }
+    await marketplaceApi.claimListing(id)
+  }
+
+  const handleReport = async (id, reason) => {
+    if (isGuest || !user) { setError('Sign in to report listings'); return }
+    await marketplaceApi.reportListing(id, reason)
+  }
+
+  return (
+    <div className="content-wrapper">
+      <div className="d-flex align-items-center justify-content-between mb-3 flex-wrap gap-2">
+        <div>
+          <h1 className="subheader-title mb-0">Community Cuttings Board</h1>
+          <p className="text-muted fs-sm mb-0">Free plant swaps, cuttings, and divisions near you. UK only.</p>
+        </div>
+        <div className="d-flex gap-2">
+          <a href="/community-guidelines" target="_blank" rel="noreferrer" className="btn btn-sm btn-outline-secondary">Guidelines</a>
+          {!isGuest && (
+            <Button size="sm" variant="primary" onClick={() => setShowCreate(true)} data-testid="offer-cutting-btn">
+              <svg className="sa-icon me-1" style={{ width: 12, height: 12 }} aria-hidden="true"><use href="/icons/sprite.svg#plus"></use></svg>
+              Offer a cutting
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="card mb-3">
+        <div className="card-body py-2">
+          <div className="row g-2 align-items-end">
+            <div className="col-6 col-md-3">
+              <Form.Label className="fs-xs text-muted mb-1">Postcode area</Form.Label>
+              <InputGroup size="sm">
+                <FormControl placeholder="e.g. SW1A" value={postcode} onChange={(e) => setPostcode(e.target.value.toUpperCase())} maxLength={4} aria-label="Postcode filter" />
+              </InputGroup>
+            </div>
+            <div className="col-6 col-md-3">
+              <Form.Label className="fs-xs text-muted mb-1">Species</Form.Label>
+              <FormControl size="sm" placeholder="e.g. Monstera" value={species} onChange={(e) => setSpecies(e.target.value)} aria-label="Species filter" />
+            </div>
+            <div className="col-6 col-md-3">
+              <Form.Label className="fs-xs text-muted mb-1">Type</Form.Label>
+              <Form.Select size="sm" value={kind} onChange={(e) => setKind(e.target.value)} aria-label="Kind filter">
+                <option value="">All types</option>
+                {Object.entries(KIND_LABELS).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
+              </Form.Select>
+            </div>
+            <div className="col-6 col-md-3">
+              <Button size="sm" variant="primary" onClick={loadListings} className="w-100">Search</Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Results */}
+      {error && <div className="alert alert-danger py-2 mb-3">{error}</div>}
+      {loading ? (
+        <p className="text-muted fs-sm">Loading listings…</p>
+      ) : listings.length === 0 ? (
+        <div className="text-center py-5">
+          <svg className="sa-icon sa-icon-2x mb-2 text-muted" aria-hidden="true"><use href="/icons/sprite.svg#package"></use></svg>
+          <p className="text-muted">No listings found. {!isGuest && 'Be the first to offer a cutting!'}</p>
+        </div>
+      ) : (
+        <div className="row g-3">
+          {listings.map((l) => (
+            <div key={l.id} className="col-12 col-sm-6 col-lg-4">
+              <ListingCard listing={l} onClaim={handleClaim} onReport={handleReport} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showCreate && (
+        <CreateListingModal
+          onClose={() => setShowCreate(false)}
+          onCreated={(newListing) => setListings((prev) => [newListing, ...prev])}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -10,6 +10,7 @@ import ErrorAlert from '../components/ErrorAlert.jsx'
 import EmptyState from '../components/EmptyState.jsx'
 import { SkeletonRect, SkeletonPlantCard } from '../components/Skeleton.jsx'
 import { outbreakApi } from '../api/plants.js'
+import NotificationBanner from '../components/NotificationBanner.jsx'
 
 export default function DashboardPage() {
   const { floors, activeFloorId, weather, handleSavePlant, handleDeletePlant, handleWaterPlant, handleMoisturePlant, plantsError, plants, plantsLoading, reloadPlants, isGuest } = usePlantContext()
@@ -116,6 +117,7 @@ export default function DashboardPage() {
     <div className="content-wrapper" style={{ padding: 0 }}>
       <div className="main-content">
         <div className="px-3 pt-2">
+          <NotificationBanner />
           <UpgradePrompt id="dashboard-plant-limit" quota="plants">
             You've reached your Free-tier plant limit. Unlock unlimited plants with Home Pro.
           </UpgradePrompt>

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -12,7 +12,7 @@ import { TIMEZONE_GROUPS } from '../hooks/useTimezone.js'
 import { SUPPORTED_LANGUAGES } from '../i18n/index.js'
 import { useTranslation } from 'react-i18next'
 import i18n from '../i18n/index.js'
-import { accountApi, exportApi, brandingApi, imagesApi, householdsApi, propertiesApi, oauthApi } from '../api/plants.js'
+import { accountApi, exportApi, brandingApi, imagesApi, householdsApi, propertiesApi, oauthApi, reportsApi } from '../api/plants.js'
 import { useHousehold } from '../context/HouseholdContext.jsx'
 import { useProperty } from '../context/PropertyContext.jsx'
 import { useProfile } from '../context/ProfileContext.jsx'
@@ -1346,6 +1346,157 @@ function LinkedDevicesTab({ search }) {
   )
 }
 
+function ReportGenerateModal({ propertyId, propertyName, onClose }) {
+  const [fromDate, setFromDate] = useState(() => {
+    const d = new Date(); d.setDate(d.getDate() - 30); return d.toISOString().split('T')[0]
+  })
+  const [toDate, setToDate] = useState(() => new Date().toISOString().split('T')[0])
+  const [sections, setSections] = useState({ health: true, watering: true, feeding: true, photos: true })
+  const [generating, setGenerating] = useState(false)
+  const [downloadUrl, setDownloadUrl] = useState(null)
+  const [error, setError] = useState(null)
+
+  const toggleSection = (key) => setSections((s) => ({ ...s, [key]: !s[key] }))
+
+  const handleGenerate = async () => {
+    setGenerating(true)
+    setError(null)
+    try {
+      const result = await reportsApi.generate({
+        propertyId,
+        dateRange: { from: `${fromDate}T00:00:00.000Z`, to: `${toDate}T23:59:59.999Z` },
+        includeSections: sections,
+      })
+      setDownloadUrl(result.downloadUrl)
+    } catch (err) {
+      setError(err.message || 'Failed to generate report')
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  return (
+    <div className="modal show d-block" tabIndex="-1" role="dialog" aria-modal="true" aria-labelledby="report-modal-title">
+      <div className="modal-dialog modal-dialog-centered">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title" id="report-modal-title">Generate Care Report — {propertyName}</h5>
+            <button type="button" className="btn-close" onClick={onClose} aria-label="Close"></button>
+          </div>
+          <div className="modal-body">
+            {error && <div className="alert alert-danger py-2 mb-3">{error}</div>}
+            {downloadUrl ? (
+              <div className="text-center py-3">
+                <svg className="sa-icon sa-icon-2x mb-2 text-success" aria-hidden="true"><use href="/icons/sprite.svg#check-circle"></use></svg>
+                <p className="mb-3">Your report is ready.</p>
+                <a href={downloadUrl} target="_blank" rel="noreferrer" className="btn btn-success">
+                  <svg className="sa-icon me-1" style={{ width: 14, height: 14 }} aria-hidden="true"><use href="/icons/sprite.svg#download"></use></svg>
+                  Download PDF
+                </a>
+              </div>
+            ) : (
+              <>
+                <Form.Group className="mb-3">
+                  <Form.Label className="fs-sm fw-semibold">Date range</Form.Label>
+                  <div className="d-flex gap-2 align-items-center">
+                    <Form.Control type="date" size="sm" value={fromDate} onChange={(e) => setFromDate(e.target.value)} aria-label="From date" />
+                    <span className="text-muted fs-sm">to</span>
+                    <Form.Control type="date" size="sm" value={toDate} onChange={(e) => setToDate(e.target.value)} aria-label="To date" />
+                  </div>
+                </Form.Group>
+                <Form.Group>
+                  <Form.Label className="fs-sm fw-semibold">Include sections</Form.Label>
+                  <div className="d-flex flex-wrap gap-2">
+                    {Object.entries(sections).map(([key, val]) => (
+                      <Form.Check
+                        key={key}
+                        type="checkbox"
+                        id={`section-${key}`}
+                        label={key.charAt(0).toUpperCase() + key.slice(1)}
+                        checked={val}
+                        onChange={() => toggleSection(key)}
+                      />
+                    ))}
+                  </div>
+                </Form.Group>
+              </>
+            )}
+          </div>
+          {!downloadUrl && (
+            <div className="modal-footer">
+              <Button variant="secondary" size="sm" onClick={onClose}>Cancel</Button>
+              <Button variant="primary" size="sm" onClick={handleGenerate} disabled={generating}>
+                {generating ? 'Generating…' : 'Generate PDF'}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="modal-backdrop show" onClick={onClose}></div>
+    </div>
+  )
+}
+
+function ReportsSection({ search }) {
+  const { isGuest } = useAuth()
+  const [reports, setReports] = useState([])
+  const [loading, setLoading] = useState(!isGuest)
+  const [error, setError] = useState(null)
+
+  const loadReports = useCallback(async () => {
+    try {
+      setLoading(true)
+      const { reports: list } = await reportsApi.list()
+      setReports(list)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { if (!isGuest) loadReports() }, [loadReports, isGuest])
+
+  return (
+    <SettingSection id="reports-history" title="Report History" icon="file-text" search={search}>
+      {error && <div className="alert alert-danger py-2 mb-2">{error}</div>}
+      {loading ? (
+        <p className="text-muted fs-sm">Loading…</p>
+      ) : reports.length === 0 ? (
+        <p className="text-muted fs-sm mb-0">No reports generated yet. Use the button above to generate your first report.</p>
+      ) : (
+        <Table size="sm" className="mb-0">
+          <thead>
+            <tr><th>Property</th><th>Period</th><th>Generated</th><th></th></tr>
+          </thead>
+          <tbody>
+            {reports.map((r) => (
+              <tr key={r.reportId}>
+                <td className="fw-medium">{r.propertyName}</td>
+                <td className="text-muted fs-xs">
+                  {new Date(r.dateRange.from).toLocaleDateString()} – {new Date(r.dateRange.to).toLocaleDateString()}
+                </td>
+                <td className="text-muted fs-xs">{new Date(r.createdAt).toLocaleDateString()}</td>
+                <td>
+                  <a
+                    href={reportsApi.downloadUrl(r.reportId)}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="btn btn-outline-secondary btn-sm"
+                    data-testid={`download-report-${r.reportId}`}
+                  >
+                    PDF
+                  </a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      )}
+    </SettingSection>
+  )
+}
+
 function ClientPropertiesTab({ search }) {
   const { properties, refresh } = useProperty()
   const [creating, setCreating] = useState(false)
@@ -1353,6 +1504,7 @@ function ClientPropertiesTab({ search }) {
   const [newType, setNewType] = useState('residential')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState(null)
+  const [reportModalProp, setReportModalProp] = useState(null)
 
   const handleCreate = async () => {
     if (!newName.trim()) return
@@ -1380,6 +1532,14 @@ function ClientPropertiesTab({ search }) {
   }
 
   return (
+    <>
+    {reportModalProp && (
+      <ReportGenerateModal
+        propertyId={reportModalProp.id}
+        propertyName={reportModalProp.name}
+        onClose={() => setReportModalProp(null)}
+      />
+    )}
     <SettingSection id="client-properties" title="Client Properties" icon="home" search={search}>
       <div className="p-0">
         <Table hover responsive className="mb-0">
@@ -1387,7 +1547,7 @@ function ClientPropertiesTab({ search }) {
             <tr>
               <th>Name</th>
               <th>Type</th>
-              <th style={{ width: 80 }}></th>
+              <th style={{ width: 160 }}></th>
             </tr>
           </thead>
           <tbody>
@@ -1396,11 +1556,16 @@ function ClientPropertiesTab({ search }) {
                 <td className="fw-medium">{p.name}</td>
                 <td className="text-capitalize text-muted fs-sm">{p.type || 'residential'}</td>
                 <td>
-                  {p.id !== 'primary' && (
-                    <Button variant="outline-danger" size="sm" onClick={() => handleArchive(p.id)} aria-label={`Archive ${p.name}`}>
-                      <svg className="sa-icon" style={{ width: 12, height: 12 }} aria-hidden="true"><use href="/icons/sprite.svg#trash"></use></svg>
+                  <div className="d-flex gap-1">
+                    <Button variant="outline-primary" size="sm" onClick={() => setReportModalProp(p)} aria-label={`Generate report for ${p.name}`} data-testid={`report-btn-${p.id}`}>
+                      Report
                     </Button>
-                  )}
+                    {p.id !== 'primary' && (
+                      <Button variant="outline-danger" size="sm" onClick={() => handleArchive(p.id)} aria-label={`Archive ${p.name}`}>
+                        <svg className="sa-icon" style={{ width: 12, height: 12 }} aria-hidden="true"><use href="/icons/sprite.svg#trash"></use></svg>
+                      </Button>
+                    )}
+                  </div>
                 </td>
               </tr>
             ))}
@@ -1431,6 +1596,8 @@ function ClientPropertiesTab({ search }) {
         )}
       </div>
     </SettingSection>
+    <ReportsSection search={search} />
+    </>
   )
 }
 

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -12,7 +12,7 @@ import { TIMEZONE_GROUPS } from '../hooks/useTimezone.js'
 import { SUPPORTED_LANGUAGES } from '../i18n/index.js'
 import { useTranslation } from 'react-i18next'
 import i18n from '../i18n/index.js'
-import { accountApi, exportApi, brandingApi, imagesApi, householdsApi, propertiesApi } from '../api/plants.js'
+import { accountApi, exportApi, brandingApi, imagesApi, householdsApi, propertiesApi, oauthApi } from '../api/plants.js'
 import { useHousehold } from '../context/HouseholdContext.jsx'
 import { useProperty } from '../context/PropertyContext.jsx'
 import { useProfile } from '../context/ProfileContext.jsx'
@@ -23,6 +23,7 @@ const TABS = [
   { id: 'household', label: 'Household', icon: 'users', tags: 'household share invite member family roommate partner role viewer editor owner code' },
   { id: 'data', label: 'Data & export', icon: 'download', tags: 'export csv download backup data' },
   { id: 'client-properties', label: 'Properties', icon: 'home', tags: 'properties clients landscaper multi-property client management' },
+  { id: 'linked-devices', label: 'Linked Devices', icon: 'mic', tags: 'voice alexa google home apple shortcuts assistant linked devices oauth integration' },
   { id: 'branding', label: 'Branding', icon: 'star', tags: 'branding logo colour color business name landscaper white label report pdf' },
 ]
 
@@ -1239,6 +1240,112 @@ function BrandingTab({ search }) {
   )
 }
 
+const VOICE_CLIENTS = [
+  { id: 'alexa.lopezcloud.dev',          name: 'Amazon Alexa',    icon: 'mic' },
+  { id: 'google-home.lopezcloud.dev',    name: 'Google Home',     icon: 'mic' },
+  { id: 'apple-shortcuts.lopezcloud.dev', name: 'Apple Shortcuts', icon: 'mic' },
+]
+
+function LinkedDevicesTab({ search }) {
+  const { isGuest } = useAuth()
+  const [grants, setGrants] = useState([])
+  const [loading, setLoading] = useState(!isGuest)
+  const [error, setError] = useState(null)
+  const [revoking, setRevoking] = useState(null)
+
+  const loadGrants = useCallback(async () => {
+    try {
+      setLoading(true)
+      const { grants: list } = await oauthApi.listGrants()
+      setGrants(list)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { if (!isGuest) loadGrants() }, [loadGrants, isGuest])
+
+  const handleRevoke = async (id) => {
+    setRevoking(id)
+    setError(null)
+    try {
+      await oauthApi.revokeGrant(id)
+      setGrants((prev) => prev.filter((g) => g.id !== id))
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setRevoking(null)
+    }
+  }
+
+  return (
+    <>
+      <SettingSection id="linked-devices-intro" title="Linked Voice Assistants" icon="mic" search={search}>
+        <p className="text-muted fs-sm mb-3">
+          Connect your plant tracker to voice assistants like Amazon Alexa, Google Home, or Apple Shortcuts.
+          Once linked, you can ask your assistant to water plants, check care schedules, and get weather alerts hands-free.
+          Requires a <strong>Home Pro</strong> subscription.
+        </p>
+        <div className="row g-2">
+          {VOICE_CLIENTS.map((client) => (
+            <div key={client.id} className="col-12 col-md-4">
+              <div className="border rounded p-3 d-flex flex-column align-items-center gap-2 text-center">
+                <svg className="sa-icon sa-icon-2x" aria-hidden="true">
+                  <use href="/icons/sprite.svg#mic"></use>
+                </svg>
+                <div className="fw-semibold fs-sm">{client.name}</div>
+                <div className="text-muted fs-xs">Account linking coming soon</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </SettingSection>
+
+      <SettingSection id="linked-devices-active" title="Active Connections" icon="shield" search={search}>
+        {error && <div className="alert alert-danger py-2 mb-3">{error}</div>}
+        {loading ? (
+          <p className="text-muted fs-sm">Loading…</p>
+        ) : grants.length === 0 ? (
+          <p className="text-muted fs-sm">No linked voice assistants yet.</p>
+        ) : (
+          <Table size="sm" className="mb-0">
+            <thead>
+              <tr>
+                <th>Device</th>
+                <th>Connected</th>
+                <th>Expires</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {grants.map((g) => (
+                <tr key={g.id}>
+                  <td>{g.clientName}</td>
+                  <td className="text-muted fs-xs">{new Date(g.createdAt).toLocaleDateString()}</td>
+                  <td className="text-muted fs-xs">{new Date(g.expiresAt).toLocaleDateString()}</td>
+                  <td>
+                    <Button
+                      variant="outline-danger"
+                      size="sm"
+                      onClick={() => handleRevoke(g.id)}
+                      disabled={revoking === g.id}
+                      data-testid={`revoke-grant-${g.id}`}
+                    >
+                      {revoking === g.id ? 'Revoking…' : 'Revoke'}
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+      </SettingSection>
+    </>
+  )
+}
+
 function ClientPropertiesTab({ search }) {
   const { properties, refresh } = useProperty()
   const [creating, setCreating] = useState(false)
@@ -1405,6 +1512,7 @@ export default function SettingsPage() {
         {tab === 'household' && <HouseholdTab search={search} />}
         {tab === 'data' && <DataTab search={search} />}
         {tab === 'client-properties' && <ClientPropertiesTab search={search} />}
+        {tab === 'linked-devices' && <LinkedDevicesTab search={search} />}
         {tab === 'branding' && <BrandingTab search={search} />}
       </div>
     </div>

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -12,7 +12,7 @@ import { TIMEZONE_GROUPS } from '../hooks/useTimezone.js'
 import { SUPPORTED_LANGUAGES } from '../i18n/index.js'
 import { useTranslation } from 'react-i18next'
 import i18n from '../i18n/index.js'
-import { accountApi, exportApi, brandingApi, imagesApi, householdsApi, propertiesApi, oauthApi, reportsApi, marketplaceApi } from '../api/plants.js'
+import { accountApi, exportApi, brandingApi, imagesApi, householdsApi, propertiesApi, oauthApi, reportsApi, marketplaceApi, notificationsApi } from '../api/plants.js'
 import { useHousehold } from '../context/HouseholdContext.jsx'
 import { useProperty } from '../context/PropertyContext.jsx'
 import { useProfile } from '../context/ProfileContext.jsx'
@@ -23,6 +23,7 @@ const TABS = [
   { id: 'household', label: 'Household', icon: 'users', tags: 'household share invite member family roommate partner role viewer editor owner code' },
   { id: 'data', label: 'Data & export', icon: 'download', tags: 'export csv download backup data' },
   { id: 'client-properties', label: 'Properties', icon: 'home', tags: 'properties clients landscaper multi-property client management' },
+  { id: 'notifications', label: 'Notifications', icon: 'bell', tags: 'notifications push email reminders watering alerts digest' },
   { id: 'marketplace', label: 'Marketplace', icon: 'package', tags: 'marketplace cuttings swaps community display name contact karma' },
   { id: 'linked-devices', label: 'Linked Devices', icon: 'mic', tags: 'voice alexa google home apple shortcuts assistant linked devices oauth integration' },
   { id: 'branding', label: 'Branding', icon: 'star', tags: 'branding logo colour color business name landscaper white label report pdf' },
@@ -1241,6 +1242,96 @@ function BrandingTab({ search }) {
   )
 }
 
+function NotificationsTab({ search }) {
+  const [prefs, setPrefs] = useState(null)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    notificationsApi.getPreferences().then(setPrefs).catch((e) => setError(e.message))
+  }, [])
+
+  const handleChange = (key, value) => setPrefs((p) => ({ ...p, [key]: value }))
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const updated = await notificationsApi.updatePreferences(prefs)
+      setPrefs(updated)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const requestPushPermission = async () => {
+    if (!('Notification' in window)) { setError('Push notifications are not supported in this browser.'); return }
+    const permission = await Notification.requestPermission()
+    if (permission !== 'granted') { setError('Push permission denied.'); return }
+    if ('serviceWorker' in navigator) {
+      const reg = await navigator.serviceWorker.ready
+      const vapidKey = import.meta.env.VITE_VAPID_PUBLIC_KEY
+      if (!vapidKey) { setError('Push not configured (missing VAPID key).'); return }
+      const sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: vapidKey })
+      await notificationsApi.registerToken({ subscription: JSON.parse(JSON.stringify(sub)), deviceLabel: navigator.userAgent.slice(0, 60) })
+      handleChange('pushEnabled', true)
+    }
+  }
+
+  if (!prefs) return <p className="text-muted fs-sm">Loading…</p>
+
+  return (
+    <div className="settings-section">
+      <h4 className="settings-section-title">Notifications</h4>
+      {error && <div className="alert alert-danger py-2 fs-sm mb-3">{error}</div>}
+      <div className="card mb-3">
+        <div className="card-body">
+          <h6 className="mb-3">Channels</h6>
+          <Form.Check type="switch" id="notif-email" label="Daily digest email" checked={!!prefs.emailEnabled} onChange={(e) => handleChange('emailEnabled', e.target.checked)} className="mb-2" />
+          {prefs.pushEnabled ? (
+            <Form.Check type="switch" id="notif-push" label="Push notifications (enabled)" checked={!!prefs.pushEnabled} onChange={(e) => handleChange('pushEnabled', e.target.checked)} className="mb-2" />
+          ) : (
+            <div className="d-flex align-items-center gap-2 mb-2">
+              <Form.Check type="switch" id="notif-push" label="Push notifications" checked={false} onChange={() => requestPushPermission()} />
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="card mb-3">
+        <div className="card-body">
+          <h6 className="mb-3">Alert types</h6>
+          <Form.Check type="switch" id="notif-daily" label="Daily digest (due plants, overdue count)" checked={!!prefs.dailyDigest} onChange={(e) => handleChange('dailyDigest', e.target.checked)} className="mb-2" />
+          <Form.Check type="switch" id="notif-weekly" label="Weekly digest" checked={!!prefs.weeklyDigest} onChange={(e) => handleChange('weeklyDigest', e.target.checked)} className="mb-2" />
+          <Form.Check type="switch" id="notif-alerts" label="Per-plant alerts (overdue ≥ 3 days, frost/heatwave)" checked={!!prefs.perPlantAlerts} onChange={(e) => handleChange('perPlantAlerts', e.target.checked)} />
+        </div>
+      </div>
+      <div className="card mb-3">
+        <div className="card-body">
+          <h6 className="mb-3">Quiet hours</h6>
+          <div className="row g-2">
+            <div className="col-6">
+              <Form.Label className="fs-xs text-muted mb-1">Start</Form.Label>
+              <Form.Control type="time" size="sm" value={prefs.quietHoursStart || '08:00'} onChange={(e) => handleChange('quietHoursStart', e.target.value)} />
+            </div>
+            <div className="col-6">
+              <Form.Label className="fs-xs text-muted mb-1">End</Form.Label>
+              <Form.Control type="time" size="sm" value={prefs.quietHoursEnd || '20:00'} onChange={(e) => handleChange('quietHoursEnd', e.target.value)} />
+            </div>
+          </div>
+        </div>
+      </div>
+      <Button size="sm" variant="primary" onClick={handleSave} disabled={saving}>
+        {saving ? 'Saving…' : saved ? 'Saved!' : 'Save preferences'}
+      </Button>
+    </div>
+  )
+}
+
 function MarketplaceTab({ search }) {
   const { isGuest } = useAuth()
   const [profile, setProfile] = useState({ displayName: '', contactEmail: '', karma: 0, badges: [] })
@@ -1751,6 +1842,7 @@ export default function SettingsPage() {
         {tab === 'household' && <HouseholdTab search={search} />}
         {tab === 'data' && <DataTab search={search} />}
         {tab === 'client-properties' && <ClientPropertiesTab search={search} />}
+        {tab === 'notifications' && <NotificationsTab search={search} />}
         {tab === 'marketplace' && <MarketplaceTab search={search} />}
         {tab === 'linked-devices' && <LinkedDevicesTab search={search} />}
         {tab === 'branding' && <BrandingTab search={search} />}

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -12,7 +12,7 @@ import { TIMEZONE_GROUPS } from '../hooks/useTimezone.js'
 import { SUPPORTED_LANGUAGES } from '../i18n/index.js'
 import { useTranslation } from 'react-i18next'
 import i18n from '../i18n/index.js'
-import { accountApi, exportApi, brandingApi, imagesApi, householdsApi, propertiesApi, oauthApi, reportsApi } from '../api/plants.js'
+import { accountApi, exportApi, brandingApi, imagesApi, householdsApi, propertiesApi, oauthApi, reportsApi, marketplaceApi } from '../api/plants.js'
 import { useHousehold } from '../context/HouseholdContext.jsx'
 import { useProperty } from '../context/PropertyContext.jsx'
 import { useProfile } from '../context/ProfileContext.jsx'
@@ -23,6 +23,7 @@ const TABS = [
   { id: 'household', label: 'Household', icon: 'users', tags: 'household share invite member family roommate partner role viewer editor owner code' },
   { id: 'data', label: 'Data & export', icon: 'download', tags: 'export csv download backup data' },
   { id: 'client-properties', label: 'Properties', icon: 'home', tags: 'properties clients landscaper multi-property client management' },
+  { id: 'marketplace', label: 'Marketplace', icon: 'package', tags: 'marketplace cuttings swaps community display name contact karma' },
   { id: 'linked-devices', label: 'Linked Devices', icon: 'mic', tags: 'voice alexa google home apple shortcuts assistant linked devices oauth integration' },
   { id: 'branding', label: 'Branding', icon: 'star', tags: 'branding logo colour color business name landscaper white label report pdf' },
 ]
@@ -1240,6 +1241,77 @@ function BrandingTab({ search }) {
   )
 }
 
+function MarketplaceTab({ search }) {
+  const { isGuest } = useAuth()
+  const [profile, setProfile] = useState({ displayName: '', contactEmail: '', karma: 0, badges: [] })
+  const [loading, setLoading] = useState(!isGuest)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+  const [saved, setSaved] = useState(false)
+
+  useEffect(() => {
+    if (isGuest) return
+    marketplaceApi.getMyProfile()
+      .then((data) => setProfile((p) => ({ ...p, ...data })))
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false))
+  }, [isGuest])
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    setSaved(false)
+    try {
+      await marketplaceApi.updateMyProfile({ displayName: profile.displayName, contactEmail: profile.contactEmail })
+      setSaved(true)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <SettingSection id="marketplace-profile" title="Marketplace Profile" icon="package" search={search}>
+        <p className="text-muted fs-sm mb-3">
+          Your public profile on the <a href="/community" className="text-primary">Community Cuttings Board</a>.
+          Your display name and karma are visible to other gardeners; your contact details are only shown to users you engage with.
+        </p>
+        {error && <div className="alert alert-danger py-2 mb-3">{error}</div>}
+        {saved && <div className="alert alert-success py-2 mb-3">Profile saved.</div>}
+        {loading ? (
+          <p className="text-muted fs-sm">Loading…</p>
+        ) : (
+          <>
+            <div className="row g-3 mb-3">
+              <div className="col-12 col-md-4 text-center">
+                <div className="fw-bold display-6 text-primary">{profile.karma || 0}</div>
+                <div className="text-muted fs-xs">Karma</div>
+              </div>
+              <div className="col-12 col-md-8">
+                <Form.Group className="mb-3">
+                  <Form.Label className="fs-sm fw-semibold">Display name</Form.Label>
+                  <Form.Control size="sm" value={profile.displayName || ''} onChange={(e) => setProfile((p) => ({ ...p, displayName: e.target.value }))}
+                    placeholder="e.g. PlantLover42" maxLength={64} />
+                  <Form.Text className="text-muted fs-xs">Shown on your listings. Leave blank to appear as &quot;Anonymous&quot;.</Form.Text>
+                </Form.Group>
+                <Form.Group className="mb-0">
+                  <Form.Label className="fs-sm fw-semibold">Contact email (for listings)</Form.Label>
+                  <Form.Control type="email" size="sm" value={profile.contactEmail || ''} onChange={(e) => setProfile((p) => ({ ...p, contactEmail: e.target.value }))}
+                    placeholder="you@example.com" />
+                  <Form.Text className="text-muted fs-xs">Shown on your active listings so collectors can reach you.</Form.Text>
+                </Form.Group>
+              </div>
+            </div>
+            <Button size="sm" variant="primary" onClick={handleSave} disabled={saving}>{saving ? 'Saving…' : 'Save profile'}</Button>
+          </>
+        )}
+      </SettingSection>
+    </>
+  )
+}
+
 const VOICE_CLIENTS = [
   { id: 'alexa.lopezcloud.dev',          name: 'Amazon Alexa',    icon: 'mic' },
   { id: 'google-home.lopezcloud.dev',    name: 'Google Home',     icon: 'mic' },
@@ -1679,6 +1751,7 @@ export default function SettingsPage() {
         {tab === 'household' && <HouseholdTab search={search} />}
         {tab === 'data' && <DataTab search={search} />}
         {tab === 'client-properties' && <ClientPropertiesTab search={search} />}
+        {tab === 'marketplace' && <MarketplaceTab search={search} />}
         {tab === 'linked-devices' && <LinkedDevicesTab search={search} />}
         {tab === 'branding' && <BrandingTab search={search} />}
       </div>

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -28,6 +28,8 @@ const PortalPage = lazy(() => import('../pages/PortalPage.jsx'))
 const SitPage = lazy(() => import('../pages/SitPage.jsx'))
 const RebatesPage = lazy(() => import('../pages/RebatesPage.jsx'))
 const GiftPage = lazy(() => import('../pages/GiftPage.jsx'))
+const CommunityPage = lazy(() => import('../pages/CommunityPage.jsx'))
+const CommunityGuidelinesPage = lazy(() => import('../pages/CommunityGuidelinesPage.jsx'))
 
 export const routes = [
   {
@@ -39,6 +41,7 @@ export const routes = [
       { path: '/scan/:shortCode', element: <Suspense fallback={null}><ScanPage /></Suspense> },
       { path: '/portal/:token', element: <Suspense fallback={null}><PortalPage /></Suspense> },
       { path: '/sit/:token', element: <Suspense fallback={null}><SitPage /></Suspense> },
+      { path: '/community-guidelines', element: <Suspense fallback={null}><CommunityGuidelinesPage /></Suspense> },
       {
         element: <AuthLayout />,
         children: [
@@ -68,6 +71,7 @@ export const routes = [
           { path: 'admin/:tab', element: <AdminPage />, handle: { breadcrumb: 'Admin' } },
           { path: 'pricing', element: <PricingPage />, handle: { breadcrumb: 'Pricing' } },
           { path: 'rebates', element: <Suspense fallback={null}><RebatesPage /></Suspense>, handle: { breadcrumb: 'Rebates & Grants' } },
+          { path: 'community', element: <Suspense fallback={null}><CommunityPage /></Suspense>, handle: { breadcrumb: 'Community' } },
         ],
       },
     ],


### PR DESCRIPTION
## Summary

Six features implemented on this branch.

### #263 — Voice-ready API (OAuth 2.0 + `/voice/*` endpoints)
- RFC 6749 authorisation code flow + RFC 7009 revocation; `/oauth/authorize`, `/oauth/token`, `/oauth/revoke`, `/oauth/grants`
- Voice intent endpoints (Bearer + home_pro): today, plant status, water, weather
- Frontend: `oauthApi` client; Settings → Linked Devices tab

### #160 — Plant care report PDF generation
- `POST /reports/generate` (home_pro+) → PDF via `@react-pdf/renderer` → GCS 30-day TTL
- `GET /reports`, `GET /reports/:id/download`; Settings → Client Properties "Report" button

### #264 — Community cuttings board
- 10 marketplace routes (create/list/get/update/claim/confirm-handover/report/profile/me) with postcodes.io centroid caching, haversine distance, Gemini moderation, blocked-word list, auto-hide at 3 reports, +1 karma on handover
- Frontend: `/community` page, `/community-guidelines`, sidebar nav, Settings → Marketplace tab

### #162 — Push & email notifications (dark-shipped)
- Notification preferences CRUD, FCM/Web Push token registration, daily dispatch handler with quiet-hours filtering, idempotency guard, SendGrid email + web-push delivery
- `api/plants/email.js` — SendGrid helper; dark-shipped behind `NOTIFICATIONS_ENABLED=true`
- Frontend: Settings → Notifications tab; `NotificationBanner` soft-prompt on dashboard

### #163 — Team members & RBAC
- `POST /team/invite`, `GET /team`, `PATCH/DELETE /team/:uid`, `POST /team/accept`, `GET /me/orgs` — all gated by `requireTier('landscaper_pro')` + `checkQuota('team_members')`
- Invite flow: 32-byte URL-safe token, 7-day expiry, single-use; dual-write to owner team + reverse `teamMemberships` lookup
- Frontend: Settings → Team tab (invite form, member list with role change + suspend)

### #164 — Visit scheduling & job tracking
- `GET/POST/PUT/DELETE /visits`, check-in / check-out / complete actions, iCal feed (`GET /visits.ics?token=...`) with per-user token, recurrence materialisation (`POST /visits/materialise`) — weekly / fortnightly / monthly / custom
- All gated by `requireTier('landscaper_pro')`; RBAC: technicians only see visits assigned to them via `?ownerUid=`
- Frontend: `/visits` calendar list view grouped by day, `VisitModal` with recurrence, iCal token copy UI, `UpgradePrompt` gate
- API client: `visitApi` added to `src/api/plants.js`; "Visit schedule" menu entry under "Pro tools"

## Test plan
- [x] Backend: 639 tests pass; coverage 80.87% stmts (above 80% threshold)
- [x] Frontend: build clean
- [x] Lint: zero errors
- [x] `npm run preflight:fast` passes

Closes #263
Closes #160
Closes #264
Closes #162
Closes #163
Closes #164

https://claude.ai/code/session_0119Nj5MiqRLH3oLHZ6LCjTj