### PR TITLE
feat(#311, #309): rebate finder + gift subscriptions

### DIFF
--- a/api/plants/data/rebates/uk-london.json
+++ b/api/plants/data/rebates/uk-london.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "london-rewilding-garden-grant",
+    "name": "London Rewilding Home Garden Grant",
+    "region": "uk-london",
+    "category": "native-plant",
+    "amountFormula": "Up to £500 for native plantings and wildlife features",
+    "amountCents": 50000,
+    "amountUnit": "flat",
+    "eligibility": {
+      "minLat": 51.28,
+      "maxLat": 51.7,
+      "minLng": -0.52,
+      "maxLng": 0.35
+    },
+    "applyUrl": "https://www.london.gov.uk/programmes-strategies/environment-and-climate-change/biodiversity",
+    "affiliateUrl": null,
+    "description": "Greater London Authority grants for homeowners converting garden space to native planting schemes that support pollinators and biodiversity.",
+    "validUntil": "2027-03-31"
+  },
+  {
+    "id": "thames-water-smart-meter",
+    "name": "Thames Water Smart Meter Programme",
+    "region": "uk-london",
+    "category": "water",
+    "amountFormula": "Free smart meter installation + water saving devices worth up to £40",
+    "amountCents": 4000,
+    "amountUnit": "flat",
+    "eligibility": {
+      "minLat": 51.28,
+      "maxLat": 51.7,
+      "minLng": -0.52,
+      "maxLng": 0.35
+    },
+    "applyUrl": "https://www.thameswater.co.uk/help/water-saving/smart-meters",
+    "affiliateUrl": null,
+    "description": "Thames Water customers can get a free smart meter and a bundle of free water-saving devices including a garden hosepipe timer.",
+    "validUntil": "2027-12-31"
+  },
+  {
+    "id": "london-water-butt-scheme",
+    "name": "London Borough Water Butt Discount Scheme",
+    "region": "uk-london",
+    "category": "water",
+    "amountFormula": "Water butts from £10 (discounted from RRP £50+)",
+    "amountCents": 1000,
+    "amountUnit": "flat",
+    "eligibility": {
+      "minLat": 51.28,
+      "maxLat": 51.7,
+      "minLng": -0.52,
+      "maxLng": 0.35
+    },
+    "applyUrl": "https://www.getcomposting.com/butt/",
+    "affiliateUrl": null,
+    "description": "Heavily subsidised water butts for London residents through borough councils. Collects rainwater for garden irrigation.",
+    "validUntil": "2027-12-31"
+  },
+  {
+    "id": "southwark-compost-bin",
+    "name": "Southwark Council Home Composting Scheme",
+    "region": "uk-london",
+    "category": "compost",
+    "amountFormula": "Subsidised compost bins from £7 (RRP £30+)",
+    "amountCents": 700,
+    "amountUnit": "flat",
+    "eligibility": {
+      "minLat": 51.45,
+      "maxLat": 51.55,
+      "minLng": -0.11,
+      "maxLng": 0.07
+    },
+    "applyUrl": "https://www.southwark.gov.uk/environment-and-green-spaces/recycling-and-rubbish/home-composting",
+    "affiliateUrl": null,
+    "description": "Southwark Council residents can buy subsidised compost bins and wormeries to recycle kitchen and garden waste into plant food.",
+    "validUntil": "2027-12-31"
+  },
+  {
+    "id": "london-urban-orchard",
+    "name": "London Urban Orchard / Community Fruit Tree Scheme",
+    "region": "uk-london",
+    "category": "native-plant",
+    "amountFormula": "Free or subsidised fruit trees (up to 3 per garden)",
+    "amountCents": 3000,
+    "amountUnit": "flat",
+    "eligibility": {
+      "minLat": 51.28,
+      "maxLat": 51.7,
+      "minLng": -0.52,
+      "maxLng": 0.35
+    },
+    "applyUrl": "https://www.londontreeofficers.com/community-fruit-tree-scheme",
+    "affiliateUrl": null,
+    "description": "Mayor of London scheme providing subsidised fruit trees for private London gardens to increase canopy cover and urban food production.",
+    "validUntil": "2027-04-30"
+  },
+  {
+    "id": "hackney-green-garden-grant",
+    "name": "Hackney Green Garden Grant",
+    "region": "uk-london",
+    "category": "native-plant",
+    "amountFormula": "Up to £250 for front-garden greening",
+    "amountCents": 25000,
+    "amountUnit": "flat",
+    "eligibility": {
+      "minLat": 51.52,
+      "maxLat": 51.58,
+      "minLng": -0.1,
+      "maxLng": 0.0
+    },
+    "applyUrl": "https://hackney.gov.uk/greener-hackney",
+    "affiliateUrl": null,
+    "description": "Hackney Council grants for replacing front-garden paving with plants, helping manage surface water run-off and improve local biodiversity.",
+    "validUntil": "2027-03-31"
+  }
+]

--- a/api/plants/data/rebates/us-ca.json
+++ b/api/plants/data/rebates/us-ca.json
@@ -1,0 +1,135 @@
+[
+  {
+    "id": "socal-mwd-turf-rebate",
+    "name": "SoCal MWD Turf Replacement Rebate",
+    "region": "us-ca",
+    "category": "water",
+    "amountFormula": "Up to $2/sq ft, max $6,000",
+    "amountCents": 200,
+    "amountUnit": "per_sq_ft",
+    "eligibility": {
+      "minLat": 32.5,
+      "maxLat": 35.5,
+      "minLng": -119.5,
+      "maxLng": -116.0
+    },
+    "applyUrl": "https://socalwatersmart.com/index.php/landing/turf_removal",
+    "affiliateUrl": null,
+    "description": "Replace lawn grass with low-water plants or permeable surfaces. Participating Southern California water agencies offer up to $2/sq ft in rebates.",
+    "validUntil": "2027-06-30"
+  },
+  {
+    "id": "ladwp-turf-removal",
+    "name": "LADWP Turf Removal & Water-Efficient Landscape",
+    "region": "us-ca",
+    "category": "water",
+    "amountFormula": "Up to $4/sq ft for qualified turf removal",
+    "amountCents": 400,
+    "amountUnit": "per_sq_ft",
+    "eligibility": {
+      "minLat": 33.7,
+      "maxLat": 34.35,
+      "minLng": -118.9,
+      "maxLng": -118.1
+    },
+    "applyUrl": "https://www.ladwp.com/conservation/conservation-programs/turf-removal-program",
+    "affiliateUrl": null,
+    "description": "Los Angeles DWP customers can receive up to $4/sq ft for replacing grass with drought-tolerant landscaping including native plants.",
+    "validUntil": "2027-03-31"
+  },
+  {
+    "id": "ebmud-baywise-rebate",
+    "name": "EBMUD Bay-Friendly Landscape Rebate",
+    "region": "us-ca",
+    "category": "water",
+    "amountFormula": "$200 per completed assessment + $2/sq ft turf removal",
+    "amountCents": 200,
+    "amountUnit": "per_sq_ft",
+    "eligibility": {
+      "minLat": 37.45,
+      "maxLat": 38.1,
+      "minLng": -122.5,
+      "maxLng": -121.8
+    },
+    "applyUrl": "https://www.ebmud.com/water-and-wastewater/conservation/rebates-and-programs/bay-friendly-landscape/",
+    "affiliateUrl": null,
+    "description": "East Bay MUD customers can receive rebates for turf removal and installation of low-water, climate-adapted plants in the Bay Area.",
+    "validUntil": "2027-12-31"
+  },
+  {
+    "id": "sdcwa-replace-dont-displace",
+    "name": "San Diego Turf Replacement Program",
+    "region": "us-ca",
+    "category": "water",
+    "amountFormula": "Up to $1.75/sq ft for grass removal, max $2,500",
+    "amountCents": 175,
+    "amountUnit": "per_sq_ft",
+    "eligibility": {
+      "minLat": 32.5,
+      "maxLat": 33.4,
+      "minLng": -117.6,
+      "maxLng": -116.1
+    },
+    "applyUrl": "https://www.sdcwa.org/your-water/conservation-programs/turf-rebate-program",
+    "affiliateUrl": null,
+    "description": "San Diego County Water Authority customers can replace grass with drought-tolerant plants and receive rebates of up to $1.75/sq ft.",
+    "validUntil": "2027-09-30"
+  },
+  {
+    "id": "ca-native-plant-rebate",
+    "name": "California Native Plant Rebate (statewide)",
+    "region": "us-ca",
+    "category": "native-plant",
+    "amountFormula": "$50–$300 voucher per participating nursery visit",
+    "amountCents": 15000,
+    "amountUnit": "flat",
+    "eligibility": {
+      "minLat": 32.5,
+      "maxLat": 42.0,
+      "minLng": -124.5,
+      "maxLng": -114.1
+    },
+    "applyUrl": "https://calwild.org/native-plant-rebate-program/",
+    "affiliateUrl": null,
+    "description": "Statewide programme offering vouchers for California native plants at participating nurseries. Available to all California homeowners.",
+    "validUntil": "2027-12-31"
+  },
+  {
+    "id": "alameda-county-compost",
+    "name": "Alameda County Compost Bin & Vermicompost Rebate",
+    "region": "us-ca",
+    "category": "compost",
+    "amountFormula": "Up to $50 back on compost bins or vermicomposters",
+    "amountCents": 5000,
+    "amountUnit": "flat",
+    "eligibility": {
+      "minLat": 37.45,
+      "maxLat": 38.0,
+      "minLng": -122.4,
+      "maxLng": -121.7
+    },
+    "applyUrl": "https://www.stopwaste.org/at-home/home-compostinginstallation",
+    "affiliateUrl": null,
+    "description": "Alameda County residents can purchase composting bins and vermicomposters at a discount or receive rebates through StopWaste.",
+    "validUntil": "2027-12-31"
+  },
+  {
+    "id": "pge-energy-upgrade-ca",
+    "name": "PG&E / Energy Upgrade California Landscape Irrigation Rebate",
+    "region": "us-ca",
+    "category": "energy",
+    "amountFormula": "Up to $300 for smart irrigation controllers",
+    "amountCents": 30000,
+    "amountUnit": "flat",
+    "eligibility": {
+      "minLat": 35.0,
+      "maxLat": 42.0,
+      "minLng": -124.5,
+      "maxLng": -119.0
+    },
+    "applyUrl": "https://www.pge.com/en/account/rate-plans/clean-energy/rebates.html",
+    "affiliateUrl": null,
+    "description": "PG&E customers in Northern California can receive rebates for installing weather-based smart irrigation controllers that reduce outdoor water and energy use.",
+    "validUntil": "2027-06-30"
+  }
+]

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -158,6 +158,8 @@ async function attachHouseholdContext(req, claims) {
   req.userId = ctx.userId;
   req.householdId = ctx.householdId;
   req.role = ctx.role;
+  req.actorDisplayName = displayName;
+  req.actorEmail = claims.email || null;
 }
 
 function requireUser(req, res, next) {
@@ -245,6 +247,73 @@ async function signPlantData(data) {
 
 const OUTDOOR_ROOMS = new Set(['Garden', 'Balcony', 'Outdoors', 'Patio', 'Terrace', 'Deck', 'Yard', 'Courtyard', 'Porch', 'Veranda']);
 
+// ── Gift subscription helpers ─────────────────────────────────────────────────
+const GIFT_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+
+function generateGiftCode() {
+  const b = crypto.randomBytes(12);
+  let out = '';
+  for (let i = 0; i < 12; i++) {
+    out += GIFT_CODE_ALPHABET[b[i] % GIFT_CODE_ALPHABET.length];
+    if (i === 3 || i === 7) out += '-';
+  }
+  return out;
+}
+
+function hashGiftCode(code) {
+  return crypto.createHash('sha256').update(code.toUpperCase()).digest('hex');
+}
+
+const GIFT_PRICE_ENV = {
+  3:  'STRIPE_PRICE_GIFT_HOMEPRO_3MO',
+  12: 'STRIPE_PRICE_GIFT_HOMEPRO_1YR',
+};
+
+async function handleGiftPurchaseCompleted(db, session) {
+  const meta = session.metadata || {};
+  const purchaserUid = meta.purchaserUid;
+  if (!purchaserUid) return;
+  const durationMonths = parseInt(meta.durationMonths, 10) || 3;
+
+  // Retry up to 3 times for a unique code.
+  let code, codeHashed;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    code = generateGiftCode();
+    codeHashed = hashGiftCode(code);
+    const existing = await db.collection('giftCodeHashes').doc(codeHashed).get();
+    if (!existing.exists) break;
+    if (attempt === 2) throw new Error('Failed to generate a unique gift code');
+  }
+
+  const now = new Date().toISOString();
+  const expiresAt = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
+  const giftId = `${purchaserUid.slice(0, 8)}-${Date.now()}`;
+
+  const giftData = {
+    code,
+    codeHashed,
+    purchaserUid,
+    purchaserEmail: session.customer_email || null,
+    recipientEmail: meta.recipientEmail || null,
+    recipientName: meta.recipientName || null,
+    tier: 'home_pro',
+    durationMonths,
+    stripePaymentIntentId: session.payment_intent || null,
+    status: 'active',
+    purchasedAt: now,
+    expiresAt,
+  };
+
+  await db.collection('gifts').doc(giftId).set(giftData);
+  await db.collection('giftCodeHashes').doc(codeHashed).set({ giftId });
+  await db.collection('users').doc(purchaserUid).collection('giftsSent').doc(giftId).set({
+    giftId, status: 'active', tier: 'home_pro', durationMonths,
+    recipientEmail: meta.recipientEmail || null,
+    recipientName: meta.recipientName || null,
+    purchasedAt: now, expiresAt,
+  });
+}
+
 // ── Rebate catalog (loaded at boot; served from memory) ───────────────────────
 const REBATE_CATALOG = [
   ...require('./data/rebates/us-ca.json'),
@@ -298,7 +367,12 @@ app.post('/billing/webhook', express.raw({ type: 'application/json' }), async (r
   await eventRef.set({ type: event.type, receivedAt: new Date().toISOString() });
 
   try {
-    await billing.applySubscriptionEvent(db, event);
+    const obj = event.data?.object || {};
+    if (event.type === 'checkout.session.completed' && obj.metadata?.giftPurchase === 'true') {
+      await handleGiftPurchaseCompleted(db, obj);
+    } else {
+      await billing.applySubscriptionEvent(db, event);
+    }
     return res.status(200).json({ received: true });
   } catch (err) {
     return res.status(500).json({ error: err.message });
@@ -6523,6 +6597,107 @@ app.post('/sit/:token/water/:plantId', async (req, res) => {
     res.status(201).json({ wateredAt: now, wateredBy: sitterName });
   } catch (err) {
     res.status(500).json({ error: err.message });
+  }
+});
+
+// ── Gift subscriptions ────────────────────────────────────────────────────────
+
+app.post('/gifts/purchase', requireUser, async (req, res) => {
+  const { durationMonths = 3, recipientEmail, recipientName, currency = 'usd' } = req.body || {};
+  const months = parseInt(durationMonths, 10);
+  if (months !== 3 && months !== 12) {
+    return res.status(400).json({ error: 'durationMonths must be 3 or 12' });
+  }
+
+  const stripe = billing.getStripe();
+  if (!stripe) return res.status(503).json({ error: 'billing_disabled' });
+
+  const priceEnvKey = GIFT_PRICE_ENV[months];
+  const priceId = process.env[priceEnvKey];
+  if (!priceId) return res.status(503).json({ error: `Gift price not configured (${priceEnvKey})` });
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      client_reference_id: req.userId,
+      line_items: [{ price: priceId, quantity: 1 }],
+      currency,
+      success_url: `${process.env.BILLING_SUCCESS_URL || 'https://plants.lopezcloud.dev'}/settings/billing?gift=sent`,
+      cancel_url: `${process.env.BILLING_CANCEL_URL || 'https://plants.lopezcloud.dev'}/gift?status=cancelled`,
+      metadata: {
+        giftPurchase: 'true',
+        purchaserUid: req.userId,
+        durationMonths: String(months),
+        recipientEmail: recipientEmail || '',
+        recipientName: recipientName || '',
+      },
+    });
+    return res.status(200).json({ url: session.url, id: session.id });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/gifts/redeem', requireUser, async (req, res) => {
+  const { code } = req.body || {};
+  if (!code || typeof code !== 'string') {
+    return res.status(400).json({ error: 'code is required' });
+  }
+  const codeHashed = hashGiftCode(code.replace(/-/g, '').trim());
+  try {
+    const hashSnap = await db.collection('giftCodeHashes').doc(codeHashed).get();
+    if (!hashSnap.exists) return res.status(404).json({ error: 'invalid_code' });
+    const { giftId } = hashSnap.data();
+
+    const giftSnap = await db.collection('gifts').doc(giftId).get();
+    if (!giftSnap.exists) return res.status(404).json({ error: 'invalid_code' });
+    const gift = giftSnap.data();
+
+    if (gift.status !== 'active') return res.status(409).json({ error: 'gift_already_redeemed' });
+    if (gift.expiresAt && gift.expiresAt < new Date().toISOString()) {
+      return res.status(410).json({ error: 'gift_expired' });
+    }
+    if (gift.recipientEmail && req.actorEmail) {
+      if (gift.recipientEmail.toLowerCase() !== req.actorEmail.toLowerCase()) {
+        return res.status(403).json({ error: 'gift_not_for_this_account' });
+      }
+    }
+
+    const now = new Date();
+    const trialEnd = new Date(now.getTime() + gift.durationMonths * 30 * 24 * 60 * 60 * 1000).toISOString();
+
+    await db.collection('users').doc(req.userId).collection('subscription').doc('current').set({
+      isTrial: true,
+      trialTier: gift.tier,
+      trialEnd,
+      status: 'active',
+      giftRedemptionId: giftId,
+      updatedAt: now.toISOString(),
+    }, { merge: true });
+
+    const update = {
+      status: 'redeemed', redeemedAt: now.toISOString(), redeemedByUid: req.userId,
+    };
+    await db.collection('gifts').doc(giftId).set(update, { merge: true });
+    if (gift.purchaserUid) {
+      await db.collection('users').doc(gift.purchaserUid).collection('giftsSent').doc(giftId).set(
+        { status: 'redeemed', redeemedAt: now.toISOString() }, { merge: true }
+      );
+    }
+
+    return res.status(200).json({ tier: gift.tier, trialEnd });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/gifts/mine', requireUser, async (req, res) => {
+  try {
+    const snap = await db.collection('users').doc(req.userId).collection('giftsSent').get();
+    const sent = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    return res.status(200).json({ sent });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
   }
 });
 

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -251,13 +251,18 @@ const OUTDOOR_ROOMS = new Set(['Garden', 'Balcony', 'Outdoors', 'Patio', 'Terrac
 const GIFT_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
 
 function generateGiftCode() {
-  const b = crypto.randomBytes(12);
-  let out = '';
-  for (let i = 0; i < 12; i++) {
-    out += GIFT_CODE_ALPHABET[b[i] % GIFT_CODE_ALPHABET.length];
-    if (i === 3 || i === 7) out += '-';
+  const len = GIFT_CODE_ALPHABET.length;
+  const maxUnbiased = 256 - (256 % len);
+  const positions = [];
+  while (positions.length < 12) {
+    const chunk = crypto.randomBytes(32);
+    for (let i = 0; i < chunk.length && positions.length < 12; i++) {
+      if (chunk[i] < maxUnbiased) positions.push(chunk[i] % len);
+    }
   }
-  return out;
+  return positions.slice(0, 4).map(p => GIFT_CODE_ALPHABET[p]).join('') + '-' +
+         positions.slice(4, 8).map(p => GIFT_CODE_ALPHABET[p]).join('') + '-' +
+         positions.slice(8, 12).map(p => GIFT_CODE_ALPHABET[p]).join('');
 }
 
 function hashGiftCode(code) {

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -245,6 +245,29 @@ async function signPlantData(data) {
 
 const OUTDOOR_ROOMS = new Set(['Garden', 'Balcony', 'Outdoors', 'Patio', 'Terrace', 'Deck', 'Yard', 'Courtyard', 'Porch', 'Veranda']);
 
+// ── Rebate catalog (loaded at boot; served from memory) ───────────────────────
+const REBATE_CATALOG = [
+  ...require('./data/rebates/us-ca.json'),
+  ...require('./data/rebates/uk-london.json'),
+];
+const REBATE_CATEGORIES = [
+  { id: 'water', label: 'Water Saving', icon: 'droplet' },
+  { id: 'native-plant', label: 'Native Plants', icon: 'leaf' },
+  { id: 'compost', label: 'Composting', icon: 'layers' },
+  { id: 'energy', label: 'Energy', icon: 'zap' },
+];
+
+function matchRebates(lat, lng) {
+  const now = new Date().toISOString().slice(0, 10);
+  return REBATE_CATALOG.filter((r) => {
+    const { minLat, maxLat, minLng, maxLng } = r.eligibility;
+    if (lat < minLat || lat > maxLat) return false;
+    if (lng < minLng || lng > maxLng) return false;
+    if (r.validUntil && r.validUntil < now) return false;
+    return true;
+  });
+}
+
 const billing = require('./billing');
 const { createTierGate } = require('./tierGate');
 
@@ -6501,6 +6524,22 @@ app.post('/sit/:token/water/:plantId', async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
+});
+
+// ── GET /rebates/categories ───────────────────────────────────────────────────
+app.get('/rebates/categories', (req, res) => {
+  res.status(200).json({ categories: REBATE_CATEGORIES });
+});
+
+// ── GET /rebates/matches ──────────────────────────────────────────────────────
+app.get('/rebates/matches', requireUser, (req, res) => {
+  const lat = parseFloat(req.query.lat);
+  const lng = parseFloat(req.query.lng);
+  if (isNaN(lat) || isNaN(lng)) {
+    return res.status(400).json({ error: 'lat and lng query parameters are required' });
+  }
+  const matches = matchRebates(lat, lng);
+  res.status(200).json({ rebates: matches, total: matches.length });
 });
 
 functions.http('plantsApi', app);

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -7100,3 +7100,76 @@ describe('GET /materials — propertyId scoping (billing enabled)', () => {
     expect(res.body.materials[0].name).toBe('Site supply');
   });
 });
+
+// ── GET /rebates/categories ───────────────────────────────────────────────────
+
+describe('GET /rebates/categories', () => {
+  it('returns the category list without auth', async () => {
+    const res = await request(app).get('/rebates/categories');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.categories)).toBe(true);
+    const ids = res.body.categories.map((c) => c.id);
+    expect(ids).toContain('water');
+    expect(ids).toContain('native-plant');
+    expect(ids).toContain('compost');
+    expect(ids).toContain('energy');
+  });
+});
+
+// ── GET /rebates/matches ──────────────────────────────────────────────────────
+
+describe('GET /rebates/matches', () => {
+  it('returns SoCal rebates for a Los Angeles coordinate', async () => {
+    const res = await request(app)
+      .get('/rebates/matches?lat=34.05&lng=-118.24')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBeGreaterThan(0);
+    const ids = res.body.rebates.map((r) => r.id);
+    expect(ids).toContain('ladwp-turf-removal');
+    expect(ids).toContain('socal-mwd-turf-rebate');
+  });
+
+  it('returns London rebates for a central London coordinate', async () => {
+    const res = await request(app)
+      .get('/rebates/matches?lat=51.5&lng=-0.1')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBeGreaterThan(0);
+    const ids = res.body.rebates.map((r) => r.id);
+    expect(ids).toContain('london-rewilding-garden-grant');
+    expect(ids).toContain('thames-water-smart-meter');
+  });
+
+  it('returns empty for a location with no matched rebates (New Zealand)', async () => {
+    const res = await request(app)
+      .get('/rebates/matches?lat=-36.85&lng=174.76')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(0);
+    expect(res.body.rebates).toHaveLength(0);
+  });
+
+  it('does not return SoCal rebates for a Bay Area coordinate', async () => {
+    const res = await request(app)
+      .get('/rebates/matches?lat=37.77&lng=-122.41')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    const ids = res.body.rebates.map((r) => r.id);
+    expect(ids).not.toContain('ladwp-turf-removal');
+    expect(ids).toContain('ebmud-baywise-rebate');
+  });
+
+  it('returns 400 when lat/lng are missing', async () => {
+    const res = await request(app)
+      .get('/rebates/matches')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/lat/);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).get('/rebates/matches?lat=34.05&lng=-118.24');
+    expect(res.status).toBe(401);
+  });
+});

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -6863,6 +6863,106 @@ describe('POST /materials', () => {
   });
 });
 
+describe('POST /gifts/purchase', () => {
+  it('returns 503 when billing is disabled', async () => {
+    const res = await request(app)
+      .post('/gifts/purchase')
+      .set('Authorization', authHeader())
+      .send({ durationMonths: 3 });
+    expect(res.status).toBe(503);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).post('/gifts/purchase').send({ durationMonths: 3 });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for an invalid durationMonths', async () => {
+    const res = await request(app)
+      .post('/gifts/purchase')
+      .set('Authorization', authHeader())
+      .send({ durationMonths: 6 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/durationMonths/);
+  });
+});
+
+describe('POST /gifts/redeem', () => {
+  it('returns 400 when code is missing', async () => {
+    const res = await request(app)
+      .post('/gifts/redeem')
+      .set('Authorization', authHeader())
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for a non-existent code', async () => {
+    const res = await request(app)
+      .post('/gifts/redeem')
+      .set('Authorization', authHeader())
+      .send({ code: 'XXXX-XXXX-XXXX' });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('invalid_code');
+  });
+
+  it('redeems a valid active gift and upgrades subscription', async () => {
+    const code = 'ABCD-EFGH-JKMN';
+    const codeHashed = require('crypto').createHash('sha256').update(code.replace(/-/g, '').trim()).digest('hex');
+    const giftId = 'gift-test-1';
+    store[`gifts/${giftId}`] = {
+      code, codeHashed, purchaserUid: 'other-user',
+      tier: 'home_pro', durationMonths: 3,
+      status: 'active', purchasedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 1e10).toISOString(),
+      recipientEmail: null,
+    };
+    store[`giftCodeHashes/${codeHashed}`] = { giftId };
+    store[`users/other-user/giftsSent/${giftId}`] = { giftId, status: 'active', durationMonths: 3 };
+
+    const res = await request(app)
+      .post('/gifts/redeem')
+      .set('Authorization', authHeader())
+      .send({ code });
+    expect(res.status).toBe(200);
+    expect(res.body.tier).toBe('home_pro');
+    expect(res.body.trialEnd).toBeDefined();
+
+    const sub = store[`users/${USER_SUB}/subscription/current`];
+    expect(sub.isTrial).toBe(true);
+    expect(sub.trialTier).toBe('home_pro');
+    expect(sub.giftRedemptionId).toBe(giftId);
+
+    const updatedGift = store[`gifts/${giftId}`];
+    expect(updatedGift.status).toBe('redeemed');
+    expect(updatedGift.redeemedByUid).toBe(USER_SUB);
+  });
+
+  it('returns 409 when the gift is already redeemed', async () => {
+    const code = 'AAAA-BBBB-CCCC';
+    const codeHashed = require('crypto').createHash('sha256').update(code.replace(/-/g, '').trim()).digest('hex');
+    const giftId = 'gift-redeemed-1';
+    store[`gifts/${giftId}`] = {
+      code, codeHashed, status: 'redeemed',
+      tier: 'home_pro', durationMonths: 3,
+      purchasedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 1e10).toISOString(),
+    };
+    store[`giftCodeHashes/${codeHashed}`] = { giftId };
+
+    const res = await request(app)
+      .post('/gifts/redeem')
+      .set('Authorization', authHeader())
+      .send({ code });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('gift_already_redeemed');
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).post('/gifts/redeem').send({ code: 'AAAA-BBBB-CCCC' });
+    expect(res.status).toBe(401);
+  });
+});
+
 describe('PUT /materials/:id', () => {
   it('updates material metadata', async () => {
     store[matPath('mat1')] = { name: 'Old name', unit: 'g', onHand: 100, reorderThreshold: 10, reorderQty: 20, archived: false };
@@ -7098,6 +7198,35 @@ describe('GET /materials — propertyId scoping (billing enabled)', () => {
     expect(res.status).toBe(200);
     expect(res.body.materials).toHaveLength(1);
     expect(res.body.materials[0].name).toBe('Site supply');
+  });
+});
+
+// ── Gift subscriptions ────────────────────────────────────────────────────────
+
+describe('GET /gifts/mine', () => {
+  beforeEach(() => {
+    store[`users/${USER_SUB}/giftsSent/gift-a`] = {
+      giftId: 'gift-a', status: 'active', tier: 'home_pro',
+      durationMonths: 3, recipientEmail: 'friend@example.com', purchasedAt: '2026-04-01T00:00:00Z',
+    };
+    store[`users/${USER_SUB}/giftsSent/gift-b`] = {
+      giftId: 'gift-b', status: 'redeemed', tier: 'home_pro',
+      durationMonths: 12, recipientEmail: null, purchasedAt: '2026-03-01T00:00:00Z',
+    };
+  });
+
+  it('returns sent gifts for the authenticated user', async () => {
+    const res = await request(app)
+      .get('/gifts/mine')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.sent)).toBe(true);
+    expect(res.body.sent.length).toBe(2);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).get('/gifts/mine');
+    expect(res.status).toBe(401);
   });
 });
 

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -7230,6 +7230,93 @@ describe('GET /gifts/mine', () => {
   });
 });
 
+
+// ── POST /billing/webhook (gift checkout) ────────────────────────────────────
+
+describe('POST /billing/webhook — gift checkout.session.completed', () => {
+  const FAKE_SK  = 'sk_test_fakefakefakefakefakefakefakefakefakefak';
+  const FAKE_WHSEC = 'whsec_testfakesecret';
+  let savedBillingEnabled;
+
+  beforeEach(() => {
+    savedBillingEnabled = process.env.BILLING_ENABLED;
+    process.env.BILLING_ENABLED = 'true';
+    process.env.STRIPE_SECRET_KEY = FAKE_SK;
+    process.env.STRIPE_WEBHOOK_SECRET = FAKE_WHSEC;
+  });
+
+  afterEach(() => {
+    if (savedBillingEnabled === undefined) {
+      delete process.env.BILLING_ENABLED;
+    } else {
+      process.env.BILLING_ENABLED = savedBillingEnabled;
+    }
+    delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+  });
+
+  function makeStripeHeader(payload) {
+    const Stripe = require('stripe');
+    const s = Stripe(FAKE_SK);
+    return s.webhooks.generateTestHeaderString({ payload, secret: FAKE_WHSEC });
+  }
+
+  it('mints a gift code and stores gift records for a completed gift checkout', async () => {
+    const purchaserUid = USER_SUB;
+    const session = {
+      id: 'cs_test_gift_001',
+      object: 'checkout.session',
+      payment_intent: 'pi_test_001',
+      customer_email: 'buyer@example.com',
+      metadata: {
+        giftPurchase: 'true',
+        purchaserUid,
+        durationMonths: '3',
+        recipientEmail: 'recipient@example.com',
+        recipientName: 'Alice',
+      },
+    };
+    const event = {
+      id: 'evt_gift_001',
+      type: 'checkout.session.completed',
+      data: { object: session },
+    };
+    const payload = JSON.stringify(event);
+    const header = makeStripeHeader(payload);
+
+    const res = await request(app)
+      .post('/billing/webhook')
+      .set('Content-Type', 'application/json')
+      .set('stripe-signature', header)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.received).toBe(true);
+
+    // A gift doc should have been written to giftCodeHashes
+    const hashEntries = Object.keys(store).filter(k => k.startsWith('giftCodeHashes/'));
+    expect(hashEntries.length).toBe(1);
+
+    // The purchaser should have a giftsSent record
+    const sentEntries = Object.keys(store).filter(k => k.startsWith(`users/${purchaserUid}/giftsSent/`));
+    expect(sentEntries.length).toBe(1);
+    const sent = store[sentEntries[0]];
+    expect(sent.status).toBe('active');
+    expect(sent.durationMonths).toBe(3);
+    expect(sent.recipientEmail).toBe('recipient@example.com');
+  });
+
+  it('returns 400 when the webhook signature is invalid', async () => {
+    const event = { id: 'evt_bad', type: 'checkout.session.completed', data: { object: {} } };
+    const res = await request(app)
+      .post('/billing/webhook')
+      .set('Content-Type', 'application/json')
+      .set('stripe-signature', 'bad-sig')
+      .send(JSON.stringify(event));
+    expect(res.status).toBe(400);
+  });
+});
+
 // ── GET /rebates/categories ───────────────────────────────────────────────────
 
 describe('GET /rebates/categories', () => {

--- a/src/__tests__/BillingPage.test.jsx
+++ b/src/__tests__/BillingPage.test.jsx
@@ -26,6 +26,10 @@ vi.mock('../context/SubscriptionContext.jsx', () => ({
   useSubscription: () => snapshot,
 }))
 
+vi.mock('../contexts/AuthContext.jsx', () => ({
+  useAuth: () => ({ isGuest: false, isAuthenticated: true, userId: 'test-user' }),
+}))
+
 import BillingPage from '../pages/BillingPage.jsx'
 
 const baseSnapshot = {

--- a/src/__tests__/BillingPage.test.jsx
+++ b/src/__tests__/BillingPage.test.jsx
@@ -11,6 +11,10 @@ vi.mock('../api/plants.js', () => ({
     createCheckoutSession: (...args) => createCheckoutSession(...args),
     createPortalSession: (...args) => createPortalSession(...args),
   },
+  giftsApi: {
+    mine: vi.fn().mockResolvedValue({ gifts: [] }),
+    redeem: vi.fn().mockResolvedValue({ ok: true }),
+  },
 }))
 
 vi.mock('../components/Toast.jsx', () => ({

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -493,6 +493,16 @@ export const companionsApi = {
     request(`/config/beds/${encodeURIComponent(roomId)}/compatibility`),
 }
 
+export const giftsApi = {
+  purchase: (durationMonths, { recipientEmail, recipientName, currency } = {}) =>
+    request('/gifts/purchase', {
+      method: 'POST',
+      body: JSON.stringify({ durationMonths, recipientEmail, recipientName, currency }),
+    }),
+  redeem: (code) => request('/gifts/redeem', { method: 'POST', body: JSON.stringify({ code }) }),
+  mine: () => request('/gifts/mine'),
+}
+
 export const rebatesApi = {
   categories: () => request('/rebates/categories'),
   matches: (lat, lng) => request(`/rebates/matches?lat=${lat}&lng=${lng}`),

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -493,6 +493,11 @@ export const companionsApi = {
     request(`/config/beds/${encodeURIComponent(roomId)}/compatibility`),
 }
 
+export const rebatesApi = {
+  categories: () => request('/rebates/categories'),
+  matches: (lat, lng) => request(`/rebates/matches?lat=${lat}&lng=${lng}`),
+}
+
 export const imagesApi = {
   async upload(file, prefix = 'plants') {
     const ext = file.name.split('.').pop()

--- a/src/layouts/components/menuData.js
+++ b/src/layouts/components/menuData.js
@@ -39,6 +39,15 @@ export const menuItems = [
     ],
   },
   {
+    key: 'discover',
+    label: 'Discover',
+    isSection: true,
+    collapsible: true,
+    children: [
+      { key: 'rebates', label: 'Rebates & Grants', icon: '/icons/sprite.svg#dollar-sign', url: '/rebates' },
+    ],
+  },
+  {
     key: 'manage',
     label: 'Manage',
     isSection: true,

--- a/src/pages/BillingPage.jsx
+++ b/src/pages/BillingPage.jsx
@@ -1,8 +1,8 @@
-import { useState } from 'react'
-import { Button, ProgressBar, Alert, Row, Col } from 'react-bootstrap'
+import { useState, useEffect } from 'react'
+import { Button, ProgressBar, Alert, Row, Col, Form, Badge } from 'react-bootstrap'
 import { Link } from 'react-router'
 import { useSubscription } from '../context/SubscriptionContext.jsx'
-import { billingApi } from '../api/plants.js'
+import { billingApi, giftsApi } from '../api/plants.js'
 import { useToast } from '../components/Toast.jsx'
 import { friendlyErrorMessage } from '../utils/errorMessages.js'
 
@@ -29,10 +29,51 @@ function Quota({ label, used, limit, unit }) {
   )
 }
 
+function GiftStatusBadge({ status }) {
+  const map = { active: 'success', redeemed: 'secondary', expired: 'warning', refunded: 'danger' }
+  return <Badge bg={map[status] || 'secondary'}>{status}</Badge>
+}
+
 export default function BillingPage() {
   const { billingEnabled, tier, status, currentPeriodEnd, cancelAtPeriodEnd, hasStripeCustomer, isTrial, quotas, usage, refresh } = useSubscription()
   const toast = useToast()
   const [busy, setBusy] = useState(false)
+  const [redeemCode, setRedeemCode] = useState('')
+  const [redeemBusy, setRedeemBusy] = useState(false)
+  const [redeemError, setRedeemError] = useState(null)
+  const [sentGifts, setSentGifts] = useState(null)
+  const [giftsLoading, setGiftsLoading] = useState(false)
+
+  useEffect(() => {
+    setGiftsLoading(true)
+    giftsApi.mine()
+      .then((r) => setSentGifts(r.sent || []))
+      .catch(() => setSentGifts([]))
+      .finally(() => setGiftsLoading(false))
+  }, [])
+
+  const redeem = async (e) => {
+    e.preventDefault()
+    if (!redeemCode.trim()) return
+    setRedeemBusy(true)
+    setRedeemError(null)
+    try {
+      await giftsApi.redeem(redeemCode.trim())
+      toast.success('Gift redeemed! Your plan has been upgraded.')
+      setRedeemCode('')
+      refresh()
+    } catch (err) {
+      const messages = {
+        invalid_code: 'That code doesn\'t match any gift. Check for typos.',
+        gift_already_redeemed: 'This gift has already been redeemed.',
+        gift_expired: 'This gift code has expired.',
+        gift_not_for_this_account: 'This gift was sent to a different email address.',
+      }
+      setRedeemError(messages[err.message] || friendlyErrorMessage(err, { context: 'redeeming gift' }))
+    } finally {
+      setRedeemBusy(false)
+    }
+  }
 
   const manage = async () => {
     setBusy(true)
@@ -114,6 +155,58 @@ export default function BillingPage() {
               <Quota label="AI analyses this month" used={usage.ai_analyses} limit={quotas.ai_analyses} />
               <Quota label="Photo storage" used={usage.photo_storage_mb} limit={quotas.photo_storage_mb} unit="MB" />
               <Button variant="link" size="sm" onClick={refresh} className="p-0">Refresh</Button>
+            </div>
+          </div>
+        </Col>
+      </Row>
+
+      <Row className="mt-2">
+        <Col md={6} className="mb-4">
+          <div className="card h-100">
+            <div className="card-body">
+              <h2 className="h5 mb-1">Redeem a gift</h2>
+              <p className="text-muted small mb-3">Enter the XXXX-XXXX-XXXX code from a gift.</p>
+              {redeemError && <Alert variant="danger" className="py-2">{redeemError}</Alert>}
+              <Form onSubmit={redeem} className="d-flex gap-2">
+                <Form.Control
+                  type="text"
+                  placeholder="XXXX-XXXX-XXXX"
+                  value={redeemCode}
+                  onChange={(e) => setRedeemCode(e.target.value)}
+                  style={{ fontFamily: 'monospace', letterSpacing: '0.05em' }}
+                  maxLength={14}
+                />
+                <Button type="submit" variant="primary" disabled={redeemBusy || !redeemCode.trim()}>
+                  {redeemBusy ? '…' : 'Redeem'}
+                </Button>
+              </Form>
+            </div>
+          </div>
+        </Col>
+        <Col md={6} className="mb-4">
+          <div className="card h-100">
+            <div className="card-body">
+              <div className="d-flex justify-content-between align-items-center mb-3">
+                <h2 className="h5 mb-0">Gifts sent</h2>
+                <Button as={Link} to="/gift" size="sm" variant="outline-primary">Buy a gift</Button>
+              </div>
+              {giftsLoading ? (
+                <div className="text-muted small">Loading…</div>
+              ) : !sentGifts || sentGifts.length === 0 ? (
+                <p className="text-muted small mb-0">No gifts sent yet.</p>
+              ) : (
+                <ul className="list-unstyled mb-0">
+                  {sentGifts.map((g) => (
+                    <li key={g.id || g.giftId} className="d-flex justify-content-between align-items-center mb-2 fs-sm">
+                      <span>
+                        {g.recipientName || g.recipientEmail || 'Open gift'}{' '}
+                        <span className="text-muted">({g.durationMonths}mo)</span>
+                      </span>
+                      <GiftStatusBadge status={g.status} />
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
           </div>
         </Col>

--- a/src/pages/BillingPage.jsx
+++ b/src/pages/BillingPage.jsx
@@ -171,6 +171,7 @@ export default function BillingPage() {
                 <Form.Control
                   type="text"
                   placeholder="XXXX-XXXX-XXXX"
+                  aria-label="Gift code"
                   value={redeemCode}
                   onChange={(e) => setRedeemCode(e.target.value)}
                   style={{ fontFamily: 'monospace', letterSpacing: '0.05em' }}

--- a/src/pages/BillingPage.jsx
+++ b/src/pages/BillingPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { Button, ProgressBar, Alert, Row, Col, Form, Badge } from 'react-bootstrap'
 import { Link } from 'react-router'
 import { useSubscription } from '../context/SubscriptionContext.jsx'
+import { useAuth } from '../contexts/AuthContext.jsx'
 import { billingApi, giftsApi } from '../api/plants.js'
 import { useToast } from '../components/Toast.jsx'
 import { friendlyErrorMessage } from '../utils/errorMessages.js'
@@ -36,6 +37,7 @@ function GiftStatusBadge({ status }) {
 
 export default function BillingPage() {
   const { billingEnabled, tier, status, currentPeriodEnd, cancelAtPeriodEnd, hasStripeCustomer, isTrial, quotas, usage, refresh } = useSubscription()
+  const { isGuest } = useAuth()
   const toast = useToast()
   const [busy, setBusy] = useState(false)
   const [redeemCode, setRedeemCode] = useState('')
@@ -45,12 +47,13 @@ export default function BillingPage() {
   const [giftsLoading, setGiftsLoading] = useState(false)
 
   useEffect(() => {
+    if (isGuest) { setSentGifts([]); return }
     setGiftsLoading(true)
     giftsApi.mine()
       .then((r) => setSentGifts(r.sent || []))
       .catch(() => setSentGifts([]))
       .finally(() => setGiftsLoading(false))
-  }, [])
+  }, [isGuest])
 
   const redeem = async (e) => {
     e.preventDefault()

--- a/src/pages/GiftPage.jsx
+++ b/src/pages/GiftPage.jsx
@@ -1,0 +1,144 @@
+import { useState } from 'react'
+import { Row, Col, Button, Form, Alert } from 'react-bootstrap'
+import { giftsApi } from '../api/plants.js'
+
+const SKUS = [
+  {
+    months: 3,
+    label: '3 Months',
+    price: { usd: '$12', gbp: '£10', eur: '€12' },
+    description: 'Give them a season of healthy plants.',
+    highlight: false,
+  },
+  {
+    months: 12,
+    label: '1 Year',
+    price: { usd: '$40', gbp: '£36', eur: '€40' },
+    description: 'A full year of unlimited plants, AI care, and more.',
+    highlight: true,
+  },
+]
+
+const CURRENCY_OPTIONS = [
+  { value: 'usd', label: 'USD ($)' },
+  { value: 'gbp', label: 'GBP (£)' },
+  { value: 'eur', label: 'EUR (€)' },
+]
+
+export default function GiftPage() {
+  const [selected, setSelected] = useState(12)
+  const [currency, setCurrency] = useState('usd')
+  const [recipientEmail, setRecipientEmail] = useState('')
+  const [recipientName, setRecipientName] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(null)
+
+  const handleBuy = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      const { url } = await giftsApi.purchase(selected, {
+        recipientEmail: recipientEmail.trim() || undefined,
+        recipientName: recipientName.trim() || undefined,
+        currency,
+      })
+      window.location.assign(url)
+    } catch (err) {
+      if (err.message === 'billing_disabled' || err.message?.includes('not configured')) {
+        setError('Gift subscriptions are coming soon. Check back shortly!')
+      } else {
+        setError(err.message)
+      }
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="container py-5" style={{ maxWidth: 680 }}>
+      <div className="text-center mb-5">
+        <svg style={{ width: 56, height: 56, color: 'var(--bs-success)' }} aria-hidden="true">
+          <use href="/icons/sprite.svg#gift" />
+        </svg>
+        <h1 className="display-6 fw-bold mt-3">Give the Gift of Greener Plants</h1>
+        <p className="text-muted">
+          Send a Home Pro gift subscription — they get unlimited plants, AI-powered care, and full
+          ML insights.
+        </p>
+      </div>
+
+      {error && <Alert variant="warning" onClose={() => setError(null)} dismissible>{error}</Alert>}
+
+      <Row className="g-3 mb-4">
+        {SKUS.map((sku) => (
+          <Col key={sku.months} xs={12} sm={6}>
+            <button
+              type="button"
+              onClick={() => setSelected(sku.months)}
+              className={`card w-100 text-start border-2 p-0 ${
+                selected === sku.months ? 'border-primary' : 'border-secondary'
+              }`}
+              style={{ background: 'none', cursor: 'pointer' }}
+            >
+              <div className="card-body">
+                {sku.highlight && (
+                  <span className="badge bg-primary mb-2">Best value</span>
+                )}
+                <h2 className="h5 mb-1">{sku.label}</h2>
+                <div className="display-6 fw-bold text-primary mb-1">{sku.price[currency]}</div>
+                <p className="text-muted small mb-0">{sku.description}</p>
+              </div>
+            </button>
+          </Col>
+        ))}
+      </Row>
+
+      <div className="card mb-4">
+        <div className="card-body">
+          <h2 className="h6 mb-3">Recipient details (optional)</h2>
+          <Form.Group className="mb-3">
+            <Form.Label>Recipient name</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="e.g. Alex"
+              value={recipientName}
+              onChange={(e) => setRecipientName(e.target.value)}
+            />
+          </Form.Group>
+          <Form.Group>
+            <Form.Label>Recipient email</Form.Label>
+            <Form.Control
+              type="email"
+              placeholder="their@email.com"
+              value={recipientEmail}
+              onChange={(e) => setRecipientEmail(e.target.value)}
+            />
+            <Form.Text className="text-muted">
+              If provided, only this email address can redeem the gift.
+            </Form.Text>
+          </Form.Group>
+        </div>
+      </div>
+
+      <div className="d-flex align-items-center gap-3 mb-4">
+        <Form.Select
+          value={currency}
+          onChange={(e) => setCurrency(e.target.value)}
+          style={{ width: 130 }}
+          aria-label="Currency"
+        >
+          {CURRENCY_OPTIONS.map((c) => (
+            <option key={c.value} value={c.value}>{c.label}</option>
+          ))}
+        </Form.Select>
+        <Button variant="primary" size="lg" className="flex-grow-1" onClick={handleBuy} disabled={busy}>
+          {busy ? 'Redirecting…' : `Buy gift — ${SKUS.find((s) => s.months === selected)?.price[currency]}`}
+        </Button>
+      </div>
+
+      <p className="text-muted small text-center">
+        After checkout you'll receive a gift code to share. The recipient redeems it at{' '}
+        <strong>Settings → Billing → Redeem a gift</strong>.
+      </p>
+    </div>
+  )
+}

--- a/src/pages/RebatesPage.jsx
+++ b/src/pages/RebatesPage.jsx
@@ -1,0 +1,197 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Row, Col, Badge, Button, Form } from 'react-bootstrap'
+import { rebatesApi } from '../api/plants.js'
+import EmptyState from '../components/EmptyState.jsx'
+import { usePlantContext } from '../context/PlantContext.jsx'
+
+const CATEGORY_ICONS = {
+  water: 'droplet',
+  'native-plant': 'leaf',
+  compost: 'layers',
+  energy: 'zap',
+}
+
+const CATEGORY_LABELS = {
+  water: 'Water Saving',
+  'native-plant': 'Native Plants',
+  compost: 'Composting',
+  energy: 'Energy',
+}
+
+function RebateCard({ rebate }) {
+  const icon = CATEGORY_ICONS[rebate.category] || 'tag'
+  const ctaUrl = rebate.affiliateUrl || rebate.applyUrl
+  return (
+    <div className="panel panel-icon h-100">
+      <div className="panel-hdr">
+        <h2>
+          <svg className="sa-icon sa-icon-2x me-2" aria-hidden="true">
+            <use href={`/icons/sprite.svg#${icon}`} />
+          </svg>
+          {rebate.name}
+        </h2>
+        <div className="panel-toolbar">
+          <Badge bg="secondary" className="text-uppercase">
+            {CATEGORY_LABELS[rebate.category] || rebate.category}
+          </Badge>
+        </div>
+      </div>
+      <div className="panel-container">
+        <div className="panel-content">
+          <p className="fw-semibold text-success mb-1">{rebate.amountFormula}</p>
+          <p className="text-muted small mb-3">{rebate.description}</p>
+          {rebate.validUntil && (
+            <p className="text-muted small mb-3">
+              Valid until {new Intl.DateTimeFormat(undefined, { year: 'numeric', month: 'long', day: 'numeric' }).format(new Date(rebate.validUntil + 'T12:00:00'))}
+            </p>
+          )}
+          <a
+            href={ctaUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn btn-sm btn-outline-primary"
+          >
+            Apply now
+            <svg className="sa-icon ms-1" aria-hidden="true" style={{ width: 14, height: 14 }}>
+              <use href="/icons/sprite.svg#external-link" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function RebatesPage() {
+  const { location } = usePlantContext()
+  const [rebates, setRebates] = useState([])
+  const [categories, setCategories] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [activeCategory, setActiveCategory] = useState('all')
+  const [coords, setCoords] = useState(null)
+
+  useEffect(() => {
+    rebatesApi.categories().then((r) => setCategories(r.categories)).catch(() => {})
+  }, [])
+
+  const fetchRebates = useCallback(async (lat, lng) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const r = await rebatesApi.matches(lat, lng)
+      setRebates(r.rebates)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (location?.lat && location?.lng) {
+      setCoords({ lat: location.lat, lng: location.lng })
+      fetchRebates(location.lat, location.lng)
+    } else if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        ({ coords: c }) => {
+          setCoords({ lat: c.latitude, lng: c.longitude })
+          fetchRebates(c.latitude, c.longitude)
+        },
+        () => setError('location_unavailable'),
+      )
+    } else {
+      setError('location_unavailable')
+    }
+  }, [location, fetchRebates])
+
+  const visible = activeCategory === 'all'
+    ? rebates
+    : rebates.filter((r) => r.category === activeCategory)
+
+  return (
+    <div className="content-wrapper">
+      <div className="subheader">
+        <h1 className="subheader-title">
+          <svg className="sa-icon sa-icon-2x me-2" aria-hidden="true">
+            <use href="/icons/sprite.svg#dollar-sign" />
+          </svg>
+          Rebates &amp; Grants
+        </h1>
+        <div className="subheader-block d-lg-flex align-items-center">
+          <p className="text-muted small mb-0">
+            Local water, composting, native-plant and energy rebates available in your area.
+          </p>
+        </div>
+      </div>
+
+      {error === 'location_unavailable' ? (
+        <EmptyState
+          icon="map-pin"
+          title="Location unavailable"
+          description="Enable location access or set your location in Settings to see rebates for your area."
+        />
+      ) : loading ? (
+        <div className="d-flex justify-content-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Loading…</span>
+          </div>
+        </div>
+      ) : error ? (
+        <div className="alert alert-danger">{error}</div>
+      ) : (
+        <>
+          {categories.length > 0 && (
+            <div className="d-flex flex-wrap gap-2 mb-4">
+              <Button
+                size="sm"
+                variant={activeCategory === 'all' ? 'primary' : 'outline-secondary'}
+                onClick={() => setActiveCategory('all')}
+              >
+                All ({rebates.length})
+              </Button>
+              {categories.map((cat) => {
+                const count = rebates.filter((r) => r.category === cat.id).length
+                if (count === 0) return null
+                return (
+                  <Button
+                    key={cat.id}
+                    size="sm"
+                    variant={activeCategory === cat.id ? 'primary' : 'outline-secondary'}
+                    onClick={() => setActiveCategory(cat.id)}
+                  >
+                    {cat.label} ({count})
+                  </Button>
+                )
+              })}
+            </div>
+          )}
+
+          {visible.length === 0 ? (
+            <EmptyState
+              icon="dollar-sign"
+              title="No rebates available in your area yet"
+              description="Let us know if there's one we're missing."
+              action={
+                <a
+                  href="mailto:hello@planttracker.app?subject=Rebate suggestion"
+                  className="btn btn-outline-primary"
+                >
+                  Suggest a rebate
+                </a>
+              }
+            />
+          ) : (
+            <Row className="g-3">
+              {visible.map((r) => (
+                <Col key={r.id} xs={12} md={6} xl={4}>
+                  <RebateCard rebate={r} />
+                </Col>
+              ))}
+            </Row>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -26,6 +26,7 @@ const TemplatesPage = lazy(() => import('../pages/TemplatesPage.jsx'))
 const MaterialsPage = lazy(() => import('../pages/MaterialsPage.jsx'))
 const PortalPage = lazy(() => import('../pages/PortalPage.jsx'))
 const SitPage = lazy(() => import('../pages/SitPage.jsx'))
+const RebatesPage = lazy(() => import('../pages/RebatesPage.jsx'))
 
 export const routes = [
   {
@@ -64,6 +65,7 @@ export const routes = [
           { path: 'admin', element: <Navigate to="/admin/features" replace /> },
           { path: 'admin/:tab', element: <AdminPage />, handle: { breadcrumb: 'Admin' } },
           { path: 'pricing', element: <PricingPage />, handle: { breadcrumb: 'Pricing' } },
+          { path: 'rebates', element: <Suspense fallback={null}><RebatesPage /></Suspense>, handle: { breadcrumb: 'Rebates & Grants' } },
         ],
       },
     ],

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -27,12 +27,14 @@ const MaterialsPage = lazy(() => import('../pages/MaterialsPage.jsx'))
 const PortalPage = lazy(() => import('../pages/PortalPage.jsx'))
 const SitPage = lazy(() => import('../pages/SitPage.jsx'))
 const RebatesPage = lazy(() => import('../pages/RebatesPage.jsx'))
+const GiftPage = lazy(() => import('../pages/GiftPage.jsx'))
 
 export const routes = [
   {
     element: <App />,
     children: [
       { path: '/privacy', element: <Suspense fallback={null}><PrivacyPage /></Suspense> },
+      { path: '/gift', element: <Suspense fallback={null}><GiftPage /></Suspense> },
       { path: '/terms', element: <Suspense fallback={null}><TermsPage /></Suspense> },
       { path: '/scan/:shortCode', element: <Suspense fallback={null}><ScanPage /></Suspense> },
       { path: '/portal/:token', element: <Suspense fallback={null}><PortalPage /></Suspense> },


### PR DESCRIPTION
## Summary

Closes #311, closes #309

---

### #311 — Local rebate & grant finder

- JSON rebate catalog in `api/plants/data/rebates/` — 7 California entries and 6 Greater London entries covering water, native-plant, composting, and energy categories
- `GET /rebates/categories` (no auth) — metadata for UI filter chips
- `GET /rebates/matches?lat=&lng=` (requireUser) — pure in-memory bounding-box matching, no Firestore reads, no external APIs
- `src/pages/RebatesPage.jsx` — category filter bar, rebate cards with amount summary and "Apply now" CTA, empty state with mailto suggestion link
- `rebatesApi` added to `src/api/plants.js`
- `/rebates` route + "Discover" sidebar section

### #309 — Gift subscriptions (dark-shippable until Stripe price IDs are provisioned)

**Backend (`api/plants/index.js`)**
- `generateGiftCode()` produces `XXXX-XXXX-XXXX` codes from an unambiguous 32-char alphabet (no 0/O/1/I/L)
- `POST /gifts/purchase` — Stripe one-time checkout session (`mode: 'payment'`) with `metadata.giftPurchase: 'true'`, purchaser UID, duration, optional recipient fields; returns 503 when `STRIPE_PRICE_GIFT_HOMEPRO_*` env vars are unset
- Stripe webhook extended: gift completions routed to `handleGiftPurchaseCompleted` — mints code, writes `gifts/{id}` + `giftCodeHashes/{hash}` + `users/{uid}/giftsSent/{id}`
- `POST /gifts/redeem` — validates code, checks expiry and optional email lock, writes `isTrial: true / trialTier / trialEnd` to `users/{uid}/subscription/current`
- `GET /gifts/mine` — returns sender's gift history
- `attachHouseholdContext` extended with `req.actorEmail` for email-locked gift enforcement

**Frontend**
- New public `/gift` page — 3-month / 1-year SKU cards, per-currency pricing (USD/GBP/EUR), optional recipient fields, graceful "coming soon" state when billing not configured
- `BillingPage` extended with **Redeem a gift** card (monospace code input, mapped error messages) and **Gifts sent** history with status badges
- `giftsApi` added to `src/api/plants.js`
- `/gift` wired as a public route (no auth required)

## Test plan

- [x] 7 rebate tests: LA→SoCal, London→London, NZ→empty, Bay Area scoping, missing params 400, unauthenticated 401
- [x] 10 gift tests: purchase (400/503/401), redeem (400/404/200/409/401), mine (200/401)
- [x] `npm run preflight:fast` passes (backend lint, both audits, frontend build)
- [ ] Manual: `/rebates` with CA or London location shows rebate cards
- [ ] Manual: `/gift` renders without auth; currency toggle updates prices
- [ ] Manual: redeem flow with invalid code shows friendly error

https://claude.ai/code/session_01Fw2iVYKu1noJHV2Ugi3R2m