### PR TITLE
feat(feed-modal): product link field + larger modal

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -2158,13 +2158,20 @@ app.post('/plants/:id/fertilise', requireUser, async (req, res) => {
     const doc = await ref.get();
     if (!doc.exists) return res.status(404).json({ error: 'Plant not found' });
 
-    const { productName, npk, dilution, amount, notes } = req.body || {};
+    const { productName, productUrl, npk, dilution, amount, notes } = req.body || {};
     const now = new Date().toISOString();
     const existing = doc.data();
+
+    // Reject anything that isn't an http(s) URL — the value is rendered as a
+    // clickable link in the UI, so allowing javascript: / data: would be XSS.
+    const safeProductUrl = typeof productUrl === 'string' && /^https?:\/\//i.test(productUrl)
+      ? productUrl
+      : null;
 
     const entry = {
       date: now,
       productName: productName || null,
+      productUrl: safeProductUrl,
       npk: npk || null,
       dilution: dilution || null,
       amount: amount || null,
@@ -2177,6 +2184,7 @@ app.post('/plants/:id/fertilise', requireUser, async (req, res) => {
     // fields were supplied.
     const fertiliser = { ...(existing.fertiliser || {}) };
     if (productName) fertiliser.productName = productName;
+    if (safeProductUrl) fertiliser.productUrl = safeProductUrl;
     if (npk) fertiliser.npk = npk;
     if (dilution) fertiliser.dilution = dilution;
 

--- a/src/components/FeedRecordModal.jsx
+++ b/src/components/FeedRecordModal.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Modal, Button, Form, Row, Col } from 'react-bootstrap'
+import { Modal, Button, Form, Row, Col, InputGroup } from 'react-bootstrap'
 import { recommendApi } from '../api/plants.js'
 import { usePlantContext } from '../context/PlantContext.jsx'
 import { useToast } from './Toast.jsx'
@@ -13,6 +13,7 @@ export default function FeedRecordModal({ plant, show, onHide }) {
   const seed = plant?.fertiliser || {}
   const [form, setForm] = useState({
     productName: seed.productName || '',
+    productUrl:  seed.productUrl || '',
     npk:         seed.npk || '',
     dilution:    seed.dilution || '',
     amount:      '',
@@ -43,6 +44,7 @@ export default function FeedRecordModal({ plant, show, onHide }) {
       setForm((f) => ({
         ...f,
         productName: rec.productName || f.productName,
+        productUrl:  rec.productUrl || f.productUrl,
         npk:         rec.npk || f.npk,
         dilution:    rec.dilution || f.dilution,
         amount:      rec.amount || f.amount,
@@ -73,7 +75,7 @@ export default function FeedRecordModal({ plant, show, onHide }) {
   const recent = log.slice(-5).reverse()
 
   return (
-    <Modal show={show} onHide={onHide} centered size="md">
+    <Modal show={show} onHide={onHide} centered size="lg">
       <Modal.Header closeButton>
         <Modal.Title>Feed {plant.name}</Modal.Title>
       </Modal.Header>
@@ -90,6 +92,32 @@ export default function FeedRecordModal({ plant, show, onHide }) {
               <Form.Group>
                 <Form.Label>NPK</Form.Label>
                 <Form.Control value={form.npk} onChange={setField('npk')} placeholder="10-10-10" />
+              </Form.Group>
+            </Col>
+            <Col xs={12}>
+              <Form.Group>
+                <Form.Label>Product link <span className="text-muted fw-normal">(optional)</span></Form.Label>
+                <InputGroup>
+                  <Form.Control
+                    type="url"
+                    value={form.productUrl}
+                    onChange={setField('productUrl')}
+                    placeholder="https://example.com/product"
+                  />
+                  {/^https?:\/\//i.test(form.productUrl) && (
+                    <Button
+                      as="a"
+                      href={form.productUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      variant="outline-secondary"
+                      title="Open product page"
+                      aria-label="Open product page in new tab"
+                    >
+                      Open
+                    </Button>
+                  )}
+                </InputGroup>
               </Form.Group>
             </Col>
             <Col xs={12} md={6}>
@@ -125,7 +153,16 @@ export default function FeedRecordModal({ plant, show, onHide }) {
                 {recent.map((e, i) => (
                   <li key={i} className="d-flex justify-content-between border-bottom py-1">
                     <span>{new Date(e.date).toLocaleDateString()}</span>
-                    <span className="text-muted">{e.productName || '—'}{e.dilution ? ` · ${e.dilution}` : ''}</span>
+                    <span className="text-muted">
+                      {e.productUrl && /^https?:\/\//i.test(e.productUrl) ? (
+                        <a href={e.productUrl} target="_blank" rel="noopener noreferrer">
+                          {e.productName || 'product'}
+                        </a>
+                      ) : (
+                        e.productName || '—'
+                      )}
+                      {e.dilution ? ` · ${e.dilution}` : ''}
+                    </span>
                   </li>
                 ))}
               </ul>

--- a/src/context/PlantContext.jsx
+++ b/src/context/PlantContext.jsx
@@ -235,6 +235,7 @@ export function PlantProvider({ children }) {
       const entry = {
         date: now,
         productName: fields.productName || null,
+        productUrl: fields.productUrl || null,
         npk: fields.npk || null,
         dilution: fields.dilution || null,
         amount: fields.amount || null,


### PR DESCRIPTION
## Summary

The Product field in the Feed modal was truncating in the md-sized modal and there was no way to record where the product was sourced. Two changes:

- **Modal size**: \`md\` → \`lg\` so the Product / NPK / Dilution / Amount inputs render full-width without truncating their values.
- **Product link (optional)**: new \`productUrl\` field below Product/NPK. \`InputGroup\` with an \"Open\" button that opens the URL in a new tab when it parses as \`http(s)://\`. Seeded from \`plant.fertiliser.productUrl\` for quick-repeat next time.

Persists through \`POST /plants/:id/fertilise\`. The backend whitelists the URL scheme (\`http://\` / \`https://\`) and stores \`null\` otherwise — \`javascript:\` / \`data:\` would render as a clickable XSS vector through the recent-feedings list.

The Recent feedings list now renders the product name as a link when a URL was recorded.

## Test plan
- [x] \`npm run preflight:fast\` passes
- [x] backend fertilise tests pass
- [ ] Open the Feed modal: modal is wider; Product field renders without truncation
- [ ] Enter \`https://example.com/product\` → Open button appears, opens in new tab
- [ ] Enter \`javascript:alert(1)\` → Open button does not appear; on save, value is dropped server-side
- [ ] After saving, Recent shows the product name as a link

🤖 Generated with [Claude Code](https://claude.com/claude-code)