### PR TITLE
feat(profile): account-type persona (PR A — data model + setting)

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -5018,6 +5018,41 @@ app.delete('/account', requireUser, async (req, res) => {
   }
 });
 
+// User profile / persona. Persona drives which menu items are visible (UI
+// filter only — actual permissions stay tier-gated). Stored separately from
+// /subscription/current because a free-tier user can be a landscaper trialing
+// the app, and a paid user can want to see both surfaces.
+const ACCOUNT_TYPES = ['household', 'landscaper', 'both'];
+
+app.get('/profile', requireUser, async (req, res) => {
+  try {
+    const ref = db.collection('users').doc(req.userId).collection('profile').doc('account');
+    const snap = await ref.get();
+    // Lazy default: never write on read so we don't churn docs for users who
+    // never visit Settings.
+    const data = snap.exists ? snap.data() : {};
+    res.status(200).json({
+      accountType: ACCOUNT_TYPES.includes(data.accountType) ? data.accountType : 'household',
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.put('/profile', requireUser, async (req, res) => {
+  try {
+    const { accountType } = req.body || {};
+    if (!ACCOUNT_TYPES.includes(accountType)) {
+      return res.status(400).json({ error: `accountType must be one of ${ACCOUNT_TYPES.join(', ')}` });
+    }
+    const ref = db.collection('users').doc(req.userId).collection('profile').doc('account');
+    await ref.set({ accountType, updatedAt: new Date().toISOString() }, { merge: true });
+    res.status(200).json({ accountType });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 app.post('/account/trial/start', requireUser, async (req, res) => {
   try {
     const subRef = db.collection('users').doc(req.userId).collection('subscription').doc('current');

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -3291,6 +3291,64 @@ describe('DELETE /plants/:id/journal/:entryId', () => {
 
 // ── DELETE /account ───────────────────────────────────────────────────────────
 
+describe('GET /profile', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/profile');
+    expect(res.status).toBe(401);
+  });
+
+  it('lazy-defaults to household when no doc exists, without writing', async () => {
+    const res = await request(app).get('/profile').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ accountType: 'household' });
+    expect(store[`users/${USER_SUB}/profile/account`]).toBeUndefined();
+  });
+
+  it('returns the stored accountType', async () => {
+    store[`users/${USER_SUB}/profile/account`] = { accountType: 'landscaper' };
+    const res = await request(app).get('/profile').set('Authorization', authHeader());
+    expect(res.body).toEqual({ accountType: 'landscaper' });
+  });
+
+  it('falls back to household when stored value is corrupt', async () => {
+    store[`users/${USER_SUB}/profile/account`] = { accountType: 'wizard' };
+    const res = await request(app).get('/profile').set('Authorization', authHeader());
+    expect(res.body).toEqual({ accountType: 'household' });
+  });
+});
+
+describe('PUT /profile', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).put('/profile').send({ accountType: 'landscaper' });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects unknown accountType with 400', async () => {
+    const res = await request(app).put('/profile')
+      .set('Authorization', authHeader())
+      .send({ accountType: 'wizard' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects missing accountType', async () => {
+    const res = await request(app).put('/profile')
+      .set('Authorization', authHeader())
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('persists each valid value and returns it', async () => {
+    for (const value of ['household', 'landscaper', 'both']) {
+      const res = await request(app).put('/profile')
+        .set('Authorization', authHeader())
+        .send({ accountType: value });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ accountType: value });
+      expect(store[`users/${USER_SUB}/profile/account`].accountType).toBe(value);
+    }
+  });
+});
+
 describe('DELETE /account', () => {
   it('returns 401 without auth', async () => {
     const res = await request(app).delete('/account');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { GoogleOAuthProvider } from '@react-oauth/google'
 import { AuthProvider } from './contexts/AuthContext.jsx'
 import { LayoutProvider } from './context/LayoutContext.jsx'
 import { SubscriptionProvider } from './context/SubscriptionContext.jsx'
+import { ProfileProvider } from './context/ProfileContext.jsx'
 import { HouseholdProvider } from './context/HouseholdContext.jsx'
 import { PropertyProvider } from './context/PropertyContext.jsx'
 import { ToastProvider } from './components/Toast.jsx'
@@ -19,14 +20,16 @@ export default function App() {
       <AuthProvider>
         <LayoutProvider>
           <SubscriptionProvider>
-            <HouseholdProvider>
-            <PropertyProvider>
-              <ToastProvider>
-                <Outlet />
-                <ConsentBanner />
-              </ToastProvider>
-            </PropertyProvider>
-            </HouseholdProvider>
+            <ProfileProvider>
+              <HouseholdProvider>
+              <PropertyProvider>
+                <ToastProvider>
+                  <Outlet />
+                  <ConsentBanner />
+                </ToastProvider>
+              </PropertyProvider>
+              </HouseholdProvider>
+            </ProfileProvider>
           </SubscriptionProvider>
         </LayoutProvider>
       </AuthProvider>

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -33,6 +33,10 @@ vi.mock('../api/plants.js', () => ({
     createPortalSession:   vi.fn(),
   },
   outbreakApi: { list: vi.fn().mockResolvedValue({ plants: [], hasMore: false, nextCursor: null }) },
+  profileApi: {
+    get: vi.fn().mockResolvedValue({ accountType: 'household' }),
+    set: vi.fn().mockResolvedValue({ accountType: 'household' }),
+  },
 }))
 
 vi.mock('../contexts/AuthContext.jsx', async (importOriginal) => {

--- a/src/__tests__/ProfileContext.test.jsx
+++ b/src/__tests__/ProfileContext.test.jsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../api/plants.js', () => ({
+  setApiCredential: vi.fn(),
+  profileApi: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+}))
+
+let authState = { isAuthenticated: true, isGuest: false }
+vi.mock('../contexts/AuthContext.jsx', () => ({
+  useAuth: () => authState,
+  AuthProvider: ({ children }) => children,
+}))
+
+import { ProfileProvider, useProfile } from '../context/ProfileContext.jsx'
+import { profileApi } from '../api/plants.js'
+
+function Consumer() {
+  const p = useProfile()
+  return (
+    <div>
+      <span data-testid="type">{p.accountType}</span>
+      <span data-testid="loading">{String(p.loading)}</span>
+      <span data-testid="error">{p.error || 'none'}</span>
+      <button onClick={async () => { try { await p.setAccountType('landscaper') } catch { /* swallow for tests */ } }}>landscaper</button>
+      <button onClick={async () => { try { await p.setAccountType('both') } catch { /* swallow for tests */ } }}>both</button>
+    </div>
+  )
+}
+
+function renderProvider() {
+  return render(<ProfileProvider><Consumer /></ProfileProvider>)
+}
+
+describe('ProfileContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authState = { isAuthenticated: true, isGuest: false }
+  })
+
+  it('loads accountType on mount', async () => {
+    profileApi.get.mockResolvedValue({ accountType: 'landscaper' })
+    renderProvider()
+    await waitFor(() => expect(screen.getByTestId('type')).toHaveTextContent('landscaper'))
+    expect(profileApi.get).toHaveBeenCalledOnce()
+  })
+
+  it('defaults to household when route returns garbage', async () => {
+    profileApi.get.mockResolvedValue({ accountType: 'wizard' })
+    renderProvider()
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'))
+    expect(screen.getByTestId('type')).toHaveTextContent('household')
+  })
+
+  it('defaults to household and surfaces error when route fails', async () => {
+    profileApi.get.mockRejectedValue(new Error('gateway 404'))
+    renderProvider()
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'))
+    expect(screen.getByTestId('type')).toHaveTextContent('household')
+    expect(screen.getByTestId('error')).toHaveTextContent('gateway 404')
+  })
+
+  it('skips network call when guest, exposes default', async () => {
+    authState = { isAuthenticated: true, isGuest: true }
+    renderProvider()
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'))
+    expect(screen.getByTestId('type')).toHaveTextContent('household')
+    expect(profileApi.get).not.toHaveBeenCalled()
+  })
+
+  it('persists via PUT and updates state optimistically', async () => {
+    profileApi.get.mockResolvedValue({ accountType: 'household' })
+    profileApi.set.mockResolvedValue({ accountType: 'landscaper' })
+    renderProvider()
+    await waitFor(() => expect(screen.getByTestId('type')).toHaveTextContent('household'))
+    await act(async () => { screen.getByText('landscaper').click() })
+    await waitFor(() => expect(screen.getByTestId('type')).toHaveTextContent('landscaper'))
+    expect(profileApi.set).toHaveBeenCalledWith('landscaper')
+  })
+
+  it('rolls back on PUT failure', async () => {
+    profileApi.get.mockResolvedValue({ accountType: 'household' })
+    profileApi.set.mockRejectedValue(new Error('500'))
+    renderProvider()
+    await waitFor(() => expect(screen.getByTestId('type')).toHaveTextContent('household'))
+    await act(async () => {
+      try { screen.getByText('both').click() } catch { /* swallowed */ }
+    })
+    await waitFor(() => expect(screen.getByTestId('error')).toHaveTextContent('500'))
+    expect(screen.getByTestId('type')).toHaveTextContent('household')
+  })
+})

--- a/src/__tests__/SettingsPage.test.jsx
+++ b/src/__tests__/SettingsPage.test.jsx
@@ -33,6 +33,11 @@ vi.mock('../context/LayoutContext.jsx', () => ({
   useLayoutContext: () => ({ theme: 'light', themeMode: 'light', changeTheme: changeThemeMock, changeThemeMode: changeThemeMock }),
 }))
 
+const setAccountTypeMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('../context/ProfileContext.jsx', () => ({
+  useProfile: () => ({ accountType: 'household', setAccountType: setAccountTypeMock, loading: false, error: null, refresh: vi.fn() }),
+}))
+
 vi.mock('../contexts/AuthContext.jsx', () => ({
   useAuth: () => ({ logout: logoutMock }),
 }))
@@ -94,6 +99,21 @@ describe('SettingsPage tabs', () => {
     renderAt('/settings/preferences')
     expect(screen.getByText(/Appearance/i)).toBeInTheDocument()
     expect(screen.getByText(/Location/i)).toBeInTheDocument()
+  })
+
+  it('shows Profile mode section with three options on Preferences', () => {
+    renderAt('/settings/preferences')
+    expect(screen.getByText(/Profile mode/i)).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /Household/i })).toBeChecked()
+    expect(screen.getByRole('radio', { name: /Landscaper/i })).not.toBeChecked()
+    expect(screen.getByRole('radio', { name: 'Both' })).not.toBeChecked()
+  })
+
+  it('persists a Profile mode change via setAccountType', async () => {
+    setAccountTypeMock.mockClear()
+    renderAt('/settings/preferences')
+    fireEvent.click(screen.getByRole('radio', { name: /Landscaper/i }))
+    await waitFor(() => expect(setAccountTypeMock).toHaveBeenCalledWith('landscaper'))
   })
 
   it('shows the Data tab content at /settings/data', () => {

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -301,6 +301,11 @@ export const accountApi = {
   startTrial: () => request('/account/trial/start', { method: 'POST' }),
 }
 
+export const profileApi = {
+  get: () => request('/profile'),
+  set: (accountType) => request('/profile', { method: 'PUT', body: JSON.stringify({ accountType }) }),
+}
+
 export const householdsApi = {
   list: () => request('/households'),
   current: () => request('/households/current'),

--- a/src/context/ProfileContext.jsx
+++ b/src/context/ProfileContext.jsx
@@ -1,0 +1,69 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { profileApi } from '../api/plants.js'
+import { useAuth } from '../contexts/AuthContext.jsx'
+
+export const ACCOUNT_TYPES = ['household', 'landscaper', 'both']
+const DEFAULT_ACCOUNT_TYPE = 'household'
+
+const ProfileContext = createContext(undefined)
+
+export function useProfile() {
+  const ctx = useContext(ProfileContext)
+  if (!ctx) throw new Error('useProfile must be used within ProfileProvider')
+  return ctx
+}
+
+export function ProfileProvider({ children }) {
+  const { isAuthenticated, isGuest } = useAuth()
+  const [accountType, setAccountTypeState] = useState(DEFAULT_ACCOUNT_TYPE)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const refresh = useCallback(async () => {
+    if (!isAuthenticated || isGuest) {
+      setAccountTypeState(DEFAULT_ACCOUNT_TYPE)
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    try {
+      const data = await profileApi.get()
+      setAccountTypeState(ACCOUNT_TYPES.includes(data?.accountType) ? data.accountType : DEFAULT_ACCOUNT_TYPE)
+      setError(null)
+    } catch (err) {
+      // Route may not be live (gateway not yet updated) — degrade to default
+      // rather than block the whole app.
+      setAccountTypeState(DEFAULT_ACCOUNT_TYPE)
+      setError(err?.message || 'Profile lookup failed')
+    } finally {
+      setLoading(false)
+    }
+  }, [isAuthenticated, isGuest])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  const setAccountType = useCallback(async (next) => {
+    if (!ACCOUNT_TYPES.includes(next)) throw new Error(`Unknown accountType: ${next}`)
+    if (!isAuthenticated || isGuest) {
+      setAccountTypeState(next)
+      return
+    }
+    const prev = accountType
+    setAccountTypeState(next)
+    try {
+      await profileApi.set(next)
+      setError(null)
+    } catch (err) {
+      setAccountTypeState(prev)
+      setError(err?.message || 'Failed to save profile')
+      throw err
+    }
+  }, [accountType, isAuthenticated, isGuest])
+
+  const value = useMemo(
+    () => ({ accountType, setAccountType, loading, error, refresh }),
+    [accountType, setAccountType, loading, error, refresh],
+  )
+
+  return <ProfileContext.Provider value={value}>{children}</ProfileContext.Provider>
+}

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -14,10 +14,11 @@ import i18n from '../i18n/index.js'
 import { accountApi, exportApi, apiKeysApi, brandingApi, imagesApi, householdsApi, propertiesApi } from '../api/plants.js'
 import { useHousehold } from '../context/HouseholdContext.jsx'
 import { useProperty } from '../context/PropertyContext.jsx'
+import { useProfile } from '../context/ProfileContext.jsx'
 
 const TABS = [
   { id: 'property', label: 'Property', icon: 'layers', tags: 'floors zones floorplan rooms upload property' },
-  { id: 'preferences', label: 'Preferences', icon: 'sliders', tags: 'theme dark mode light temperature celsius fahrenheit metric imperial units location city weather' },
+  { id: 'preferences', label: 'Preferences', icon: 'sliders', tags: 'theme dark mode light temperature celsius fahrenheit metric imperial units location city weather profile mode persona household landscaper gardener role' },
   { id: 'household', label: 'Household', icon: 'users', tags: 'household share invite member family roommate partner role viewer editor owner code' },
   { id: 'data', label: 'Data & export', icon: 'download', tags: 'export csv download backup data' },
   { id: 'api-keys', label: 'API Keys', icon: 'key', tags: 'api keys rest integration home assistant automation developer' },
@@ -384,13 +385,36 @@ function PropertyTab({ search }) {
   )
 }
 
+const PROFILE_OPTIONS = [
+  {
+    value: 'household',
+    label: 'Household',
+    description: 'Track plants in your home, share with family, log watering and feeding.',
+    icon: 'home',
+  },
+  {
+    value: 'landscaper',
+    label: 'Landscaper / gardener',
+    description: 'Manage client properties, schedule visits, run a team, send branded reports.',
+    icon: 'briefcase',
+  },
+  {
+    value: 'both',
+    label: 'Both',
+    description: "I do both — show me everything.",
+    icon: 'layers',
+  },
+]
+
 function PreferencesTab({ search }) {
   const { tempUnit, unitSystem, location, setLocation, timezone, setTimezone } = usePlantContext()
   const { themeMode, changeThemeMode } = useLayoutContext()
+  const { accountType, setAccountType } = useProfile()
   const { t } = useTranslation('settings')
   const [locationSearch, setLocationSearch] = useState('')
   const [locationResults, setLocationResults] = useState([])
   const [locationSearching, setLocationSearching] = useState(false)
+  const [profileSaving, setProfileSaving] = useState(false)
 
   const THEME_OPTIONS = [
     { value: 'light', label: 'Light', icon: 'sun' },
@@ -398,8 +422,59 @@ function PreferencesTab({ search }) {
     { value: 'auto', label: 'Auto', icon: 'monitor' },
   ]
 
+  const onPickProfile = async (next) => {
+    if (next === accountType || profileSaving) return
+    setProfileSaving(true)
+    try {
+      await setAccountType(next)
+    } catch { /* ProfileContext surfaces the error; no-op here */ }
+    finally { setProfileSaving(false) }
+  }
+
   return (
     <>
+      <SettingSection id="profile-mode" title="Profile mode" icon="user" search={search}>
+        <p className="text-muted small mb-3">
+          Tailors which menus you see. Doesn&apos;t change what you can pay for —
+          your plan still controls premium features and quotas.
+        </p>
+        <div className="d-flex flex-column flex-md-row gap-2" role="radiogroup" aria-label="Profile mode">
+          {PROFILE_OPTIONS.map(({ value, label, description, icon }) => {
+            const selected = accountType === value
+            return (
+              <div
+                key={value}
+                className={`flex-fill border rounded p-3 d-flex gap-2 ${selected ? 'border-primary bg-primary-subtle' : ''} ${profileSaving ? 'opacity-50' : ''}`}
+                onClick={() => onPickProfile(value)}
+                style={{ cursor: profileSaving ? 'wait' : 'pointer' }}
+              >
+                <Form.Check
+                  type="radio"
+                  id={`profile-${value}`}
+                  name="profile-mode"
+                  value={value}
+                  checked={selected}
+                  onChange={() => onPickProfile(value)}
+                  disabled={profileSaving}
+                  aria-label={label}
+                  aria-describedby={`profile-${value}-desc`}
+                  onClick={(e) => e.stopPropagation()}
+                />
+                <div>
+                  <div className="d-flex align-items-center gap-1 fw-500">
+                    <svg className="sa-icon" style={{ width: 14, height: 14 }} aria-hidden="true">
+                      <use href={`/icons/sprite.svg#${icon}`}></use>
+                    </svg>
+                    {label}
+                  </div>
+                  <div id={`profile-${value}-desc`} className="text-muted small">{description}</div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </SettingSection>
+
       <SettingSection id="appearance" title="Appearance" icon="sun" search={search}>
         <div className="d-flex align-items-center justify-content-between flex-wrap gap-2">
           <span>Theme</span>


### PR DESCRIPTION
## Summary

PR A of the household-vs-landscaper persona split. Lays the groundwork for filtering menus without flipping any visible behavior yet. PR B (next) wires the Sidebar filter — splitting this way means a regression in the data layer doesn't hide menus from everyone.

### Backend
- \`GET /profile\` and \`PUT /profile\` (\`requireUser\`) at \`users/{userId}/profile/account\`
- Enum: \`household\` | \`landscaper\` | \`both\`
- \`PUT\` validates the enum (400 otherwise); \`GET\` lazy-defaults to \`household\` **without writing** — avoids churn for users who never visit Settings
- Stored separately from \`/subscription/current\` because tier and persona are orthogonal: a free-tier landscaper exists, and a paid user can want to see both surfaces

### Frontend
- \`profileApi { get, set }\` in \`src/api/plants.js\`
- \`ProfileContext\` + \`useProfile()\`: optimistic update, rollback on PUT failure, graceful degrade to default if the route 404s (gateway not yet updated)
- \`ProfileProvider\` mounted under \`SubscriptionProvider\`
- New **Profile mode** section at the top of the Preferences tab — three radio cards (Household / Landscaper / Both) with copy making clear it's a UI filter, not a billing change

### Out of scope
- Sidebar / menu filtering by persona — that's PR B
- Onboarding step — defer to PR B (lands with the visible behavior)
- Empty-state and tour copy — PR C (optional)

### Tier gating is unchanged
Persona is a UI filter only. \`requireTier('landscaper_pro')\` still 403s landscaper-only routes regardless of persona.

## Required platform-infra change

Same gotcha as \`/households\` and \`/api-keys\` — these new paths need OpenAPI Gateway entries before they're reachable from prod:

\`\`\`
GET  /profile  (auth: x-api-key + Google JWT)
PUT  /profile  (auth: x-api-key + Google JWT)
\`\`\`

Until that ships, the frontend degrades to \`accountType: 'household'\` silently — no UX impact.

## Test plan
- [x] Backend: \`GET /profile\` lazy-defaults without writing; \`PUT\` validates enum (8 new tests)
- [x] \`ProfileContext\` unit tests: load + persist, rollback on failure, guest skip, graceful 404 degrade (6 tests)
- [x] \`SettingsPage\`: Profile mode section renders, radio change calls \`setAccountType\` (2 new tests)
- [x] \`npm run preflight:fast\` passes
- [ ] Manually: load Settings → Preferences, see Profile mode card, switching persists across reload
- [ ] Verify guest mode shows the default selection without blowing up

## Pre-existing test flake
\`src/__tests__/App.test.jsx > "renders the dashboard when authenticated"\` was already failing on main before this PR. Confirmed by stashing and re-running. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)