### PR TITLE
feat(profile): persona menu filter + onboarding picker (PR B)

### DIFF
--- a/src/__tests__/Onboarding.test.jsx
+++ b/src/__tests__/Onboarding.test.jsx
@@ -1,29 +1,56 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const setAccountTypeMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('../context/ProfileContext.jsx', () => ({
+  useProfile: () => ({ accountType: 'household', setAccountType: setAccountTypeMock, loading: false, error: null, refresh: vi.fn() }),
+}))
+
 import Onboarding from '../components/Onboarding.jsx'
 
 const STORAGE_KEY = 'plant-tracker-onboarded'
 
+async function advancePastPersona() {
+  await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Caring for your home garden/i })) })
+}
+
 describe('Onboarding', () => {
   beforeEach(() => {
     localStorage.clear()
+    setAccountTypeMock.mockClear()
   })
 
-  it('renders when localStorage has no onboarding key', () => {
+  it('renders the persona picker as the first step', () => {
     render(<Onboarding />)
-    expect(screen.getByText('Upload a Floorplan')).toBeInTheDocument()
+    expect(screen.getByText(/How will you use Plant Tracker/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Caring for your home garden/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Managing client properties/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /I do both/i })).toBeInTheDocument()
   })
 
   it('does not render when localStorage indicates onboarding is done', () => {
     localStorage.setItem(STORAGE_KEY, '1')
-    const { container } = render(<Onboarding />)
-    expect(screen.queryByText('Upload a Floorplan')).not.toBeInTheDocument()
+    render(<Onboarding />)
+    expect(screen.queryByText(/How will you use Plant Tracker/i)).not.toBeInTheDocument()
   })
 
-  it('clicking Next advances through steps', () => {
+  it('picking a persona persists and advances to the info steps', async () => {
     render(<Onboarding />)
-    expect(screen.getByText('Upload a Floorplan')).toBeInTheDocument()
+    await advancePastPersona()
+    expect(setAccountTypeMock).toHaveBeenCalledWith('household')
+    await waitFor(() => expect(screen.getByText('Upload a Floorplan')).toBeInTheDocument())
+  })
+
+  it('"I do both" picks the both persona', async () => {
+    render(<Onboarding />)
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /I do both/i })) })
+    expect(setAccountTypeMock).toHaveBeenCalledWith('both')
+  })
+
+  it('Next advances through info steps after persona is picked', async () => {
+    render(<Onboarding />)
+    await advancePastPersona()
 
     fireEvent.click(screen.getByText('Next'))
     expect(screen.getByText('Add Your Plants')).toBeInTheDocument()
@@ -32,9 +59,9 @@ describe('Onboarding', () => {
     expect(screen.getByText('Track Watering')).toBeInTheDocument()
   })
 
-  it('shows "Get started" on the last step and clicking it dismisses', () => {
+  it('shows "Get started" on the last step and clicking it dismisses', async () => {
     render(<Onboarding />)
-
+    await advancePastPersona()
     fireEvent.click(screen.getByText('Next'))
     fireEvent.click(screen.getByText('Next'))
     expect(screen.getByText('Get started')).toBeInTheDocument()
@@ -44,12 +71,13 @@ describe('Onboarding', () => {
     expect(localStorage.getItem(STORAGE_KEY)).toBe('1')
   })
 
-  it('Skip tour button sets localStorage and hides onboarding', () => {
+  it('skip-tour button sets localStorage and hides onboarding from the persona step', () => {
     render(<Onboarding />)
-    expect(screen.getByText('Upload a Floorplan')).toBeInTheDocument()
+    expect(screen.getByText(/How will you use Plant Tracker/i)).toBeInTheDocument()
 
-    fireEvent.click(screen.getByText('Skip tour'))
-    expect(screen.queryByText('Upload a Floorplan')).not.toBeInTheDocument()
+    // Persona step shows the X close button (no Skip-tour link in footer)
+    fireEvent.click(screen.getByRole('button', { name: /Skip tour/i }))
+    expect(screen.queryByText(/How will you use Plant Tracker/i)).not.toBeInTheDocument()
     expect(localStorage.getItem(STORAGE_KEY)).toBe('1')
   })
 })

--- a/src/__tests__/Sidebar.test.jsx
+++ b/src/__tests__/Sidebar.test.jsx
@@ -31,6 +31,10 @@ vi.mock('../context/TourContext.jsx', () => ({
 vi.mock('../context/PropertyContext.jsx', () => ({
   useProperty: () => ({ properties: [], activePropertyId: 'primary', switchTo: vi.fn() }),
 }))
+let profileAccountType = 'household'
+vi.mock('../context/ProfileContext.jsx', () => ({
+  useProfile: () => ({ accountType: profileAccountType }),
+}))
 
 import Sidebar from '../layouts/components/Sidebar.jsx'
 
@@ -58,5 +62,32 @@ describe('Sidebar tour menu', () => {
     render(<MemoryRouter><Sidebar /></MemoryRouter>)
     fireEvent.click(screen.getByRole('button', { name: /What's new/i }))
     expect(openWhatsNew).toHaveBeenCalled()
+  })
+})
+
+describe('Sidebar persona filter', () => {
+  it('hides the Pro section for household persona', () => {
+    profileAccountType = 'household'
+    render(<MemoryRouter><Sidebar /></MemoryRouter>)
+    expect(screen.getByRole('link', { name: /Today/i })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /^Visits$/i })).toBeNull()
+    expect(screen.queryByRole('link', { name: /^Properties$/i })).toBeNull()
+    expect(screen.queryByRole('link', { name: /^Branding$/i })).toBeNull()
+  })
+
+  it('shows the Pro section for landscaper persona', () => {
+    profileAccountType = 'landscaper'
+    render(<MemoryRouter><Sidebar /></MemoryRouter>)
+    expect(screen.getByRole('link', { name: /^Visits$/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /^Properties$/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /^Branding$/i })).toBeInTheDocument()
+  })
+
+  it('shows the Pro section for both persona', () => {
+    profileAccountType = 'both'
+    render(<MemoryRouter><Sidebar /></MemoryRouter>)
+    expect(screen.getByRole('link', { name: /^Visits$/i })).toBeInTheDocument()
+    // Universal items still visible
+    expect(screen.getByRole('link', { name: /Today/i })).toBeInTheDocument()
   })
 })

--- a/src/components/Onboarding.jsx
+++ b/src/components/Onboarding.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Modal, Button, ProgressBar } from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
+import { useProfile } from '../context/ProfileContext.jsx'
 
 const LS_KEY = 'plant-tracker-onboarded'
 
@@ -12,14 +13,21 @@ const STEP_ICONS = [
 
 export default function Onboarding() {
   const { t } = useTranslation('onboarding')
+  const { setAccountType } = useProfile()
   const [step, setStep] = useState(0)
   const [show, setShow] = useState(false)
+  const [savingPersona, setSavingPersona] = useState(false)
 
-  const STEPS = [
-    { icon: STEP_ICONS[0], title: t('step1.title'), description: t('step1.description') },
-    { icon: STEP_ICONS[1], title: t('step2.title'), description: t('step2.description') },
-    { icon: STEP_ICONS[2], title: t('step3.title'), description: t('step3.description') },
+  // First step is the persona picker (no Next button — clicking a card
+  // saves and advances). Remaining steps are the original info screens,
+  // unchanged.
+  const PERSONA_STEP = { kind: 'persona' }
+  const INFO_STEPS = [
+    { kind: 'info', icon: STEP_ICONS[0], title: t('step1.title'), description: t('step1.description') },
+    { kind: 'info', icon: STEP_ICONS[1], title: t('step2.title'), description: t('step2.description') },
+    { kind: 'info', icon: STEP_ICONS[2], title: t('step3.title'), description: t('step3.description') },
   ]
+  const STEPS = [PERSONA_STEP, ...INFO_STEPS]
 
   useEffect(() => {
     if (!localStorage.getItem(LS_KEY)) setShow(true)
@@ -35,11 +43,24 @@ export default function Onboarding() {
     else dismiss()
   }
 
+  const pickPersona = async (accountType) => {
+    if (savingPersona) return
+    setSavingPersona(true)
+    try {
+      await setAccountType(accountType)
+    } catch { /* ProfileContext rolls back; surface nothing here */ }
+    finally {
+      setSavingPersona(false)
+      setStep((s) => s + 1)
+    }
+  }
+
   if (!show) return null
   const current = STEPS[step]
+  const isPersonaStep = current.kind === 'persona'
 
   return (
-    <Modal show={show} onHide={dismiss} centered size="sm">
+    <Modal show={show} onHide={dismiss} centered size={isPersonaStep ? 'md' : 'sm'}>
       <Modal.Body className="p-4">
         <ProgressBar
           now={((step + 1) / STEPS.length) * 100}
@@ -48,33 +69,82 @@ export default function Onboarding() {
           style={{ height: 4 }}
         />
 
-        <div className="d-flex align-items-start justify-content-between mb-3">
-          <div className="rounded-3 bg-primary bg-opacity-10 d-flex align-items-center justify-content-center" style={{ width: 48, height: 48 }}>
-            <svg className="sa-icon sa-icon-2x text-primary">
-              <use href={current.icon}></use>
-            </svg>
-          </div>
+        <div className="d-flex align-items-start justify-content-end mb-3">
           <button className="btn btn-sm text-muted p-0" onClick={dismiss} aria-label={t('skipTour')}>
             <svg className="sa-icon"><use href="/icons/sprite.svg#x"></use></svg>
           </button>
         </div>
 
-        <h5 className="fw-500 mb-2">{current.title}</h5>
-        <p className="text-muted fs-sm mb-0">{current.description}</p>
+        {isPersonaStep ? (
+          <>
+            <h5 className="fw-500 mb-2">How will you use Plant Tracker?</h5>
+            <p className="text-muted fs-sm mb-3">You can change this later in Settings.</p>
+            <div className="d-flex flex-column gap-2" role="radiogroup" aria-label="Profile mode">
+              <button
+                type="button"
+                onClick={() => pickPersona('household')}
+                disabled={savingPersona}
+                className="btn btn-outline-primary text-start p-3 d-flex gap-2 align-items-start"
+              >
+                <svg className="sa-icon sa-icon-2x flex-shrink-0 mt-1" aria-hidden="true">
+                  <use href="/icons/sprite.svg#home"></use>
+                </svg>
+                <span>
+                  <span className="d-block fw-500">Caring for your home garden</span>
+                  <span className="d-block text-muted fs-sm">Track plants, share with family, log watering and feeding.</span>
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => pickPersona('landscaper')}
+                disabled={savingPersona}
+                className="btn btn-outline-primary text-start p-3 d-flex gap-2 align-items-start"
+              >
+                <svg className="sa-icon sa-icon-2x flex-shrink-0 mt-1" aria-hidden="true">
+                  <use href="/icons/sprite.svg#briefcase"></use>
+                </svg>
+                <span>
+                  <span className="d-block fw-500">Managing client properties</span>
+                  <span className="d-block text-muted fs-sm">Multi-property visits, team scheduling, branded reports.</span>
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => pickPersona('both')}
+                disabled={savingPersona}
+                className="btn btn-link btn-sm text-muted text-decoration-none align-self-center"
+              >
+                I do both — show me everything
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="rounded-3 bg-primary bg-opacity-10 d-flex align-items-center justify-content-center mb-3" style={{ width: 48, height: 48 }}>
+              <svg className="sa-icon sa-icon-2x text-primary">
+                <use href={current.icon}></use>
+              </svg>
+            </div>
+            <h5 className="fw-500 mb-2">{current.title}</h5>
+            <p className="text-muted fs-sm mb-0">{current.description}</p>
+          </>
+        )}
       </Modal.Body>
-      <Modal.Footer className="border-top-0 d-flex justify-content-between">
-        <button className="btn btn-link btn-sm text-muted p-0" onClick={dismiss}>
-          {t('skipTour')}
-        </button>
-        <Button variant="primary" size="sm" onClick={next}>
-          {step < STEPS.length - 1 ? (
-            <>
-              {t('common:actions.next')}
-              <svg className="sa-icon ms-1" style={{ width: 14, height: 14 }}><use href="/icons/sprite.svg#chevron-right"></use></svg>
-            </>
-          ) : t('getStarted')}
-        </Button>
-      </Modal.Footer>
+      {!isPersonaStep && (
+        <Modal.Footer className="border-top-0 d-flex justify-content-between">
+          <button className="btn btn-link btn-sm text-muted p-0" onClick={dismiss}>
+            {t('skipTour')}
+          </button>
+          <Button variant="primary" size="sm" onClick={next}>
+            {step < STEPS.length - 1 ? (
+              <>
+                {t('common:actions.next')}
+                <svg className="sa-icon ms-1" style={{ width: 14, height: 14 }}><use href="/icons/sprite.svg#chevron-right"></use></svg>
+              </>
+            ) : t('getStarted')}
+          </Button>
+        </Modal.Footer>
+      )}
     </Modal>
   )
 }

--- a/src/layouts/components/Sidebar.jsx
+++ b/src/layouts/components/Sidebar.jsx
@@ -6,15 +6,17 @@ import { usePlantContext } from '../../context/PlantContext.jsx'
 import { useHelp } from '../../context/HelpContext.jsx'
 import { useTour, TOURS } from '../../context/TourContext.jsx'
 import { useProperty } from '../../context/PropertyContext.jsx'
+import { useProfile } from '../../context/ProfileContext.jsx'
 import SidebarMenu from './SidebarMenu.jsx'
 import WeatherStrip from '../../components/WeatherStrip.jsx'
 import OfflineIndicator from '../../components/OfflineIndicator.jsx'
-import { menuItems } from './menuData.js'
+import { menuItems, filterMenuByPersona } from './menuData.js'
 import { buildWaterTasks } from '../../utils/todayTasks.js'
 
 export default function Sidebar() {
   const { user, logout } = useAuth()
   const { properties, activePropertyId, switchTo } = useProperty()
+  const { accountType } = useProfile()
   const { navMinified, toggleSetting } = useLayoutContext()
   const { weather, location, plants, floors } = usePlantContext()
   const { open: openHelp } = useHelp()
@@ -25,6 +27,11 @@ export default function Sidebar() {
   const todayCount = useMemo(
     () => buildWaterTasks(plants, weather, floors).tasks.length,
     [plants, weather, floors],
+  )
+
+  const visibleMenu = useMemo(
+    () => filterMenuByPersona(menuItems, accountType),
+    [accountType],
   )
 
   const toggleSidenav = () => {
@@ -83,7 +90,7 @@ export default function Sidebar() {
       {/* Navigation */}
       <div className="primary-nav flex-grow-1 overflow-auto">
         <div className="scrollbar">
-          <SidebarMenu items={menuItems} badges={{ today: todayCount }} />
+          <SidebarMenu items={visibleMenu} badges={{ today: todayCount }} />
           {/* Sign out — below Settings */}
           <ul className="nav-menu d-flex flex-column">
             <li>

--- a/src/layouts/components/menuData.js
+++ b/src/layouts/components/menuData.js
@@ -1,3 +1,6 @@
+// `personas` (optional): which Profile-mode personas the item is shown to.
+// Items / sections without a `personas` key are universal. Filter is applied
+// in Sidebar.jsx; ordering and labels stay declared here.
 export const menuItems = [
   {
     key: 'garden',
@@ -10,6 +13,18 @@ export const menuItems = [
       { key: 'calendar', label: 'Care Calendar', icon: '/icons/sprite.svg#calendar', url: '/calendar' },
       { key: 'forecast', label: 'Forecast', icon: '/icons/sprite.svg#cloud', url: '/forecast' },
       { key: 'propagation', label: 'Propagation', icon: '/icons/sprite.svg#git-branch', url: '/propagation' },
+    ],
+  },
+  {
+    key: 'pro',
+    label: 'Pro',
+    isSection: true,
+    collapsible: true,
+    personas: ['landscaper', 'both'],
+    children: [
+      { key: 'visits', label: 'Visits', icon: '/icons/sprite.svg#calendar', url: '/visits' },
+      { key: 'client-properties', label: 'Properties', icon: '/icons/sprite.svg#home', url: '/settings/client-properties' },
+      { key: 'branding', label: 'Branding', icon: '/icons/sprite.svg#star', url: '/settings/branding' },
     ],
   },
   {
@@ -34,3 +49,20 @@ export const menuItems = [
     ],
   },
 ]
+
+/**
+ * Drop sections / children whose `personas` array doesn't include the
+ * current accountType. Universal items (no `personas` key) always pass.
+ * Empty sections (all children filtered out) are removed.
+ */
+export function filterMenuByPersona(items, accountType) {
+  const matches = (item) => !item.personas || item.personas.includes(accountType)
+  return items
+    .filter(matches)
+    .map((section) => {
+      if (!section.children) return section
+      const children = section.children.filter(matches)
+      return { ...section, children }
+    })
+    .filter((section) => !section.children || section.children.length > 0)
+}


### PR DESCRIPTION
## Summary

PR B of the household-vs-landscaper persona split. Wires the visible behaviour for the data layer that #375 just landed.

### Sidebar
- New **Pro** section in \`menuData.js\`: **Visits / Properties / Branding** — all already exist as routes/pages, just weren't reachable from the nav. Tagged \`personas: ['landscaper', 'both']\`. Existing **Garden / Insights / Manage** sections stay universal (no \`personas\` key, always visible).
- \`filterMenuByPersona()\` is a small pure function: drops sections / children whose \`personas\` array excludes the active \`accountType\`, and prunes sections that end up empty. Easy to unit-test and reason about.
- \`Sidebar\` reads \`useProfile().accountType\` and feeds the filtered list to \`SidebarMenu\`. Memoised — only re-runs when persona changes.

### Onboarding
- New first step asks **"How will you use Plant Tracker?"** with two big cards (Caring for your home garden / Managing client properties) plus a small **"I do both"** link. Picking persists via \`setAccountType\` and advances to the original 3 info screens, which are unchanged.
- Picker step uses \`size="md"\` and skips the footer — the cards themselves are the action. Info steps keep the existing \`size="sm"\` + Next / Get-started flow.

### Tier gating untouched
Persona is still a UI filter, not a permission boundary:
- A household-mode \`landscaper_pro\` user who knows \`/visits\` can navigate there directly — the page loads.
- A free-tier landscaper-mode user sees the Pro menu but hits 403 / \`UpgradePrompt\` inside.

## Test plan
- [x] \`Sidebar.test.jsx\` — three new tests: household hides Pro, landscaper shows Pro, both shows everything (5 total)
- [x] \`Onboarding.test.jsx\` — rewritten to cover the picker step (7 total): renders persona picker first, picking household calls setAccountType, "I do both" picks 'both', Next advances through info steps, Get started dismisses, Skip-tour from picker dismisses
- [x] \`npm run preflight:fast\` passes
- [ ] Open onboarding (clear \`plant-tracker-onboarded\` in localStorage, reload): picker shows; picking landscaper persists, sidebar Pro section appears immediately
- [ ] Switch persona in Settings → Preferences: sidebar updates without reload
- [ ] Persona = household: \`/visits\` URL still loads (tier-gated, not menu-gated)

## Stacked on #375
Branched from PR A's commit so the \`useProfile\` hook is available; rebased onto current main now that #375 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)