### PR TITLE
feat(profile): persona-aware onboarding info steps (PR C)

### DIFF
--- a/src/__tests__/Onboarding.test.jsx
+++ b/src/__tests__/Onboarding.test.jsx
@@ -2,9 +2,12 @@ import React from 'react'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const setAccountTypeMock = vi.fn().mockResolvedValue(undefined)
+let mockedAccountType = 'household'
+const setAccountTypeMock = vi.fn().mockImplementation(async (next) => {
+  mockedAccountType = next
+})
 vi.mock('../context/ProfileContext.jsx', () => ({
-  useProfile: () => ({ accountType: 'household', setAccountType: setAccountTypeMock, loading: false, error: null, refresh: vi.fn() }),
+  useProfile: () => ({ accountType: mockedAccountType, setAccountType: setAccountTypeMock, loading: false, error: null, refresh: vi.fn() }),
 }))
 
 import Onboarding from '../components/Onboarding.jsx'
@@ -19,6 +22,7 @@ describe('Onboarding', () => {
   beforeEach(() => {
     localStorage.clear()
     setAccountTypeMock.mockClear()
+    mockedAccountType = 'household'
   })
 
   it('renders the persona picker as the first step', () => {
@@ -69,6 +73,26 @@ describe('Onboarding', () => {
     fireEvent.click(screen.getByText('Get started'))
     expect(screen.queryByText('Track Watering')).not.toBeInTheDocument()
     expect(localStorage.getItem(STORAGE_KEY)).toBe('1')
+  })
+
+  it('shows landscaper-specific info steps after picking landscaper', async () => {
+    render(<Onboarding />)
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Managing client properties/i })) })
+
+    expect(setAccountTypeMock).toHaveBeenCalledWith('landscaper')
+    await waitFor(() => expect(screen.getByText('Add Your First Property')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('Next'))
+    expect(screen.getByText('Schedule a Visit')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Next'))
+    expect(screen.getByText('Send Branded Reports')).toBeInTheDocument()
+  })
+
+  it('"both" persona uses the household track', async () => {
+    render(<Onboarding />)
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /I do both/i })) })
+    await waitFor(() => expect(screen.getByText('Upload a Floorplan')).toBeInTheDocument())
   })
 
   it('skip-tour button sets localStorage and hides onboarding from the persona step', () => {

--- a/src/components/Onboarding.jsx
+++ b/src/components/Onboarding.jsx
@@ -5,28 +5,43 @@ import { useProfile } from '../context/ProfileContext.jsx'
 
 const LS_KEY = 'plant-tracker-onboarded'
 
-const STEP_ICONS = [
-  '/icons/sprite.svg#upload',
-  '/icons/sprite.svg#plus',
-  '/icons/sprite.svg#droplet',
-]
+// Step icons keyed by persona — landscaper steps are about properties /
+// visits / branding, household are about floorplan / plants / watering.
+const STEP_ICONS = {
+  household:  ['/icons/sprite.svg#upload',     '/icons/sprite.svg#plus',     '/icons/sprite.svg#droplet'],
+  landscaper: ['/icons/sprite.svg#home',       '/icons/sprite.svg#calendar', '/icons/sprite.svg#star'],
+}
+
+// `both` reuses the household track — it's the broader of the two and the
+// user can re-take the landscaper tour from the Take-a-tour menu later.
+const STEP_KEYS = {
+  household:  ['step1', 'step2', 'step3'],
+  landscaper: ['landscaperStep1', 'landscaperStep2', 'landscaperStep3'],
+}
+
+function infoStepsFor(persona, t) {
+  const track = persona === 'landscaper' ? 'landscaper' : 'household'
+  return STEP_KEYS[track].map((key, i) => ({
+    kind: 'info',
+    icon: STEP_ICONS[track][i],
+    title: t(`${key}.title`),
+    description: t(`${key}.description`),
+  }))
+}
 
 export default function Onboarding() {
   const { t } = useTranslation('onboarding')
-  const { setAccountType } = useProfile()
+  const { accountType, setAccountType } = useProfile()
   const [step, setStep] = useState(0)
   const [show, setShow] = useState(false)
   const [savingPersona, setSavingPersona] = useState(false)
 
   // First step is the persona picker (no Next button — clicking a card
-  // saves and advances). Remaining steps are the original info screens,
-  // unchanged.
+  // saves and advances). Remaining steps adapt to the picked persona —
+  // landscaper sees Property/Visit/Branding copy, household sees the
+  // original Floorplan/Plants/Watering copy.
   const PERSONA_STEP = { kind: 'persona' }
-  const INFO_STEPS = [
-    { kind: 'info', icon: STEP_ICONS[0], title: t('step1.title'), description: t('step1.description') },
-    { kind: 'info', icon: STEP_ICONS[1], title: t('step2.title'), description: t('step2.description') },
-    { kind: 'info', icon: STEP_ICONS[2], title: t('step3.title'), description: t('step3.description') },
-  ]
+  const INFO_STEPS = infoStepsFor(accountType, t)
   const STEPS = [PERSONA_STEP, ...INFO_STEPS]
 
   useEffect(() => {

--- a/src/i18n/locales/en/onboarding.json
+++ b/src/i18n/locales/en/onboarding.json
@@ -11,6 +11,18 @@
     "title": "Track Watering",
     "description": "Mark plants as watered to build your care schedule. Get reminders when plants need attention."
   },
+  "landscaperStep1": {
+    "title": "Add Your First Property",
+    "description": "Each client gets their own property with its own plants, floorplan, and care schedule. Add one from Settings → Properties."
+  },
+  "landscaperStep2": {
+    "title": "Schedule a Visit",
+    "description": "Plan watering, pruning, or maintenance visits ahead of time. Check in on arrival and complete on the way out — your client gets a record of work done."
+  },
+  "landscaperStep3": {
+    "title": "Send Branded Reports",
+    "description": "Configure your business logo and colours in Settings → Branding so every client report carries your brand."
+  },
   "skipTour": "Skip tour",
   "getStarted": "Get started"
 }

--- a/src/i18n/locales/es/onboarding.json
+++ b/src/i18n/locales/es/onboarding.json
@@ -11,6 +11,18 @@
     "title": "Registra el riego",
     "description": "Marca las plantas como regadas para crear tu horario de cuidados. Recibe recordatorios cuando las plantas necesiten atención."
   },
+  "landscaperStep1": {
+    "title": "Añade tu primera propiedad",
+    "description": "Cada cliente tiene su propia propiedad con plantas, plano y calendario de cuidados. Añade una desde Ajustes → Propiedades."
+  },
+  "landscaperStep2": {
+    "title": "Programa una visita",
+    "description": "Planifica visitas de riego, poda o mantenimiento. Marca tu llegada y la finalización — el cliente recibe un registro del trabajo realizado."
+  },
+  "landscaperStep3": {
+    "title": "Envía informes con tu marca",
+    "description": "Configura el logo y los colores de tu negocio en Ajustes → Marca para que cada informe de cliente lleve tu identidad."
+  },
   "skipTour": "Omitir tour",
   "getStarted": "Empezar"
 }


### PR DESCRIPTION
## Summary

Final piece of the persona split. After the picker landed in #376, the three info screens that follow were still showing the household-flavoured copy ("Upload a Floorplan / Add Your Plants / Track Watering") to landscapers — who'd just told us they manage client properties.

Branches the info-step copy on the picked persona:

| Persona | Track | Step 1 | Step 2 | Step 3 |
|---|---|---|---|---|
| household / both | existing | Upload a Floorplan | Add Your Plants | Track Watering |
| landscaper | new | Add Your First Property | Schedule a Visit | Send Branded Reports |

\`both\` reuses the household track because it's the broader of the two — the user can re-take any tour later from the sidebar's Take-a-tour menu.

## i18n
- New \`landscaperStep1/2/3\` keys added to:
  - \`en/onboarding.json\` (canonical)
  - \`es/onboarding.json\` (the full-coverage locale)
- Other locales (\`fr/de/pt/ja/ar\`) fall back to \`en\` for the new keys per the project's i18n fallback design. The household track in those locales is unchanged.

## Test plan
- [x] \`Onboarding.test.jsx\` — 2 new tests covering the landscaper info-step copy and the \`both\` → household-track behaviour (9 total)
- [x] \`npm run preflight:fast\` passes
- [ ] Manually: open onboarding (clear \`plant-tracker-onboarded\` in localStorage, reload), pick "Managing client properties", verify the next 3 screens show Property / Visit / Branding copy

## Stack
Stacks on #375 (PR A — data model) and #376 (PR B — menu filter + picker). Both are merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)