### PR TITLE
fix(e2e): update onboarding smoke for persona picker step

### DIFF
--- a/e2e/modals.spec.js
+++ b/e2e/modals.spec.js
@@ -29,10 +29,13 @@ test.describe('First-run overlays', () => {
     // Set consent + whatsNewSeen; leave onboarded unset → Onboarding shows.
     await enterGuestMode(page, { consent: true, onboarded: false, whatsNewSeen: true })
     await page.goto('/', { waitUntil: 'networkidle' })
-    // Onboarding is a Bootstrap modal; step 1 title is "Upload a Floorplan".
+    // Onboarding is a Bootstrap modal. Step 1 (added in PR #376) is the
+    // persona picker — "How will you use Plant Tracker?". The original info
+    // steps (Upload a Floorplan / Add Your Plants / Track Watering) follow
+    // once a persona is picked.
     const dialog = page.getByRole('dialog')
     await expect(dialog).toBeVisible({ timeout: 8_000 })
-    await expect(dialog).toContainText('Upload a Floorplan')
+    await expect(dialog).toContainText('How will you use Plant Tracker')
     expect(errors, `Unexpected errors on Onboarding:\n${errors.join('\n\n')}`).toEqual([])
   })
 


### PR DESCRIPTION
## Summary

PR #376 made the persona picker the new first onboarding step but didn't update the Playwright smoke in \`e2e/modals.spec.js\`, which still asserted \"Upload a Floorplan\" as the visible step-1 text. That smoke failed on the deploy run for #377 → \`needs: [test, e2e]\` skipped \`deploy-function\` and \`build-and-deploy\`, so **production has been serving the Cloud Function from PR #374** ever since.

That's why \`curl /profile\` and \`curl /ml/status\` returned 404 from Express even after platform-infra #55/#56 registered the routes — the gateway was forwarding correctly, the function just didn't have the handlers.

## Fix
Update the assertion to match the new step-1 copy:
\`\`\`diff
- await expect(dialog).toContainText('Upload a Floorplan')
+ await expect(dialog).toContainText('How will you use Plant Tracker')
\`\`\`

The original info-step copy is still verified indirectly by \`src/__tests__/Onboarding.test.jsx\`, which advances through the picker step before asserting on step-2/3 content.

## Test plan
- [x] \`npm run preflight:fast\` passes
- [ ] CI E2E smoke passes
- [ ] After merge: function deploy runs → \`curl /profile\` returns 401 (auth required) instead of 404 (Express \"Cannot GET\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)