### PR TITLE
feat(profile): admin-only feature visibility toggles

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1594,6 +1594,70 @@ app.put('/config/branding', requireUser, requireTier('landscaper_pro'), async (r
   }
 });
 
+// ── Feature-flag overrides (workspace-scoped, admin-edited) ───────────────────
+// The admin (household owner / landscaper org manager) can override which
+// menu items each persona sees, on top of the static defaults declared in
+// src/layouts/components/menuData.js. Any member can READ; only admins WRITE.
+//
+// Document shape at users/{ownerId}/config/featureFlags:
+//   { overrides: { [itemKey]: 'household'|'landscaper'|'both'|'hidden' },
+//     updatedAt: ISO }
+// Items absent from `overrides` fall back to their static persona array.
+
+const FEATURE_FLAG_VALUES = ['household', 'landscaper', 'both', 'hidden'];
+const FEATURE_KEY_RE = /^[a-z0-9-]{1,40}$/;
+
+function isWorkspaceAdmin(req) {
+  return req.role === 'owner' || req.orgRole === 'manager';
+}
+
+app.get('/config/feature-flags', requireUser, async (req, res) => {
+  try {
+    const doc = await userConfig(req.userId).doc('featureFlags').get();
+    const data = doc.exists ? doc.data() : {};
+    res.status(200).json({
+      overrides: data.overrides || {},
+      updatedAt: data.updatedAt || null,
+      canEdit: isWorkspaceAdmin(req),
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.put('/config/feature-flags', requireUser, async (req, res) => {
+  if (!isWorkspaceAdmin(req)) {
+    return res.status(403).json({
+      error: 'forbidden_role',
+      requiredRole: 'owner',
+      currentRole: req.orgRole || req.role || null,
+    });
+  }
+  try {
+    const { overrides } = req.body || {};
+    if (!overrides || typeof overrides !== 'object' || Array.isArray(overrides)) {
+      return res.status(400).json({ error: 'overrides must be an object' });
+    }
+    const cleaned = {};
+    for (const [key, value] of Object.entries(overrides)) {
+      if (!FEATURE_KEY_RE.test(key)) {
+        return res.status(400).json({ error: `invalid feature key: ${key}` });
+      }
+      if (!FEATURE_FLAG_VALUES.includes(value)) {
+        return res.status(400).json({
+          error: `value for ${key} must be one of ${FEATURE_FLAG_VALUES.join(', ')}`,
+        });
+      }
+      cleaned[key] = value;
+    }
+    const updatedAt = new Date().toISOString();
+    await userConfig(req.userId).doc('featureFlags').set({ overrides: cleaned, updatedAt }, { merge: false });
+    res.status(200).json({ overrides: cleaned, updatedAt, canEdit: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Households (multi-user shared access) ────────────────────────────────────
 // All data still lives at users/{ownerId}/... — households add a membership
 // overlay that lets multiple users see and edit the same plants. See

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -688,6 +688,146 @@ describe('PUT /config/branding', () => {
   });
 });
 
+// ── /config/feature-flags ─────────────────────────────────────────────────────
+
+const featureFlagsPath = (sub) => `users/${sub || USER_SUB}/config/featureFlags`;
+
+describe('GET /config/feature-flags', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).get('/config/feature-flags');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns empty overrides when nothing has been saved', async () => {
+    const res = await request(app)
+      .get('/config/feature-flags')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.overrides).toEqual({});
+    expect(res.body.canEdit).toBe(true); // lazy-created household → owner
+  });
+
+  it('returns saved overrides and canEdit=true for the owner', async () => {
+    store[featureFlagsPath()] = {
+      overrides: { branding: 'landscaper', propagation: 'household' },
+      updatedAt: '2026-04-29T10:00:00Z',
+    };
+    const res = await request(app)
+      .get('/config/feature-flags')
+      .set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.overrides).toEqual({ branding: 'landscaper', propagation: 'household' });
+    expect(res.body.updatedAt).toBe('2026-04-29T10:00:00Z');
+    expect(res.body.canEdit).toBe(true);
+  });
+
+  it('returns canEdit=false for a non-owner household member', async () => {
+    // Owner creates the household; viewer joins it.
+    const list = await request(app).get('/households').set('Authorization', authHeader('alice'));
+    const householdId = list.body.households[0].id;
+    const inviteRes = await request(app)
+      .post(`/households/${householdId}/invites`)
+      .set('Authorization', authHeader('alice'))
+      .send({ role: 'viewer' });
+    await request(app)
+      .post('/households/join')
+      .set('Authorization', authHeader('viewerbob'))
+      .send({ code: inviteRes.body.code });
+
+    store[featureFlagsPath('alice')] = {
+      overrides: { branding: 'hidden' },
+      updatedAt: '2026-04-29T10:00:00Z',
+    };
+
+    const res = await request(app)
+      .get('/config/feature-flags')
+      .set('Authorization', authHeader('viewerbob'));
+    expect(res.status).toBe(200);
+    expect(res.body.overrides).toEqual({ branding: 'hidden' });
+    expect(res.body.canEdit).toBe(false);
+  });
+});
+
+describe('PUT /config/feature-flags', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app)
+      .put('/config/feature-flags')
+      .send({ overrides: {} });
+    expect(res.status).toBe(401);
+  });
+
+  it('saves overrides for an owner and returns them', async () => {
+    const res = await request(app)
+      .put('/config/feature-flags')
+      .set('Authorization', authHeader())
+      .send({ overrides: { branding: 'landscaper', today: 'both' } });
+    expect(res.status).toBe(200);
+    expect(res.body.overrides).toEqual({ branding: 'landscaper', today: 'both' });
+    expect(res.body.canEdit).toBe(true);
+    expect(store[featureFlagsPath()].overrides).toEqual({ branding: 'landscaper', today: 'both' });
+    expect(store[featureFlagsPath()].updatedAt).toBeTruthy();
+  });
+
+  it('replaces (not merges) the overrides map on each PUT', async () => {
+    store[featureFlagsPath()] = {
+      overrides: { branding: 'landscaper', propagation: 'household' },
+      updatedAt: '2026-04-29T10:00:00Z',
+    };
+    await request(app)
+      .put('/config/feature-flags')
+      .set('Authorization', authHeader())
+      .send({ overrides: { today: 'both' } });
+    expect(store[featureFlagsPath()].overrides).toEqual({ today: 'both' });
+  });
+
+  it('returns 400 when overrides is missing', async () => {
+    const res = await request(app)
+      .put('/config/feature-flags')
+      .set('Authorization', authHeader())
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/overrides/);
+  });
+
+  it('returns 400 for an unknown persona value', async () => {
+    const res = await request(app)
+      .put('/config/feature-flags')
+      .set('Authorization', authHeader())
+      .send({ overrides: { branding: 'admin' } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/branding/);
+  });
+
+  it('returns 400 for an invalid feature key', async () => {
+    const res = await request(app)
+      .put('/config/feature-flags')
+      .set('Authorization', authHeader())
+      .send({ overrides: { 'BAD KEY!': 'household' } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/invalid feature key/);
+  });
+
+  it('returns 403 forbidden_role for a non-owner household member', async () => {
+    const list = await request(app).get('/households').set('Authorization', authHeader('alice'));
+    const householdId = list.body.households[0].id;
+    const inviteRes = await request(app)
+      .post(`/households/${householdId}/invites`)
+      .set('Authorization', authHeader('alice'))
+      .send({ role: 'editor' });
+    await request(app)
+      .post('/households/join')
+      .set('Authorization', authHeader('editbob'))
+      .send({ code: inviteRes.body.code });
+
+    const res = await request(app)
+      .put('/config/feature-flags')
+      .set('Authorization', authHeader('editbob'))
+      .send({ overrides: { branding: 'landscaper' } });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('forbidden_role');
+  });
+});
+
 // ── GET /plants ───────────────────────────────────────────────────────────────
 
 describe('GET /plants', () => {

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -37,6 +37,10 @@ vi.mock('../api/plants.js', () => ({
     get: vi.fn().mockResolvedValue({ accountType: 'household' }),
     set: vi.fn().mockResolvedValue({ accountType: 'household' }),
   },
+  featureFlagsApi: {
+    get: vi.fn().mockResolvedValue({ overrides: {}, canEdit: false }),
+    save: vi.fn().mockResolvedValue({ overrides: {}, canEdit: true }),
+  },
 }))
 
 vi.mock('../contexts/AuthContext.jsx', async (importOriginal) => {

--- a/src/__tests__/ProfileContext.test.jsx
+++ b/src/__tests__/ProfileContext.test.jsx
@@ -8,6 +8,10 @@ vi.mock('../api/plants.js', () => ({
     get: vi.fn(),
     set: vi.fn(),
   },
+  featureFlagsApi: {
+    get: vi.fn().mockResolvedValue({ overrides: {}, canEdit: false }),
+    save: vi.fn().mockResolvedValue({ overrides: {}, canEdit: true }),
+  },
 }))
 
 let authState = { isAuthenticated: true, isGuest: false }

--- a/src/__tests__/SettingsPage.test.jsx
+++ b/src/__tests__/SettingsPage.test.jsx
@@ -34,8 +34,20 @@ vi.mock('../context/LayoutContext.jsx', () => ({
 }))
 
 const setAccountTypeMock = vi.fn().mockResolvedValue(undefined)
+const saveFeatureOverridesMock = vi.fn().mockResolvedValue(undefined)
+let profileCanEdit = false
+let profileFeatureOverrides = {}
 vi.mock('../context/ProfileContext.jsx', () => ({
-  useProfile: () => ({ accountType: 'household', setAccountType: setAccountTypeMock, loading: false, error: null, refresh: vi.fn() }),
+  useProfile: () => ({
+    accountType: 'household',
+    setAccountType: setAccountTypeMock,
+    featureOverrides: profileFeatureOverrides,
+    saveFeatureOverrides: saveFeatureOverridesMock,
+    canEditFeatureFlags: profileCanEdit,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
 }))
 
 vi.mock('../contexts/AuthContext.jsx', () => ({
@@ -498,3 +510,54 @@ describe('SettingsPage Branding tab', () => {
     await waitFor(() => expect(brandingApi.save).toHaveBeenCalledWith({ logoUrl: 'https://storage.example.com/branding/logo.png' }))
   })
 })
+
+describe('SettingsPage Features tab (admin only)', () => {
+  beforeEach(() => {
+    saveFeatureOverridesMock.mockClear()
+    profileFeatureOverrides = {}
+  })
+
+  function tabLabels(container) {
+    return Array.from(container.querySelectorAll('.nav-link')).map((el) => el.textContent.trim().toLowerCase())
+  }
+
+  it('hides the Features tab from non-admins', () => {
+    profileCanEdit = false
+    const { container } = renderAt('/settings/property')
+    expect(tabLabels(container).some((l) => l.includes('features'))).toBe(false)
+  })
+
+  it('redirects non-admins away from /settings/features', () => {
+    profileCanEdit = false
+    renderAt('/settings/features')
+    // Falls back to the Property tab content
+    expect(screen.getByText(/Floors & Zones/i)).toBeInTheDocument()
+  })
+
+  it('shows the Features tab to admins', () => {
+    profileCanEdit = true
+    const { container } = renderAt('/settings/property')
+    expect(tabLabels(container).some((l) => l.includes('features'))).toBe(true)
+  })
+
+  it('renders the feature toggle table at /settings/features for admins', () => {
+    profileCanEdit = true
+    renderAt('/settings/features')
+    expect(screen.getByText(/Feature visibility/i)).toBeInTheDocument()
+    // Each menu item should have an override <select> with our four options + Default
+    const selects = screen.getAllByRole('combobox')
+    expect(selects.length).toBeGreaterThan(0)
+  })
+
+  it('saves overrides via saveFeatureOverrides', async () => {
+    profileCanEdit = true
+    renderAt('/settings/features')
+    const branding = screen.getByLabelText(/Override for Branding/i)
+    fireEvent.change(branding, { target: { value: 'household' } })
+    fireEvent.click(screen.getByRole('button', { name: /Save changes/i }))
+    await waitFor(() =>
+      expect(saveFeatureOverridesMock).toHaveBeenCalledWith(expect.objectContaining({ branding: 'household' })),
+    )
+  })
+})
+

--- a/src/__tests__/Sidebar.test.jsx
+++ b/src/__tests__/Sidebar.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 
 const startTour = vi.fn()
 const openWhatsNew = vi.fn()
@@ -32,8 +32,9 @@ vi.mock('../context/PropertyContext.jsx', () => ({
   useProperty: () => ({ properties: [], activePropertyId: 'primary', switchTo: vi.fn() }),
 }))
 let profileAccountType = 'household'
+let profileFeatureOverrides = {}
 vi.mock('../context/ProfileContext.jsx', () => ({
-  useProfile: () => ({ accountType: profileAccountType }),
+  useProfile: () => ({ accountType: profileAccountType, featureOverrides: profileFeatureOverrides }),
 }))
 
 import Sidebar from '../layouts/components/Sidebar.jsx'
@@ -85,9 +86,33 @@ describe('Sidebar persona filter', () => {
 
   it('shows the Pro section for both persona', () => {
     profileAccountType = 'both'
+    profileFeatureOverrides = {}
     render(<MemoryRouter><Sidebar /></MemoryRouter>)
     expect(screen.getByRole('link', { name: /^Visits$/i })).toBeInTheDocument()
     // Universal items still visible
     expect(screen.getByRole('link', { name: /Today/i })).toBeInTheDocument()
+  })
+})
+
+describe('Sidebar feature-flag overrides', () => {
+  it("admin override 'hidden' removes a normally-visible item", () => {
+    profileAccountType = 'household'
+    profileFeatureOverrides = { propagation: 'hidden' }
+    render(<MemoryRouter><Sidebar /></MemoryRouter>)
+    expect(screen.queryByRole('link', { name: /Propagation/i })).toBeNull()
+    // Other universal items unaffected
+    expect(screen.getByRole('link', { name: /Today/i })).toBeInTheDocument()
+  })
+
+  it("admin override 'both' shows a normally-landscaper-only item to households", () => {
+    profileAccountType = 'household'
+    // The Pro section itself is landscaper-only; force it open and force a child visible.
+    profileFeatureOverrides = { pro: 'both', branding: 'both' }
+    render(<MemoryRouter><Sidebar /></MemoryRouter>)
+    expect(screen.getByRole('link', { name: /^Branding$/i })).toBeInTheDocument()
+  })
+
+  afterEach(() => {
+    profileFeatureOverrides = {}
   })
 })

--- a/src/__tests__/menuData.test.js
+++ b/src/__tests__/menuData.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { filterMenuByPersona } from '../layouts/components/menuData.js'
+
+const SAMPLE = [
+  {
+    key: 'garden',
+    label: 'Garden',
+    isSection: true,
+    children: [
+      { key: 'today', label: 'Today' },
+      { key: 'propagation', label: 'Propagation' },
+    ],
+  },
+  {
+    key: 'pro',
+    label: 'Pro',
+    isSection: true,
+    personas: ['landscaper', 'both'],
+    children: [
+      { key: 'visits', label: 'Visits' },
+      { key: 'branding', label: 'Branding' },
+    ],
+  },
+  {
+    key: 'manage',
+    label: 'Manage',
+    isSection: true,
+    children: [
+      { key: 'settings', label: 'Settings' },
+    ],
+  },
+]
+
+describe('filterMenuByPersona — static defaults', () => {
+  it('hides landscaper-only sections from household persona', () => {
+    const out = filterMenuByPersona(SAMPLE, 'household')
+    expect(out.find((s) => s.key === 'pro')).toBeUndefined()
+    expect(out.find((s) => s.key === 'garden')).toBeDefined()
+  })
+
+  it('shows landscaper-only sections to landscaper persona', () => {
+    const out = filterMenuByPersona(SAMPLE, 'landscaper')
+    expect(out.find((s) => s.key === 'pro')).toBeDefined()
+  })
+
+  it('shows landscaper-only sections to "both" persona', () => {
+    const out = filterMenuByPersona(SAMPLE, 'both')
+    expect(out.find((s) => s.key === 'pro')).toBeDefined()
+  })
+
+  it('back-compat: works with two args (no overrides)', () => {
+    const out = filterMenuByPersona(SAMPLE, 'household')
+    expect(out.find((s) => s.key === 'garden').children.map((c) => c.key)).toEqual(['today', 'propagation'])
+  })
+})
+
+describe('filterMenuByPersona — admin overrides', () => {
+  it("'hidden' override removes the item even when its persona would have shown it", () => {
+    const out = filterMenuByPersona(SAMPLE, 'landscaper', { visits: 'hidden' })
+    const pro = out.find((s) => s.key === 'pro')
+    expect(pro).toBeDefined()
+    expect(pro.children.map((c) => c.key)).toEqual(['branding'])
+  })
+
+  it("'household' override forces a landscaper-only item visible to households", () => {
+    const out = filterMenuByPersona(SAMPLE, 'household', { branding: 'household' })
+    // The 'pro' section is still gated by its own personas array.
+    expect(out.find((s) => s.key === 'pro')).toBeUndefined()
+    // But within an unfiltered tree, the per-item override applies. Check via persona='both'.
+    const out2 = filterMenuByPersona(SAMPLE, 'both', { branding: 'household' })
+    const pro2 = out2.find((s) => s.key === 'pro')
+    expect(pro2.children.find((c) => c.key === 'branding')).toBeUndefined()
+  })
+
+  it("'both' override forces an item visible regardless of persona", () => {
+    const out = filterMenuByPersona(SAMPLE, 'household', { visits: 'both', pro: 'both' })
+    const pro = out.find((s) => s.key === 'pro')
+    expect(pro).toBeDefined()
+    expect(pro.children.find((c) => c.key === 'visits')).toBeDefined()
+  })
+
+  it('drops empty sections after children are filtered', () => {
+    const out = filterMenuByPersona(SAMPLE, 'household', {
+      pro: 'both', visits: 'hidden', branding: 'hidden',
+    })
+    expect(out.find((s) => s.key === 'pro')).toBeUndefined()
+  })
+
+  it('items without an entry in overrides fall back to static defaults', () => {
+    const out = filterMenuByPersona(SAMPLE, 'household', { visits: 'household' })
+    // 'today' has no override and no personas → still visible
+    const garden = out.find((s) => s.key === 'garden')
+    expect(garden.children.map((c) => c.key)).toEqual(['today', 'propagation'])
+  })
+})

--- a/src/api/plants.js
+++ b/src/api/plants.js
@@ -306,6 +306,11 @@ export const profileApi = {
   set: (accountType) => request('/profile', { method: 'PUT', body: JSON.stringify({ accountType }) }),
 }
 
+export const featureFlagsApi = {
+  get: () => request('/config/feature-flags'),
+  save: (overrides) => request('/config/feature-flags', { method: 'PUT', body: JSON.stringify({ overrides }) }),
+}
+
 export const householdsApi = {
   list: () => request('/households'),
   current: () => request('/households/current'),

--- a/src/context/ProfileContext.jsx
+++ b/src/context/ProfileContext.jsx
@@ -1,9 +1,10 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
-import { profileApi } from '../api/plants.js'
+import { profileApi, featureFlagsApi } from '../api/plants.js'
 import { useAuth } from '../contexts/AuthContext.jsx'
 
 export const ACCOUNT_TYPES = ['household', 'landscaper', 'both']
 const DEFAULT_ACCOUNT_TYPE = 'household'
+export const FEATURE_FLAG_VALUES = ['household', 'landscaper', 'both', 'hidden']
 
 const ProfileContext = createContext(undefined)
 
@@ -16,28 +17,43 @@ export function useProfile() {
 export function ProfileProvider({ children }) {
   const { isAuthenticated, isGuest } = useAuth()
   const [accountType, setAccountTypeState] = useState(DEFAULT_ACCOUNT_TYPE)
+  const [featureOverrides, setFeatureOverrides] = useState({})
+  const [canEditFeatureFlags, setCanEditFeatureFlags] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 
   const refresh = useCallback(async () => {
     if (!isAuthenticated || isGuest) {
       setAccountTypeState(DEFAULT_ACCOUNT_TYPE)
+      setFeatureOverrides({})
+      setCanEditFeatureFlags(false)
       setLoading(false)
       return
     }
     setLoading(true)
-    try {
-      const data = await profileApi.get()
+    const [profileResult, flagsResult] = await Promise.allSettled([
+      profileApi.get(),
+      featureFlagsApi.get(),
+    ])
+    if (profileResult.status === 'fulfilled') {
+      const data = profileResult.value
       setAccountTypeState(ACCOUNT_TYPES.includes(data?.accountType) ? data.accountType : DEFAULT_ACCOUNT_TYPE)
-      setError(null)
-    } catch (err) {
+    } else {
       // Route may not be live (gateway not yet updated) — degrade to default
       // rather than block the whole app.
       setAccountTypeState(DEFAULT_ACCOUNT_TYPE)
-      setError(err?.message || 'Profile lookup failed')
-    } finally {
-      setLoading(false)
     }
+    if (flagsResult.status === 'fulfilled') {
+      const data = flagsResult.value
+      setFeatureOverrides(data?.overrides && typeof data.overrides === 'object' ? data.overrides : {})
+      setCanEditFeatureFlags(Boolean(data?.canEdit))
+    } else {
+      setFeatureOverrides({})
+      setCanEditFeatureFlags(false)
+    }
+    const firstErr = [profileResult, flagsResult].find((r) => r.status === 'rejected')
+    setError(firstErr ? (firstErr.reason?.message || 'Profile lookup failed') : null)
+    setLoading(false)
   }, [isAuthenticated, isGuest])
 
   useEffect(() => { refresh() }, [refresh])
@@ -60,9 +76,33 @@ export function ProfileProvider({ children }) {
     }
   }, [accountType, isAuthenticated, isGuest])
 
+  const saveFeatureOverrides = useCallback(async (next) => {
+    if (!next || typeof next !== 'object') throw new Error('overrides must be an object')
+    for (const [key, value] of Object.entries(next)) {
+      if (!FEATURE_FLAG_VALUES.includes(value)) {
+        throw new Error(`Unknown feature value for ${key}: ${value}`)
+      }
+    }
+    const prev = featureOverrides
+    setFeatureOverrides(next)
+    try {
+      const data = await featureFlagsApi.save(next)
+      setFeatureOverrides(data?.overrides || next)
+      setError(null)
+    } catch (err) {
+      setFeatureOverrides(prev)
+      setError(err?.message || 'Failed to save feature flags')
+      throw err
+    }
+  }, [featureOverrides])
+
   const value = useMemo(
-    () => ({ accountType, setAccountType, loading, error, refresh }),
-    [accountType, setAccountType, loading, error, refresh],
+    () => ({
+      accountType, setAccountType,
+      featureOverrides, saveFeatureOverrides, canEditFeatureFlags,
+      loading, error, refresh,
+    }),
+    [accountType, setAccountType, featureOverrides, saveFeatureOverrides, canEditFeatureFlags, loading, error, refresh],
   )
 
   return <ProfileContext.Provider value={value}>{children}</ProfileContext.Provider>

--- a/src/layouts/components/Sidebar.jsx
+++ b/src/layouts/components/Sidebar.jsx
@@ -16,7 +16,7 @@ import { buildWaterTasks } from '../../utils/todayTasks.js'
 export default function Sidebar() {
   const { user, logout } = useAuth()
   const { properties, activePropertyId, switchTo } = useProperty()
-  const { accountType } = useProfile()
+  const { accountType, featureOverrides } = useProfile()
   const { navMinified, toggleSetting } = useLayoutContext()
   const { weather, location, plants, floors } = usePlantContext()
   const { open: openHelp } = useHelp()
@@ -30,8 +30,8 @@ export default function Sidebar() {
   )
 
   const visibleMenu = useMemo(
-    () => filterMenuByPersona(menuItems, accountType),
-    [accountType],
+    () => filterMenuByPersona(menuItems, accountType, featureOverrides),
+    [accountType, featureOverrides],
   )
 
   const toggleSidenav = () => {

--- a/src/layouts/components/menuData.js
+++ b/src/layouts/components/menuData.js
@@ -54,9 +54,21 @@ export const menuItems = [
  * Drop sections / children whose `personas` array doesn't include the
  * current accountType. Universal items (no `personas` key) always pass.
  * Empty sections (all children filtered out) are removed.
+ *
+ * `overrides` is an optional map of `{ [item.key]: 'household'|'landscaper'|'both'|'hidden' }`
+ * set by the workspace admin. When present, the override wins over the static
+ * `personas` array; missing keys fall back to the static default.
  */
-export function filterMenuByPersona(items, accountType) {
-  const matches = (item) => !item.personas || item.personas.includes(accountType)
+export function filterMenuByPersona(items, accountType, overrides = {}) {
+  const matches = (item) => {
+    const override = overrides[item.key]
+    if (override) {
+      if (override === 'hidden') return false
+      if (override === 'both') return true
+      return override === accountType
+    }
+    return !item.personas || item.personas.includes(accountType)
+  }
   return items
     .filter(matches)
     .map((section) => {

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -15,6 +15,7 @@ import { accountApi, exportApi, apiKeysApi, brandingApi, imagesApi, householdsAp
 import { useHousehold } from '../context/HouseholdContext.jsx'
 import { useProperty } from '../context/PropertyContext.jsx'
 import { useProfile } from '../context/ProfileContext.jsx'
+import { menuItems } from '../layouts/components/menuData.js'
 
 const TABS = [
   { id: 'property', label: 'Property', icon: 'layers', tags: 'floors zones floorplan rooms upload property' },
@@ -24,6 +25,7 @@ const TABS = [
   { id: 'api-keys', label: 'API Keys', icon: 'key', tags: 'api keys rest integration home assistant automation developer' },
   { id: 'client-properties', label: 'Properties', icon: 'home', tags: 'properties clients landscaper multi-property client management' },
   { id: 'branding', label: 'Branding', icon: 'star', tags: 'branding logo colour color business name landscaper white label report pdf' },
+  { id: 'features', label: 'Features', icon: 'grid', tags: 'features admin menu visibility persona toggle hide show workspace', adminOnly: true },
   { id: 'advanced', label: 'Advanced', icon: 'tool', tags: 'reset onboarding developer version advanced' },
 ]
 
@@ -1518,22 +1520,157 @@ function ClientPropertiesTab({ search }) {
   )
 }
 
+function describeStaticDefault(personas) {
+  if (!personas) return 'Visible to all'
+  const set = new Set(personas)
+  if (set.has('both') || (set.has('household') && set.has('landscaper'))) return 'Visible to all'
+  if (set.has('landscaper')) return 'Landscaper only'
+  if (set.has('household')) return 'Household only'
+  return 'Visible to all'
+}
+
+function flattenMenuForFeatures(items) {
+  const rows = []
+  for (const section of items) {
+    rows.push({ key: section.key, label: section.label, isSection: true, personas: section.personas })
+    for (const child of section.children || []) {
+      rows.push({ key: child.key, label: child.label, isSection: false, personas: child.personas, parentKey: section.key })
+    }
+  }
+  return rows
+}
+
+function FeaturesTab({ search }) {
+  const { featureOverrides, saveFeatureOverrides, canEditFeatureFlags } = useProfile()
+  const [draft, setDraft] = useState(() => ({ ...featureOverrides }))
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [saveError, setSaveError] = useState(null)
+
+  // Reset draft when context overrides change (e.g. after refresh).
+  useEffect(() => { setDraft({ ...featureOverrides }) }, [featureOverrides])
+
+  const rows = useMemo(() => flattenMenuForFeatures(menuItems), [])
+  const dirty = useMemo(() => {
+    const a = featureOverrides
+    const b = draft
+    const keys = new Set([...Object.keys(a), ...Object.keys(b)])
+    for (const k of keys) if (a[k] !== b[k]) return true
+    return false
+  }, [featureOverrides, draft])
+
+  const setRow = (key, value) => {
+    setDraft((prev) => {
+      const next = { ...prev }
+      if (value === '__default__') delete next[key]
+      else next[key] = value
+      return next
+    })
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setSaveError(null)
+    try {
+      await saveFeatureOverrides(draft)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (err) {
+      setSaveError(err?.message || 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleReset = () => setDraft({})
+
+  if (!canEditFeatureFlags) {
+    return (
+      <SettingSection id="features-locked" title="Features" icon="grid" search={search}>
+        <p className="text-muted mb-0">Only the workspace admin (household owner or landscaper manager) can change feature visibility.</p>
+      </SettingSection>
+    )
+  }
+
+  return (
+    <SettingSection id="features" title="Feature visibility" icon="grid" search={search}>
+      <p className="text-muted mb-3">
+        Override which menu items each persona sees. Items left as <em>Default</em> follow the built-in persona rules.
+      </p>
+      <Table hover responsive size="sm" className="mb-3">
+        <thead>
+          <tr>
+            <th>Feature</th>
+            <th style={{ width: 200 }}>Default</th>
+            <th style={{ width: 220 }}>Override</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const value = draft[row.key] || '__default__'
+            return (
+              <tr key={row.key} className={row.isSection ? 'table-active fw-500' : ''}>
+                <td>
+                  {row.isSection ? row.label : (<span className="ps-3">{row.label}</span>)}
+                </td>
+                <td><span className="text-muted small">{describeStaticDefault(row.personas)}</span></td>
+                <td>
+                  <Form.Select
+                    size="sm"
+                    value={value}
+                    onChange={(e) => setRow(row.key, e.target.value)}
+                    aria-label={`Override for ${row.label}`}
+                  >
+                    <option value="__default__">Default</option>
+                    <option value="both">Visible to all</option>
+                    <option value="household">Household only</option>
+                    <option value="landscaper">Landscaper only</option>
+                    <option value="hidden">Hidden</option>
+                  </Form.Select>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </Table>
+      <div className="d-flex align-items-center gap-2">
+        <Button variant="primary" size="sm" onClick={handleSave} disabled={!dirty || saving}>
+          {saving ? 'Saving…' : 'Save changes'}
+        </Button>
+        <Button variant="outline-secondary" size="sm" onClick={handleReset} disabled={saving || Object.keys(draft).length === 0}>
+          Reset to defaults
+        </Button>
+        {saved && <span className="text-success small ms-2">Saved</span>}
+        {saveError && <span className="text-danger small ms-2">{saveError}</span>}
+      </div>
+    </SettingSection>
+  )
+}
+
 const VALID_TABS = TABS.map((t) => t.id)
 
 export default function SettingsPage() {
   const { tab = 'property' } = useParams()
   const [search, setSearch] = useState('')
+  const { canEditFeatureFlags } = useProfile()
 
-  if (!VALID_TABS.includes(tab)) {
-    return <Navigate to="/settings/property" replace />
-  }
+  // Hide admin-only tabs from non-admins.
+  const visibleTabs = useMemo(
+    () => TABS.filter((t) => !t.adminOnly || canEditFeatureFlags),
+    [canEditFeatureFlags],
+  )
+  const visibleTabIds = useMemo(() => visibleTabs.map((t) => t.id), [visibleTabs])
 
   // Which tabs match the current search query (used to badge the tab links)
   const matchingTabs = useMemo(() => {
     if (!search.trim()) return null
     const q = search.toLowerCase()
-    return new Set(TABS.filter((t) => t.tags.includes(q) || t.label.toLowerCase().includes(q)).map((t) => t.id))
-  }, [search])
+    return new Set(visibleTabs.filter((t) => t.tags.includes(q) || t.label.toLowerCase().includes(q)).map((t) => t.id))
+  }, [search, visibleTabs])
+
+  if (!VALID_TABS.includes(tab) || !visibleTabIds.includes(tab)) {
+    return <Navigate to="/settings/property" replace />
+  }
 
   return (
     <div className="content-wrapper">
@@ -1542,7 +1679,7 @@ export default function SettingsPage() {
       {/* Tab bar + search */}
       <div className="d-flex align-items-center gap-3 mb-4 flex-wrap">
         <Nav variant="tabs" className="flex-grow-1" role="tablist">
-          {TABS.map((t) => (
+          {visibleTabs.map((t) => (
             <Nav.Item key={t.id}>
               <Nav.Link
                 as={Link}
@@ -1592,6 +1729,7 @@ export default function SettingsPage() {
         {tab === 'api-keys' && <ApiKeysTab search={search} />}
         {tab === 'client-properties' && <ClientPropertiesTab search={search} />}
         {tab === 'branding' && <BrandingTab search={search} />}
+        {tab === 'features' && <FeaturesTab search={search} />}
         {tab === 'advanced' && <AdvancedTab search={search} />}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- New workspace-scoped feature-flag layer: household owner / landscaper manager can override which menu items each persona sees, on top of the static defaults in `menuData.js`.
- Backend `GET/PUT /config/feature-flags` (PUT gated to admin). Stored at `users/{ownerId}/config/featureFlags`.
- New admin-only **Features** tab in Settings with a toggle table per item (Default / Visible to all / Household only / Landscaper only / Hidden) and a reset-to-defaults button. Tab is hidden from non-admins; deep links redirect.

This is the first slice of the larger "admin role" plan; personal-vs-admin settings split and global-admin UI come later.

## Cross-repo
The two new routes need matching entries in the API Gateway OpenAPI spec in `platform-infra` — a separate plan will follow.

## Test plan
- [x] Backend unit tests cover GET (empty + populated + canEdit for non-owner), PUT (save, replace, missing body, invalid persona, invalid key, 403 for non-owner)
- [x] Menu filter unit tests cover hidden/both/household/landscaper override semantics + back-compat with two-arg call
- [x] Sidebar tests cover override hiding a normally-visible item and override forcing a landscaper-only item visible to a household
- [x] SettingsPage tests cover Features tab visibility (hidden for non-admins, shown for admins), redirect, and save round-trip
- [x] `npm run preflight` (902 passing; one pre-existing flake in `App.test.jsx > displays plants in the list after loading` — already failing on `main`)
- [ ] After API Gateway is updated, smoke test in deployed env: log in as household owner, toggle Branding to Hidden, confirm sidebar updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)