### PR TITLE
fix(billing): gate Manage Subscription on Stripe customer existence

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -683,6 +683,7 @@ app.get('/billing/subscription', requireUser, async (req, res) => {
       cancelAtPeriodEnd: sub?.cancelAtPeriodEnd || false,
       isTrial:           sub?.isTrial || false,
       trialDaysRemaining,
+      hasStripeCustomer: Boolean(sub?.stripeCustomerId),
       quotas: billing.TIERS[tier].quotas,
       usage: {
         plants:           plantsCount,

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -2708,6 +2708,29 @@ describe('Billing routes — dark mode (BILLING_ENABLED unset)', () => {
     expect(res.body.tier).toBe('free');
     expect(res.body.quotas.plants).toBe(10);
     expect(res.body.usage).toEqual({ plants: 0, ai_analyses: 0, photo_storage_mb: 0 });
+    expect(res.body.hasStripeCustomer).toBe(false);
+  });
+
+  it('GET /billing/subscription reports hasStripeCustomer=true when subscription has a customer id', async () => {
+    process.env.BILLING_ENABLED = 'true';
+    store[`users/${USER_SUB}/subscription/current`] = {
+      tier: 'home_pro', status: 'active', stripeCustomerId: 'cus_test_123',
+    };
+    const res = await request(app).get('/billing/subscription').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.hasStripeCustomer).toBe(true);
+  });
+
+  it('GET /billing/subscription reports hasStripeCustomer=false for trial users without a customer id', async () => {
+    process.env.BILLING_ENABLED = 'true';
+    store[`users/${USER_SUB}/subscription/current`] = {
+      tier: 'home_pro', status: 'trialing', isTrial: true, trialEnd: '2099-01-01T00:00:00Z',
+    };
+    const res = await request(app).get('/billing/subscription').set('Authorization', authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.tier).toBe('home_pro');
+    expect(res.body.isTrial).toBe(true);
+    expect(res.body.hasStripeCustomer).toBe(false);
   });
 
   it('POST /billing/create-checkout-session returns 503 when billing disabled', async () => {

--- a/src/__tests__/BillingPage.test.jsx
+++ b/src/__tests__/BillingPage.test.jsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const createCheckoutSession = vi.fn().mockResolvedValue({ url: 'https://checkout.stripe.example/123' })
+const createPortalSession = vi.fn().mockResolvedValue({ url: 'https://portal.stripe.example/abc' })
+
+vi.mock('../api/plants.js', () => ({
+  billingApi: {
+    createCheckoutSession: (...args) => createCheckoutSession(...args),
+    createPortalSession: (...args) => createPortalSession(...args),
+  },
+}))
+
+vi.mock('../components/Toast.jsx', () => ({
+  useToast: () => ({ error: vi.fn(), success: vi.fn() }),
+}))
+
+let snapshot
+vi.mock('../context/SubscriptionContext.jsx', () => ({
+  useSubscription: () => snapshot,
+}))
+
+import BillingPage from '../pages/BillingPage.jsx'
+
+const baseSnapshot = {
+  billingEnabled: true,
+  tier: 'home_pro',
+  status: 'active',
+  currentPeriodEnd: null,
+  cancelAtPeriodEnd: false,
+  isTrial: false,
+  hasStripeCustomer: false,
+  quotas: { plants: 100, ai_analyses: 100, photo_storage_mb: 2048 },
+  usage: { plants: 0, ai_analyses: 0, photo_storage_mb: 0 },
+  refresh: vi.fn(),
+}
+
+beforeEach(() => {
+  snapshot = { ...baseSnapshot }
+  createCheckoutSession.mockClear()
+  createPortalSession.mockClear()
+  // jsdom doesn't implement window.location.assign
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, assign: vi.fn() },
+  })
+})
+
+describe('BillingPage — manage vs add payment method', () => {
+  it('shows "Manage subscription" when the user has a Stripe customer', () => {
+    snapshot.hasStripeCustomer = true
+    render(<MemoryRouter><BillingPage /></MemoryRouter>)
+    expect(screen.getByRole('button', { name: /^Manage subscription$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Add payment method$/i })).toBeNull()
+  })
+
+  it('shows "Add payment method" instead of "Manage subscription" for pro-tier trial users', () => {
+    snapshot.isTrial = true
+    snapshot.status = 'trialing'
+    render(<MemoryRouter><BillingPage /></MemoryRouter>)
+    expect(screen.queryByRole('button', { name: /^Manage subscription$/i })).toBeNull()
+    expect(screen.getByRole('button', { name: /^Add payment method$/i })).toBeInTheDocument()
+    expect(screen.getByText(/free trial/i)).toBeInTheDocument()
+  })
+
+  it('shows the upgrade buttons (not Manage subscription) for free-tier users', () => {
+    snapshot.tier = 'free'
+    snapshot.status = 'free'
+    render(<MemoryRouter><BillingPage /></MemoryRouter>)
+    expect(screen.getByRole('button', { name: /Upgrade to Home Pro/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Manage subscription$/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /^Add payment method$/i })).toBeNull()
+  })
+
+  it('clicking Manage subscription calls createPortalSession', async () => {
+    snapshot.hasStripeCustomer = true
+    render(<MemoryRouter><BillingPage /></MemoryRouter>)
+    fireEvent.click(screen.getByRole('button', { name: /^Manage subscription$/i }))
+    await waitFor(() => expect(createPortalSession).toHaveBeenCalled())
+  })
+
+  it('clicking Add payment method routes through createCheckoutSession for the current tier', async () => {
+    snapshot.isTrial = true
+    snapshot.tier = 'home_pro'
+    render(<MemoryRouter><BillingPage /></MemoryRouter>)
+    fireEvent.click(screen.getByRole('button', { name: /^Add payment method$/i }))
+    await waitFor(() => expect(createCheckoutSession).toHaveBeenCalledWith('home_pro', 'month'))
+  })
+})

--- a/src/context/SubscriptionContext.jsx
+++ b/src/context/SubscriptionContext.jsx
@@ -15,6 +15,7 @@ const DEFAULT_SNAPSHOT = {
   cancelAtPeriodEnd: false,
   isTrial:           false,
   trialDaysRemaining: null,
+  hasStripeCustomer: false,
 }
 
 export const SubscriptionContext = createContext(undefined)

--- a/src/pages/BillingPage.jsx
+++ b/src/pages/BillingPage.jsx
@@ -30,7 +30,7 @@ function Quota({ label, used, limit, unit }) {
 }
 
 export default function BillingPage() {
-  const { billingEnabled, tier, status, currentPeriodEnd, cancelAtPeriodEnd, quotas, usage, refresh } = useSubscription()
+  const { billingEnabled, tier, status, currentPeriodEnd, cancelAtPeriodEnd, hasStripeCustomer, isTrial, quotas, usage, refresh } = useSubscription()
   const toast = useToast()
   const [busy, setBusy] = useState(false)
 
@@ -81,18 +81,28 @@ export default function BillingPage() {
                   {cancelAtPeriodEnd ? 'Ends' : 'Renews'} {new Date(currentPeriodEnd).toLocaleDateString()}
                 </div>
               )}
-              <div className="d-flex gap-2 mt-3">
+              <div className="d-flex gap-2 mt-3 flex-wrap">
                 {tier === 'free' && billingEnabled && (
                   <>
                     <Button variant="primary" onClick={() => upgrade('home_pro')} disabled={busy}>Upgrade to Home Pro</Button>
                     <Button variant="outline-primary" onClick={() => upgrade('landscaper_pro')} disabled={busy}>Landscaper Pro</Button>
                   </>
                 )}
-                {tier !== 'free' && billingEnabled && (
+                {tier !== 'free' && billingEnabled && hasStripeCustomer && (
                   <Button variant="outline-primary" onClick={manage} disabled={busy}>Manage subscription</Button>
+                )}
+                {tier !== 'free' && billingEnabled && !hasStripeCustomer && (
+                  <Button variant="primary" onClick={() => upgrade(tier)} disabled={busy}>Add payment method</Button>
                 )}
                 <Button as={Link} to="/pricing" variant="outline-secondary">See all plans</Button>
               </div>
+              {tier !== 'free' && billingEnabled && !hasStripeCustomer && (
+                <div className="text-muted fs-sm mt-2">
+                  {isTrial
+                    ? 'You\'re on a free trial. Add a payment method to keep your plan active when the trial ends.'
+                    : 'No payment method on file yet. Add one to manage billing through the Stripe portal.'}
+                </div>
+              )}
             </div>
           </div>
         </Col>


### PR DESCRIPTION
## Summary
- Trial users (auto-started for new users in `SubscriptionContext.jsx:44-54`) and gift-code users land on a paid tier without going through Stripe checkout, so they have no `stripeCustomerId`. Clicking "Manage subscription" hit the portal endpoint and got back 404 "No active subscription".
- Backend `GET /billing/subscription` now returns `hasStripeCustomer`.
- `BillingPage` shows "Manage subscription" only when `hasStripeCustomer === true`. Otherwise pro-tier users see "Add payment method", which routes through `createCheckoutSession` for their current tier — Stripe creates the customer as a side effect, and the portal becomes meaningful on subsequent visits.
- Adds `BillingPage.test.jsx` covering both states.

No new gateway routes — uses existing `/billing/subscription` and `/billing/create-checkout-session`.

## Test plan
- [x] Backend: existing `/billing/subscription` test asserts `hasStripeCustomer=false`; two new tests assert true (when stripeCustomerId is set) and false (trial user without customer)
- [x] Frontend: 5 new BillingPage tests covering — Manage shown for paying users, Add payment method shown for trial users, Free tier sees upgrade buttons, both buttons trigger the right API
- [x] `npm run preflight` (906 passing; same pre-existing `App.test.jsx > displays plants in the list after loading` flake as before, unrelated)
- [ ] After deploy: log in as a trial user, visit Settings → Billing, confirm "Add payment method" appears with a "free trial" hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)