### PR TITLE
chore(deploy): force Cloud Function redeploy after Stripe secrets update

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1,11 +1,10 @@
 'use strict';
 
-// chore(deploy): force Cloud Function redeploy 2026-04-29 — production has
-// been stuck on PR #374 since #377's deploy failed at E2E smoke (the
-// onboarding spec wasn't updated for the persona picker). #379 fixed the
-// E2E but only touched e2e/, so paths-filter still skipped deploy-function.
-// This bumps a backend-path file so the next push triggers the deploy and
-// production picks up /profile, /households, and the rest.
+// chore(deploy): force Cloud Function redeploy 2026-04-29 — Stripe secrets
+// in Secret Manager were updated from the placeholder "DISABLED" value to
+// real keys, but the running function instances still had the old value
+// cached. Bumping this comment triggers a fresh deploy so all instances
+// resolve the new secret-version values on cold start.
 const functions = require('@google-cloud/functions-framework');
 const { Firestore } = require('@google-cloud/firestore');
 const { Storage } = require('@google-cloud/storage');


### PR DESCRIPTION
## Summary
Stripe Secret Manager values (`home-plant-tracker-stripe-secret-key` and `home-plant-tracker-stripe-webhook-secret`) were updated from the terraform-provisioned placeholder `"DISABLED"` to real Stripe keys. Existing function instances had the placeholder cached, so calls to Stripe were returning `Invalid API Key provided: DISABLED`.

This bumps a comment in `api/plants/index.js` to trigger the deploy pipeline; the new function revision binds to `:latest` and resolves the real secret values on cold start.

## Test plan
- [x] Empty/comment-only change — existing tests still pass
- [ ] After deploy: log in as trial user, click "Add payment method", confirm we reach Stripe Checkout (no longer the DISABLED error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)