### PR TITLE
chore(deploy): force redeploy with real Stripe keys (take 2)

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -1,10 +1,11 @@
 'use strict';
 
-// chore(deploy): force Cloud Function redeploy 2026-04-29 — Stripe secrets
-// in Secret Manager were updated from the placeholder "DISABLED" value to
-// real keys, but the running function instances still had the old value
-// cached. Bumping this comment triggers a fresh deploy so all instances
-// resolve the new secret-version values on cold start.
+// chore(deploy): force Cloud Function redeploy 2026-04-29 (take 2) — the
+// first redeploy bumped instances after the wrong secret name was updated;
+// the function actually binds to the legacy `plant-tracker-stripe-*` names,
+// not the `home-plant-tracker-*` ones terraform manages. Real keys are now
+// in the legacy secrets; this bump rolls the function so warm instances
+// pick up the new :latest values.
 const functions = require('@google-cloud/functions-framework');
 const { Firestore } = require('@google-cloud/firestore');
 const { Storage } = require('@google-cloud/storage');


### PR DESCRIPTION
## Summary
First redeploy in #383 ran while the legacy `plant-tracker-stripe-*` secrets still had the placeholder `DISABLED` (only the `home-plant-tracker-*` terraform-managed secrets had been updated, which the function doesn't actually bind to — terraform drift, see below). Real `sk_test_...` + `whsec_...` are now in the legacy secrets; this bump rolls warm instances so they read `:latest`.

**Drift to fix later:** function binds to `plant-tracker-stripe-secret-key` / `plant-tracker-stripe-webhook-secret` (legacy, no `home-` prefix), but terraform `billing.tf` provisions `home-plant-tracker-stripe-*`. Tidy-up plan to follow.

## Test plan
- [x] Comment-only — existing tests untouched
- [ ] Post-deploy: hit `/billing/create-portal-session` (or click "Add payment method") and confirm we no longer see `Invalid API Key provided: DISABLED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)