### PR TITLE
feat(admin): split Features, API Keys, and Advanced into a dedicated Admin page

### DIFF
--- a/src/__tests__/AdminPage.test.jsx
+++ b/src/__tests__/AdminPage.test.jsx
@@ -1,0 +1,203 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const setAccountTypeMock = vi.fn().mockResolvedValue(undefined)
+const saveFeatureOverridesMock = vi.fn().mockResolvedValue(undefined)
+let profileCanEdit = true
+let profileLoading = false
+let profileFeatureOverrides = {}
+
+vi.mock('../context/ProfileContext.jsx', () => ({
+  useProfile: () => ({
+    accountType: 'household',
+    setAccountType: setAccountTypeMock,
+    featureOverrides: profileFeatureOverrides,
+    saveFeatureOverrides: saveFeatureOverridesMock,
+    canEditFeatureFlags: profileCanEdit,
+    loading: profileLoading,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}))
+
+vi.mock('../contexts/AuthContext.jsx', () => ({
+  useAuth: () => ({ isGuest: false, logout: vi.fn() }),
+}))
+
+vi.mock('../api/plants.js', () => ({
+  apiKeysApi: {
+    list: vi.fn().mockResolvedValue({ keys: [] }),
+    create: vi.fn(),
+    revoke: vi.fn(),
+  },
+}))
+
+import AdminPage from '../pages/AdminPage.jsx'
+import { apiKeysApi } from '../api/plants.js'
+
+function renderAt(path) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/admin/:tab" element={<AdminPage />} />
+        <Route path="/admin" element={<AdminPage />} />
+        <Route path="/settings/:tab" element={<div data-testid="settings-stub" />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('AdminPage routing & gating', () => {
+  beforeEach(() => {
+    profileCanEdit = true
+    profileLoading = false
+    profileFeatureOverrides = {}
+  })
+
+  it('renders the Admin heading', () => {
+    renderAt('/admin/features')
+    expect(screen.getByRole('heading', { name: /^Admin$/i })).toBeInTheDocument()
+  })
+
+  it('renders the three tabs in navigation', () => {
+    const { container } = renderAt('/admin/features')
+    const labels = Array.from(container.querySelectorAll('.nav-link')).map((el) =>
+      el.textContent.trim().toLowerCase(),
+    )
+    expect(labels.some((l) => l.includes('features'))).toBe(true)
+    expect(labels.some((l) => l.includes('api keys'))).toBe(true)
+    expect(labels.some((l) => l.includes('advanced'))).toBe(true)
+  })
+
+  it('redirects /admin (no tab) to /admin/features by default', () => {
+    renderAt('/admin')
+    // Default features tab content
+    expect(screen.getByText(/Feature visibility/i)).toBeInTheDocument()
+  })
+
+  it('redirects unknown tab to default features tab', () => {
+    renderAt('/admin/nonsense')
+    expect(screen.getByText(/Feature visibility/i)).toBeInTheDocument()
+  })
+
+  it('redirects non-admins to /settings/property', () => {
+    profileCanEdit = false
+    renderAt('/admin/features')
+    expect(screen.getByTestId('settings-stub')).toBeInTheDocument()
+  })
+
+  it('does not redirect while profile is still loading', () => {
+    profileCanEdit = false
+    profileLoading = true
+    renderAt('/admin/features')
+    // Renders the page (we can't decide yet)
+    expect(screen.getByRole('heading', { name: /^Admin$/i })).toBeInTheDocument()
+  })
+})
+
+describe('AdminPage Features tab', () => {
+  beforeEach(() => {
+    profileCanEdit = true
+    profileFeatureOverrides = {}
+    saveFeatureOverridesMock.mockClear()
+  })
+
+  it('renders the feature toggle table for admins', () => {
+    renderAt('/admin/features')
+    expect(screen.getByText(/Feature visibility/i)).toBeInTheDocument()
+    const selects = screen.getAllByRole('combobox')
+    expect(selects.length).toBeGreaterThan(0)
+  })
+
+  it('saves overrides via saveFeatureOverrides', async () => {
+    renderAt('/admin/features')
+    const branding = screen.getByLabelText(/Override for Branding/i)
+    fireEvent.change(branding, { target: { value: 'household' } })
+    fireEvent.click(screen.getByRole('button', { name: /Save changes/i }))
+    await waitFor(() =>
+      expect(saveFeatureOverridesMock).toHaveBeenCalledWith(
+        expect.objectContaining({ branding: 'household' }),
+      ),
+    )
+  })
+})
+
+describe('AdminPage API Keys tab', () => {
+  beforeEach(() => {
+    profileCanEdit = true
+    vi.clearAllMocks()
+    apiKeysApi.list.mockResolvedValue({ keys: [] })
+  })
+
+  it('renders the Public REST API section', async () => {
+    renderAt('/admin/api-keys')
+    await waitFor(() => expect(screen.getByText(/Public REST API/)).toBeInTheDocument())
+  })
+
+  it('shows no-keys message when list is empty', async () => {
+    renderAt('/admin/api-keys')
+    await waitFor(() => expect(screen.getByTestId('no-keys-message')).toBeInTheDocument())
+  })
+
+  it('displays existing active keys in the table', async () => {
+    apiKeysApi.list.mockResolvedValue({
+      keys: [
+        {
+          id: 'k1',
+          name: 'Home Assistant',
+          key: 'pt_live_hass...',
+          prefix: 'pt_live_hass',
+          createdAt: '2026-04-01T00:00:00Z',
+          lastUsedAt: null,
+          revokedAt: null,
+        },
+      ],
+    })
+    renderAt('/admin/api-keys')
+    await waitFor(() => expect(screen.getByTestId('api-keys-table')).toBeInTheDocument())
+    expect(screen.getByText('Home Assistant')).toBeInTheDocument()
+  })
+
+  it('creates a key with the entered name and shows the new-key banner', async () => {
+    apiKeysApi.create.mockResolvedValue({
+      id: 'new-k',
+      key: 'pt_live_secret123',
+      name: 'My App',
+      prefix: 'pt_live_secr',
+      createdAt: '2026-04-23T00:00:00Z',
+    })
+    renderAt('/admin/api-keys')
+    await waitFor(() => expect(screen.getByTestId('new-key-name-input')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('new-key-name-input'), { target: { value: 'My App' } })
+    fireEvent.click(screen.getByTestId('create-key-btn'))
+    await waitFor(() => expect(apiKeysApi.create).toHaveBeenCalledWith('My App'))
+    await waitFor(() => expect(screen.getByTestId('new-key-banner')).toBeInTheDocument())
+    expect(screen.getByTestId('new-key-value')).toHaveTextContent('pt_live_secret123')
+  })
+
+  it('revokes a key and removes it from the list', async () => {
+    apiKeysApi.list.mockResolvedValue({
+      keys: [{ id: 'k1', name: 'HA', key: 'pt_live_ha...', prefix: 'pt_live_ha', createdAt: '2026-04-01T00:00:00Z', lastUsedAt: null }],
+    })
+    apiKeysApi.revoke.mockResolvedValue({ revoked: true })
+    renderAt('/admin/api-keys')
+    await waitFor(() => expect(screen.getByTestId('revoke-key-k1')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('revoke-key-k1'))
+    await waitFor(() => expect(apiKeysApi.revoke).toHaveBeenCalledWith('k1'))
+    await waitFor(() => expect(screen.queryByTestId('revoke-key-k1')).not.toBeInTheDocument())
+  })
+})
+
+describe('AdminPage Advanced tab', () => {
+  beforeEach(() => {
+    profileCanEdit = true
+  })
+
+  it('shows the About / version section at /admin/advanced', () => {
+    renderAt('/admin/advanced')
+    expect(screen.getByText(/^About$/i)).toBeInTheDocument()
+    expect(screen.getByText(/0\.0\.0-test/i)).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/SettingsPage.test.jsx
+++ b/src/__tests__/SettingsPage.test.jsx
@@ -88,7 +88,7 @@ vi.mock('../components/LeafletFloorplan.jsx', () => ({
 }))
 
 import SettingsPage from '../pages/SettingsPage.jsx'
-import { accountApi, apiKeysApi, brandingApi, imagesApi } from '../api/plants.js'
+import { accountApi, brandingApi, imagesApi } from '../api/plants.js'
 
 function renderAt(path) {
   return render(
@@ -134,11 +134,16 @@ describe('SettingsPage tabs', () => {
     expect(screen.getByText(/Delete account/i)).toBeInTheDocument()
   })
 
-  it('shows the Advanced tab content at /settings/advanced', () => {
-    renderAt('/settings/advanced')
-    expect(screen.getByText(/About/i)).toBeInTheDocument()
-    // Version string from mocked constant
-    expect(screen.getByText(/0\.0\.0-test/i)).toBeInTheDocument()
+  it('redirects legacy admin tabs (advanced/api-keys/features) to /admin', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/settings/advanced']}>
+        <Routes>
+          <Route path="/settings/:tab" element={<SettingsPage />} />
+          <Route path="/admin/:tab" element={<div data-testid="admin-stub" />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    expect(container.querySelector('[data-testid="admin-stub"]')).not.toBeNull()
   })
 
   it('renders navigation tabs for Property and Preferences', () => {
@@ -342,93 +347,6 @@ describe('SettingsPage Data tab', () => {
   })
 })
 
-describe('SettingsPage API Keys tab', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    apiKeysApi.list.mockResolvedValue({ keys: [] })
-  })
-
-  it('shows the API Keys tab in navigation', () => {
-    renderAt('/settings/api-keys')
-    expect(screen.getByText('API Keys')).toBeInTheDocument()
-  })
-
-  it('renders the Public REST API section', async () => {
-    renderAt('/settings/api-keys')
-    await waitFor(() => expect(screen.getByText(/Public REST API/)).toBeInTheDocument())
-  })
-
-  it('shows no-keys message when list is empty', async () => {
-    renderAt('/settings/api-keys')
-    await waitFor(() => expect(screen.getByTestId('no-keys-message')).toBeInTheDocument())
-    expect(screen.getByText(/No API keys yet/)).toBeInTheDocument()
-  })
-
-  it('displays existing active keys in table', async () => {
-    apiKeysApi.list.mockResolvedValue({
-      keys: [
-        { id: 'k1', name: 'Home Assistant', key: 'pt_live_hass...', prefix: 'pt_live_hass', createdAt: '2026-04-01T00:00:00Z', lastUsedAt: null, revokedAt: null },
-      ],
-    })
-    renderAt('/settings/api-keys')
-    await waitFor(() => expect(screen.getByTestId('api-keys-table')).toBeInTheDocument())
-    expect(screen.getByText('Home Assistant')).toBeInTheDocument()
-    expect(screen.getByText('pt_live_hass...')).toBeInTheDocument()
-  })
-
-  it('shows create key button and name input', async () => {
-    renderAt('/settings/api-keys')
-    await waitFor(() => expect(screen.getByTestId('create-key-btn')).toBeInTheDocument())
-    expect(screen.getByTestId('new-key-name-input')).toBeInTheDocument()
-  })
-
-  it('create key button is disabled when name input is empty', async () => {
-    renderAt('/settings/api-keys')
-    await waitFor(() => expect(screen.getByTestId('create-key-btn')).toBeDisabled())
-  })
-
-  it('calls apiKeysApi.create with the entered name', async () => {
-    apiKeysApi.create.mockResolvedValue({ id: 'new-k', key: 'pt_live_newkeyxxx', name: 'My App', prefix: 'pt_live_newk', createdAt: '2026-04-23T00:00:00Z' })
-    renderAt('/settings/api-keys')
-    await waitFor(() => expect(screen.getByTestId('new-key-name-input')).toBeInTheDocument())
-    fireEvent.change(screen.getByTestId('new-key-name-input'), { target: { value: 'My App' } })
-    fireEvent.click(screen.getByTestId('create-key-btn'))
-    await waitFor(() => expect(apiKeysApi.create).toHaveBeenCalledWith('My App'))
-  })
-
-  it('shows the new plaintext key banner after creation', async () => {
-    apiKeysApi.create.mockResolvedValue({ id: 'new-k', key: 'pt_live_secret123', name: 'My App', prefix: 'pt_live_secr', createdAt: '2026-04-23T00:00:00Z' })
-    renderAt('/settings/api-keys')
-    await waitFor(() => expect(screen.getByTestId('new-key-name-input')).toBeInTheDocument())
-    fireEvent.change(screen.getByTestId('new-key-name-input'), { target: { value: 'My App' } })
-    fireEvent.click(screen.getByTestId('create-key-btn'))
-    await waitFor(() => expect(screen.getByTestId('new-key-banner')).toBeInTheDocument())
-    expect(screen.getByTestId('new-key-value')).toHaveTextContent('pt_live_secret123')
-  })
-
-  it('shows revoke button for each key and calls apiKeysApi.revoke', async () => {
-    apiKeysApi.list.mockResolvedValue({
-      keys: [{ id: 'k1', name: 'HA', key: 'pt_live_ha...', prefix: 'pt_live_ha', createdAt: '2026-04-01T00:00:00Z', lastUsedAt: null }],
-    })
-    apiKeysApi.revoke.mockResolvedValue({ revoked: true })
-    renderAt('/settings/api-keys')
-    await waitFor(() => expect(screen.getByTestId('revoke-key-k1')).toBeInTheDocument())
-    fireEvent.click(screen.getByTestId('revoke-key-k1'))
-    await waitFor(() => expect(apiKeysApi.revoke).toHaveBeenCalledWith('k1'))
-  })
-
-  it('removes key from list after successful revoke', async () => {
-    apiKeysApi.list.mockResolvedValue({
-      keys: [{ id: 'k1', name: 'HA', key: 'pt_live_ha...', prefix: 'pt_live_ha', createdAt: '2026-04-01T00:00:00Z', lastUsedAt: null }],
-    })
-    apiKeysApi.revoke.mockResolvedValue({ revoked: true })
-    renderAt('/settings/api-keys')
-    await waitFor(() => expect(screen.getByTestId('revoke-key-k1')).toBeInTheDocument())
-    fireEvent.click(screen.getByTestId('revoke-key-k1'))
-    await waitFor(() => expect(screen.queryByTestId('revoke-key-k1')).not.toBeInTheDocument())
-  })
-})
-
 describe('SettingsPage Branding tab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -508,56 +426,6 @@ describe('SettingsPage Branding tab', () => {
     fireEvent.change(screen.getByTestId('branding-logo-input'), { target: { files: [file] } })
     await waitFor(() => expect(imagesApi.upload).toHaveBeenCalledWith(file, 'branding'))
     await waitFor(() => expect(brandingApi.save).toHaveBeenCalledWith({ logoUrl: 'https://storage.example.com/branding/logo.png' }))
-  })
-})
-
-describe('SettingsPage Features tab (admin only)', () => {
-  beforeEach(() => {
-    saveFeatureOverridesMock.mockClear()
-    profileFeatureOverrides = {}
-  })
-
-  function tabLabels(container) {
-    return Array.from(container.querySelectorAll('.nav-link')).map((el) => el.textContent.trim().toLowerCase())
-  }
-
-  it('hides the Features tab from non-admins', () => {
-    profileCanEdit = false
-    const { container } = renderAt('/settings/property')
-    expect(tabLabels(container).some((l) => l.includes('features'))).toBe(false)
-  })
-
-  it('redirects non-admins away from /settings/features', () => {
-    profileCanEdit = false
-    renderAt('/settings/features')
-    // Falls back to the Property tab content
-    expect(screen.getByText(/Floors & Zones/i)).toBeInTheDocument()
-  })
-
-  it('shows the Features tab to admins', () => {
-    profileCanEdit = true
-    const { container } = renderAt('/settings/property')
-    expect(tabLabels(container).some((l) => l.includes('features'))).toBe(true)
-  })
-
-  it('renders the feature toggle table at /settings/features for admins', () => {
-    profileCanEdit = true
-    renderAt('/settings/features')
-    expect(screen.getByText(/Feature visibility/i)).toBeInTheDocument()
-    // Each menu item should have an override <select> with our four options + Default
-    const selects = screen.getAllByRole('combobox')
-    expect(selects.length).toBeGreaterThan(0)
-  })
-
-  it('saves overrides via saveFeatureOverrides', async () => {
-    profileCanEdit = true
-    renderAt('/settings/features')
-    const branding = screen.getByLabelText(/Override for Branding/i)
-    fireEvent.change(branding, { target: { value: 'household' } })
-    fireEvent.click(screen.getByRole('button', { name: /Save changes/i }))
-    await waitFor(() =>
-      expect(saveFeatureOverridesMock).toHaveBeenCalledWith(expect.objectContaining({ branding: 'household' })),
-    )
   })
 })
 

--- a/src/__tests__/Sidebar.test.jsx
+++ b/src/__tests__/Sidebar.test.jsx
@@ -33,8 +33,13 @@ vi.mock('../context/PropertyContext.jsx', () => ({
 }))
 let profileAccountType = 'household'
 let profileFeatureOverrides = {}
+let profileCanEditFeatureFlags = false
 vi.mock('../context/ProfileContext.jsx', () => ({
-  useProfile: () => ({ accountType: profileAccountType, featureOverrides: profileFeatureOverrides }),
+  useProfile: () => ({
+    accountType: profileAccountType,
+    featureOverrides: profileFeatureOverrides,
+    canEditFeatureFlags: profileCanEditFeatureFlags,
+  }),
 }))
 
 import Sidebar from '../layouts/components/Sidebar.jsx'
@@ -114,5 +119,26 @@ describe('Sidebar feature-flag overrides', () => {
 
   afterEach(() => {
     profileFeatureOverrides = {}
+  })
+})
+
+describe('Sidebar admin section', () => {
+  afterEach(() => {
+    profileCanEditFeatureFlags = false
+  })
+
+  it('hides the Admin section from non-admins', () => {
+    profileCanEditFeatureFlags = false
+    render(<MemoryRouter><Sidebar /></MemoryRouter>)
+    expect(screen.queryByRole('link', { name: /^Features$/i })).toBeNull()
+    expect(screen.queryByRole('link', { name: /API Keys/i })).toBeNull()
+  })
+
+  it('shows Admin links to admins', () => {
+    profileCanEditFeatureFlags = true
+    render(<MemoryRouter><Sidebar /></MemoryRouter>)
+    expect(screen.getByRole('link', { name: /^Features$/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /API Keys/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /^Advanced$/i })).toBeInTheDocument()
   })
 })

--- a/src/components/SettingSection.jsx
+++ b/src/components/SettingSection.jsx
@@ -1,0 +1,24 @@
+import HelpTooltip from './HelpTooltip.jsx'
+
+export default function SettingSection({ id, title, icon, search, helpArticle, children }) {
+  const visible = !search || title.toLowerCase().includes(search.toLowerCase())
+  if (!visible) return null
+  return (
+    <div id={`settings-section-${id}`} className="mb-4">
+      <div className="panel panel-icon">
+        <div className="panel-hdr">
+          <span className="d-flex align-items-center gap-1">
+            {icon && (
+              <svg className="sa-icon me-2" aria-hidden="true"><use href={`/icons/sprite.svg#${icon}`}></use></svg>
+            )}
+            {title}
+            {helpArticle && <HelpTooltip articleId={helpArticle} label={`Help: ${title}`} />}
+          </span>
+        </div>
+        <div className="panel-container"><div className="panel-content">
+          {children}
+        </div></div>
+      </div>
+    </div>
+  )
+}

--- a/src/layouts/components/Sidebar.jsx
+++ b/src/layouts/components/Sidebar.jsx
@@ -16,7 +16,7 @@ import { buildWaterTasks } from '../../utils/todayTasks.js'
 export default function Sidebar() {
   const { user, logout } = useAuth()
   const { properties, activePropertyId, switchTo } = useProperty()
-  const { accountType, featureOverrides } = useProfile()
+  const { accountType, featureOverrides, canEditFeatureFlags } = useProfile()
   const { navMinified, toggleSetting } = useLayoutContext()
   const { weather, location, plants, floors } = usePlantContext()
   const { open: openHelp } = useHelp()
@@ -29,10 +29,24 @@ export default function Sidebar() {
     [plants, weather, floors],
   )
 
-  const visibleMenu = useMemo(
-    () => filterMenuByPersona(menuItems, accountType, featureOverrides),
-    [accountType, featureOverrides],
-  )
+  const visibleMenu = useMemo(() => {
+    const filtered = filterMenuByPersona(menuItems, accountType, featureOverrides)
+    if (!canEditFeatureFlags) return filtered
+    return [
+      ...filtered,
+      {
+        key: 'admin',
+        label: 'Admin',
+        isSection: true,
+        collapsible: true,
+        children: [
+          { key: 'admin-features', label: 'Features', icon: '/icons/sprite.svg#grid', url: '/admin/features' },
+          { key: 'admin-api-keys', label: 'API Keys', icon: '/icons/sprite.svg#key', url: '/admin/api-keys' },
+          { key: 'admin-advanced', label: 'Advanced', icon: '/icons/sprite.svg#tool', url: '/admin/advanced' },
+        ],
+      },
+    ]
+  }, [accountType, featureOverrides, canEditFeatureFlags])
 
   const toggleSidenav = () => {
     toggleSetting('navMinified', !navMinified)

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -1,0 +1,383 @@
+import { useState, useCallback, useMemo, useEffect } from 'react'
+import { Link, useParams, Navigate } from 'react-router'
+import { Button, Form, Table, Badge, Nav, InputGroup, FormControl } from 'react-bootstrap'
+import { useAuth } from '../contexts/AuthContext.jsx'
+import { useProfile } from '../context/ProfileContext.jsx'
+import { apiKeysApi } from '../api/plants.js'
+import { menuItems } from '../layouts/components/menuData.js'
+import SettingSection from '../components/SettingSection.jsx'
+
+const TABS = [
+  { id: 'features', label: 'Features', icon: 'grid', tags: 'features admin menu visibility persona toggle hide show workspace' },
+  { id: 'api-keys', label: 'API Keys', icon: 'key', tags: 'api keys rest integration home assistant automation developer' },
+  { id: 'advanced', label: 'Advanced', icon: 'tool', tags: 'reset onboarding developer version advanced about' },
+]
+const VALID_TABS = TABS.map((t) => t.id)
+const DEFAULT_TAB = 'features'
+
+function describeStaticDefault(personas) {
+  if (!personas) return 'Visible to all'
+  const set = new Set(personas)
+  if (set.has('both') || (set.has('household') && set.has('landscaper'))) return 'Visible to all'
+  if (set.has('landscaper')) return 'Landscaper only'
+  if (set.has('household')) return 'Household only'
+  return 'Visible to all'
+}
+
+function flattenMenuForFeatures(items) {
+  const rows = []
+  for (const section of items) {
+    rows.push({ key: section.key, label: section.label, isSection: true, personas: section.personas })
+    for (const child of section.children || []) {
+      rows.push({ key: child.key, label: child.label, isSection: false, personas: child.personas, parentKey: section.key })
+    }
+  }
+  return rows
+}
+
+function FeaturesTab({ search }) {
+  const { featureOverrides, saveFeatureOverrides, canEditFeatureFlags } = useProfile()
+  const [draft, setDraft] = useState(() => ({ ...featureOverrides }))
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [saveError, setSaveError] = useState(null)
+
+  useEffect(() => { setDraft({ ...featureOverrides }) }, [featureOverrides])
+
+  const rows = useMemo(() => flattenMenuForFeatures(menuItems), [])
+  const dirty = useMemo(() => {
+    const a = featureOverrides
+    const b = draft
+    const keys = new Set([...Object.keys(a), ...Object.keys(b)])
+    for (const k of keys) if (a[k] !== b[k]) return true
+    return false
+  }, [featureOverrides, draft])
+
+  const setRow = (key, value) => {
+    setDraft((prev) => {
+      const next = { ...prev }
+      if (value === '__default__') delete next[key]
+      else next[key] = value
+      return next
+    })
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setSaveError(null)
+    try {
+      await saveFeatureOverrides(draft)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (err) {
+      setSaveError(err?.message || 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleReset = () => setDraft({})
+
+  if (!canEditFeatureFlags) {
+    return (
+      <SettingSection id="features-locked" title="Features" icon="grid" search={search}>
+        <p className="text-muted mb-0">Only the workspace admin (household owner or landscaper manager) can change feature visibility.</p>
+      </SettingSection>
+    )
+  }
+
+  return (
+    <SettingSection id="features" title="Feature visibility" icon="grid" search={search}>
+      <p className="text-muted mb-3">
+        Override which menu items each persona sees. Items left as <em>Default</em> follow the built-in persona rules.
+      </p>
+      <Table hover responsive size="sm" className="mb-3">
+        <thead>
+          <tr>
+            <th>Feature</th>
+            <th style={{ width: 200 }}>Default</th>
+            <th style={{ width: 220 }}>Override</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const value = draft[row.key] || '__default__'
+            return (
+              <tr key={row.key} className={row.isSection ? 'table-active fw-500' : ''}>
+                <td>
+                  {row.isSection ? row.label : (<span className="ps-3">{row.label}</span>)}
+                </td>
+                <td><span className="text-muted small">{describeStaticDefault(row.personas)}</span></td>
+                <td>
+                  <Form.Select
+                    size="sm"
+                    value={value}
+                    onChange={(e) => setRow(row.key, e.target.value)}
+                    aria-label={`Override for ${row.label}`}
+                  >
+                    <option value="__default__">Default</option>
+                    <option value="both">Visible to all</option>
+                    <option value="household">Household only</option>
+                    <option value="landscaper">Landscaper only</option>
+                    <option value="hidden">Hidden</option>
+                  </Form.Select>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </Table>
+      <div className="d-flex align-items-center gap-2">
+        <Button variant="primary" size="sm" onClick={handleSave} disabled={!dirty || saving}>
+          {saving ? 'Saving…' : 'Save changes'}
+        </Button>
+        <Button variant="outline-secondary" size="sm" onClick={handleReset} disabled={saving || Object.keys(draft).length === 0}>
+          Reset to defaults
+        </Button>
+        {saved && <span className="text-success small ms-2">Saved</span>}
+        {saveError && <span className="text-danger small ms-2">{saveError}</span>}
+      </div>
+    </SettingSection>
+  )
+}
+
+function ApiKeysTab({ search }) {
+  const { isGuest } = useAuth()
+  const [keys, setKeys] = useState([])
+  const [loading, setLoading] = useState(!isGuest)
+  const [error, setError] = useState(null)
+  const [creating, setCreating] = useState(false)
+  const [newKeyName, setNewKeyName] = useState('')
+  const [newKeyValue, setNewKeyValue] = useState(null)
+  const [revoking, setRevoking] = useState(null)
+
+  const loadKeys = useCallback(async () => {
+    try {
+      setLoading(true)
+      const { keys: list } = await apiKeysApi.list()
+      setKeys(list)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { if (!isGuest) loadKeys() }, [loadKeys, isGuest])
+
+  const handleCreate = async () => {
+    if (!newKeyName.trim()) return
+    setCreating(true)
+    setError(null)
+    try {
+      const result = await apiKeysApi.create(newKeyName.trim())
+      setNewKeyValue(result.key)
+      setNewKeyName('')
+      await loadKeys()
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleRevoke = async (id) => {
+    setRevoking(id)
+    setError(null)
+    try {
+      await apiKeysApi.revoke(id)
+      setKeys((prev) => prev.filter((k) => k.id !== id))
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setRevoking(null)
+    }
+  }
+
+  return (
+    <>
+      <SettingSection id="api-keys-intro" title="Public REST API" icon="key" search={search}>
+        <p className="text-muted fs-sm mb-3">
+          Use API keys to integrate your plant data with external tools — Home Assistant, custom dashboards, and smart irrigation systems.
+          API keys are available on <strong>Home Pro</strong> and <strong>Landscaper Pro</strong> plans. Each key is shown <strong>once</strong> at creation.
+        </p>
+        <div className="alert alert-info py-2 fs-sm mb-0">
+          <strong>Base URL:</strong> <code>{import.meta.env.VITE_API_BASE_URL || 'https://api.plants.lopezcloud.dev'}/api/v1</code>
+          {' · '}
+          Pass the key as <code>x-plant-api-key: pt_live_...</code>
+        </div>
+      </SettingSection>
+
+      <SettingSection id="api-keys-manage" title="Your API Keys" icon="shield" search={search}>
+        {error && <div className="alert alert-danger py-2 mb-3" data-testid="api-key-error">{error}</div>}
+
+        {newKeyValue && (
+          <div className="alert alert-success mb-3" data-testid="new-key-banner">
+            <strong>Copy your new API key — it won&apos;t be shown again:</strong>
+            <div className="d-flex align-items-center gap-2 mt-2">
+              <code className="flex-grow-1 text-break" data-testid="new-key-value">{newKeyValue}</code>
+              <Button size="sm" variant="outline-success" onClick={() => { navigator.clipboard?.writeText(newKeyValue); }}>
+                Copy
+              </Button>
+            </div>
+            <Button size="sm" variant="link" className="p-0 mt-1 text-muted" onClick={() => setNewKeyValue(null)}>Dismiss</Button>
+          </div>
+        )}
+
+        {loading ? (
+          <p className="text-muted fs-sm">Loading…</p>
+        ) : keys.length === 0 ? (
+          <p className="text-muted fs-sm mb-3" data-testid="no-keys-message">No API keys yet. Create one below.</p>
+        ) : (
+          <Table size="sm" className="mb-3" data-testid="api-keys-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Key</th>
+                <th>Created</th>
+                <th>Last used</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => (
+                <tr key={k.id}>
+                  <td>{k.name}</td>
+                  <td><code>{k.key}</code></td>
+                  <td className="text-muted fs-xs">{new Date(k.createdAt).toLocaleDateString()}</td>
+                  <td className="text-muted fs-xs">{k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleDateString() : 'Never'}</td>
+                  <td>
+                    <Button
+                      variant="outline-danger"
+                      size="sm"
+                      onClick={() => handleRevoke(k.id)}
+                      disabled={revoking === k.id}
+                      data-testid={`revoke-key-${k.id}`}
+                    >
+                      {revoking === k.id ? 'Revoking…' : 'Revoke'}
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+
+        {keys.length < 3 && (
+          <div className="d-flex gap-2 align-items-end">
+            <Form.Group controlId="new-key-name" className="flex-grow-1">
+              <Form.Label className="fs-sm fw-500 mb-1">New key name</Form.Label>
+              <Form.Control
+                size="sm"
+                placeholder="e.g. Home Assistant"
+                value={newKeyName}
+                onChange={(e) => setNewKeyName(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+                maxLength={64}
+                data-testid="new-key-name-input"
+              />
+            </Form.Group>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleCreate}
+              disabled={creating || !newKeyName.trim()}
+              data-testid="create-key-btn"
+            >
+              {creating ? 'Creating…' : 'Create key'}
+            </Button>
+          </div>
+        )}
+        {keys.length >= 3 && (
+          <p className="text-muted fs-xs mb-0">Maximum of 3 active API keys reached. Revoke one to create a new key.</p>
+        )}
+      </SettingSection>
+    </>
+  )
+}
+
+function AdvancedTab({ search }) {
+  return (
+    <SettingSection id="version" title="About" icon="info" search={search}>
+      <p className="text-muted fs-sm mb-0">
+        Version: {__APP_VERSION__} &middot; Built: {new Date(__BUILD_TIME__).toLocaleString()}
+      </p>
+    </SettingSection>
+  )
+}
+
+export default function AdminPage() {
+  const { tab = DEFAULT_TAB } = useParams()
+  const [search, setSearch] = useState('')
+  const { canEditFeatureFlags, loading } = useProfile()
+
+  const matchingTabs = useMemo(() => {
+    if (!search.trim()) return null
+    const q = search.toLowerCase()
+    return new Set(TABS.filter((t) => t.tags.includes(q) || t.label.toLowerCase().includes(q)).map((t) => t.id))
+  }, [search])
+
+  if (!loading && !canEditFeatureFlags) {
+    return <Navigate to="/settings/property" replace />
+  }
+
+  if (!VALID_TABS.includes(tab)) {
+    return <Navigate to={`/admin/${DEFAULT_TAB}`} replace />
+  }
+
+  return (
+    <div className="content-wrapper">
+      <h1 className="subheader-title mb-3">Admin</h1>
+
+      <div className="d-flex align-items-center gap-3 mb-4 flex-wrap">
+        <Nav variant="tabs" className="flex-grow-1" role="tablist">
+          {TABS.map((t) => (
+            <Nav.Item key={t.id}>
+              <Nav.Link
+                as={Link}
+                to={`/admin/${t.id}`}
+                active={tab === t.id}
+                className="d-flex align-items-center gap-1"
+                aria-current={tab === t.id ? 'page' : undefined}
+              >
+                <svg className="sa-icon" style={{ width: 14, height: 14 }} aria-hidden="true">
+                  <use href={`/icons/sprite.svg#${t.icon}`}></use>
+                </svg>
+                <span className="d-none d-sm-inline">{t.label}</span>
+                <span className="d-inline d-sm-none">{t.label.split(' ')[0]}</span>
+                {matchingTabs?.has(t.id) && (
+                  <Badge bg="primary" pill className="ms-1" style={{ fontSize: '0.6rem' }}>
+                    match
+                  </Badge>
+                )}
+              </Nav.Link>
+            </Nav.Item>
+          ))}
+        </Nav>
+
+        <InputGroup size="sm" style={{ maxWidth: 200 }}>
+          <InputGroup.Text aria-hidden="true">
+            <svg className="sa-icon" style={{ width: 12, height: 12 }}><use href="/icons/sprite.svg#search"></use></svg>
+          </InputGroup.Text>
+          <FormControl
+            placeholder="Search admin…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search admin"
+          />
+          {search && (
+            <Button variant="outline-secondary" size="sm" onClick={() => setSearch('')} aria-label="Clear search">
+              <svg className="sa-icon" style={{ width: 10, height: 10 }}><use href="/icons/sprite.svg#x"></use></svg>
+            </Button>
+          )}
+        </InputGroup>
+      </div>
+
+      <div className="main-content">
+        {tab === 'features' && <FeaturesTab search={search} />}
+        {tab === 'api-keys' && <ApiKeysTab search={search} />}
+        {tab === 'advanced' && <AdvancedTab search={search} />}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -6,27 +6,24 @@ import { useLayoutContext } from '../context/LayoutContext.jsx'
 import { useAuth } from '../contexts/AuthContext.jsx'
 import HelpTooltip from '../components/HelpTooltip.jsx'
 import LeafletFloorplan from '../components/LeafletFloorplan.jsx'
+import SettingSection from '../components/SettingSection.jsx'
 import { YARD_AREAS } from '../utils/watering.js'
 import { TIMEZONE_GROUPS } from '../hooks/useTimezone.js'
 import { SUPPORTED_LANGUAGES } from '../i18n/index.js'
 import { useTranslation } from 'react-i18next'
 import i18n from '../i18n/index.js'
-import { accountApi, exportApi, apiKeysApi, brandingApi, imagesApi, householdsApi, propertiesApi } from '../api/plants.js'
+import { accountApi, exportApi, brandingApi, imagesApi, householdsApi, propertiesApi } from '../api/plants.js'
 import { useHousehold } from '../context/HouseholdContext.jsx'
 import { useProperty } from '../context/PropertyContext.jsx'
 import { useProfile } from '../context/ProfileContext.jsx'
-import { menuItems } from '../layouts/components/menuData.js'
 
 const TABS = [
   { id: 'property', label: 'Property', icon: 'layers', tags: 'floors zones floorplan rooms upload property' },
   { id: 'preferences', label: 'Preferences', icon: 'sliders', tags: 'theme dark mode light temperature celsius fahrenheit metric imperial units location city weather profile mode persona household landscaper gardener role' },
   { id: 'household', label: 'Household', icon: 'users', tags: 'household share invite member family roommate partner role viewer editor owner code' },
   { id: 'data', label: 'Data & export', icon: 'download', tags: 'export csv download backup data' },
-  { id: 'api-keys', label: 'API Keys', icon: 'key', tags: 'api keys rest integration home assistant automation developer' },
   { id: 'client-properties', label: 'Properties', icon: 'home', tags: 'properties clients landscaper multi-property client management' },
   { id: 'branding', label: 'Branding', icon: 'star', tags: 'branding logo colour color business name landscaper white label report pdf' },
-  { id: 'features', label: 'Features', icon: 'grid', tags: 'features admin menu visibility persona toggle hide show workspace', adminOnly: true },
-  { id: 'advanced', label: 'Advanced', icon: 'tool', tags: 'reset onboarding developer version advanced' },
 ]
 
 function FloorRow({ floor, onChange, onDelete, expanded, onToggle }) {
@@ -256,29 +253,6 @@ function FloorRow({ floor, onChange, onDelete, expanded, onToggle }) {
         </tr>
       )}
     </>
-  )
-}
-
-function SettingSection({ id, title, icon, search, helpArticle, children }) {
-  const visible = !search || title.toLowerCase().includes(search.toLowerCase())
-  if (!visible) return null
-  return (
-    <div id={`settings-section-${id}`} className="mb-4">
-      <div className="panel panel-icon">
-        <div className="panel-hdr">
-          <span className="d-flex align-items-center gap-1">
-            {icon && (
-              <svg className="sa-icon me-2" aria-hidden="true"><use href={`/icons/sprite.svg#${icon}`}></use></svg>
-            )}
-            {title}
-            {helpArticle && <HelpTooltip articleId={helpArticle} label={`Help: ${title}`} />}
-          </span>
-        </div>
-        <div className="panel-container"><div className="panel-content">
-          {children}
-        </div></div>
-      </div>
-    </div>
   )
 }
 
@@ -1087,163 +1061,6 @@ function DataTab({ search }) {
   )
 }
 
-function ApiKeysTab({ search }) {
-  const { isGuest } = useAuth()
-  const [keys, setKeys] = useState([])
-  const [loading, setLoading] = useState(!isGuest)
-  const [error, setError] = useState(null)
-  const [creating, setCreating] = useState(false)
-  const [newKeyName, setNewKeyName] = useState('')
-  const [newKeyValue, setNewKeyValue] = useState(null)
-  const [revoking, setRevoking] = useState(null)
-
-  const loadKeys = useCallback(async () => {
-    try {
-      setLoading(true)
-      const { keys: list } = await apiKeysApi.list()
-      setKeys(list)
-    } catch (err) {
-      setError(err.message)
-    } finally {
-      setLoading(false)
-    }
-  }, [])
-
-  // Guests never have API keys — skip the fetch so demo/preview modes don't
-  // produce a spurious NetworkError in the console.
-  useEffect(() => { if (!isGuest) loadKeys() }, [loadKeys, isGuest])
-
-  const handleCreate = async () => {
-    if (!newKeyName.trim()) return
-    setCreating(true)
-    setError(null)
-    try {
-      const result = await apiKeysApi.create(newKeyName.trim())
-      setNewKeyValue(result.key)
-      setNewKeyName('')
-      await loadKeys()
-    } catch (err) {
-      setError(err.message)
-    } finally {
-      setCreating(false)
-    }
-  }
-
-  const handleRevoke = async (id) => {
-    setRevoking(id)
-    setError(null)
-    try {
-      await apiKeysApi.revoke(id)
-      setKeys((prev) => prev.filter((k) => k.id !== id))
-    } catch (err) {
-      setError(err.message)
-    } finally {
-      setRevoking(null)
-    }
-  }
-
-  return (
-    <>
-      <SettingSection id="api-keys-intro" title="Public REST API" icon="key" search={search}>
-        <p className="text-muted fs-sm mb-3">
-          Use API keys to integrate your plant data with external tools — Home Assistant, custom dashboards, and smart irrigation systems.
-          API keys are available on <strong>Home Pro</strong> and <strong>Landscaper Pro</strong> plans. Each key is shown <strong>once</strong> at creation.
-        </p>
-        <div className="alert alert-info py-2 fs-sm mb-0">
-          <strong>Base URL:</strong> <code>{import.meta.env.VITE_API_BASE_URL || 'https://api.plants.lopezcloud.dev'}/api/v1</code>
-          {' · '}
-          Pass the key as <code>x-plant-api-key: pt_live_...</code>
-        </div>
-      </SettingSection>
-
-      <SettingSection id="api-keys-manage" title="Your API Keys" icon="shield" search={search}>
-        {error && <div className="alert alert-danger py-2 mb-3" data-testid="api-key-error">{error}</div>}
-
-        {newKeyValue && (
-          <div className="alert alert-success mb-3" data-testid="new-key-banner">
-            <strong>Copy your new API key — it won&apos;t be shown again:</strong>
-            <div className="d-flex align-items-center gap-2 mt-2">
-              <code className="flex-grow-1 text-break" data-testid="new-key-value">{newKeyValue}</code>
-              <Button size="sm" variant="outline-success" onClick={() => { navigator.clipboard?.writeText(newKeyValue); }}>
-                Copy
-              </Button>
-            </div>
-            <Button size="sm" variant="link" className="p-0 mt-1 text-muted" onClick={() => setNewKeyValue(null)}>Dismiss</Button>
-          </div>
-        )}
-
-        {loading ? (
-          <p className="text-muted fs-sm">Loading…</p>
-        ) : keys.length === 0 ? (
-          <p className="text-muted fs-sm mb-3" data-testid="no-keys-message">No API keys yet. Create one below.</p>
-        ) : (
-          <Table size="sm" className="mb-3" data-testid="api-keys-table">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Key</th>
-                <th>Created</th>
-                <th>Last used</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {keys.map((k) => (
-                <tr key={k.id}>
-                  <td>{k.name}</td>
-                  <td><code>{k.key}</code></td>
-                  <td className="text-muted fs-xs">{new Date(k.createdAt).toLocaleDateString()}</td>
-                  <td className="text-muted fs-xs">{k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleDateString() : 'Never'}</td>
-                  <td>
-                    <Button
-                      variant="outline-danger"
-                      size="sm"
-                      onClick={() => handleRevoke(k.id)}
-                      disabled={revoking === k.id}
-                      data-testid={`revoke-key-${k.id}`}
-                    >
-                      {revoking === k.id ? 'Revoking…' : 'Revoke'}
-                    </Button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </Table>
-        )}
-
-        {keys.length < 3 && (
-          <div className="d-flex gap-2 align-items-end">
-            <Form.Group controlId="new-key-name" className="flex-grow-1">
-              <Form.Label className="fs-sm fw-500 mb-1">New key name</Form.Label>
-              <Form.Control
-                size="sm"
-                placeholder="e.g. Home Assistant"
-                value={newKeyName}
-                onChange={(e) => setNewKeyName(e.target.value)}
-                onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
-                maxLength={64}
-                data-testid="new-key-name-input"
-              />
-            </Form.Group>
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={handleCreate}
-              disabled={creating || !newKeyName.trim()}
-              data-testid="create-key-btn"
-            >
-              {creating ? 'Creating…' : 'Create key'}
-            </Button>
-          </div>
-        )}
-        {keys.length >= 3 && (
-          <p className="text-muted fs-xs mb-0">Maximum of 3 active API keys reached. Revoke one to create a new key.</p>
-        )}
-      </SettingSection>
-    </>
-  )
-}
-
 function BrandingTab({ search }) {
   const { isGuest } = useAuth()
   const [form, setForm] = useState({ businessName: '', brandColour: '#3a7d44', contactPhone: '', contactEmail: '', contactWebsite: '' })
@@ -1422,16 +1239,6 @@ function BrandingTab({ search }) {
   )
 }
 
-function AdvancedTab({ search }) {
-  return (
-    <SettingSection id="version" title="About" icon="info" search={search}>
-      <p className="text-muted fs-sm mb-0">
-        Version: {__APP_VERSION__} &middot; Built: {new Date(__BUILD_TIME__).toLocaleString()}
-      </p>
-    </SettingSection>
-  )
-}
-
 function ClientPropertiesTab({ search }) {
   const { properties, refresh } = useProperty()
   const [creating, setCreating] = useState(false)
@@ -1520,155 +1327,26 @@ function ClientPropertiesTab({ search }) {
   )
 }
 
-function describeStaticDefault(personas) {
-  if (!personas) return 'Visible to all'
-  const set = new Set(personas)
-  if (set.has('both') || (set.has('household') && set.has('landscaper'))) return 'Visible to all'
-  if (set.has('landscaper')) return 'Landscaper only'
-  if (set.has('household')) return 'Household only'
-  return 'Visible to all'
-}
-
-function flattenMenuForFeatures(items) {
-  const rows = []
-  for (const section of items) {
-    rows.push({ key: section.key, label: section.label, isSection: true, personas: section.personas })
-    for (const child of section.children || []) {
-      rows.push({ key: child.key, label: child.label, isSection: false, personas: child.personas, parentKey: section.key })
-    }
-  }
-  return rows
-}
-
-function FeaturesTab({ search }) {
-  const { featureOverrides, saveFeatureOverrides, canEditFeatureFlags } = useProfile()
-  const [draft, setDraft] = useState(() => ({ ...featureOverrides }))
-  const [saving, setSaving] = useState(false)
-  const [saved, setSaved] = useState(false)
-  const [saveError, setSaveError] = useState(null)
-
-  // Reset draft when context overrides change (e.g. after refresh).
-  useEffect(() => { setDraft({ ...featureOverrides }) }, [featureOverrides])
-
-  const rows = useMemo(() => flattenMenuForFeatures(menuItems), [])
-  const dirty = useMemo(() => {
-    const a = featureOverrides
-    const b = draft
-    const keys = new Set([...Object.keys(a), ...Object.keys(b)])
-    for (const k of keys) if (a[k] !== b[k]) return true
-    return false
-  }, [featureOverrides, draft])
-
-  const setRow = (key, value) => {
-    setDraft((prev) => {
-      const next = { ...prev }
-      if (value === '__default__') delete next[key]
-      else next[key] = value
-      return next
-    })
-  }
-
-  const handleSave = async () => {
-    setSaving(true)
-    setSaveError(null)
-    try {
-      await saveFeatureOverrides(draft)
-      setSaved(true)
-      setTimeout(() => setSaved(false), 2000)
-    } catch (err) {
-      setSaveError(err?.message || 'Failed to save')
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  const handleReset = () => setDraft({})
-
-  if (!canEditFeatureFlags) {
-    return (
-      <SettingSection id="features-locked" title="Features" icon="grid" search={search}>
-        <p className="text-muted mb-0">Only the workspace admin (household owner or landscaper manager) can change feature visibility.</p>
-      </SettingSection>
-    )
-  }
-
-  return (
-    <SettingSection id="features" title="Feature visibility" icon="grid" search={search}>
-      <p className="text-muted mb-3">
-        Override which menu items each persona sees. Items left as <em>Default</em> follow the built-in persona rules.
-      </p>
-      <Table hover responsive size="sm" className="mb-3">
-        <thead>
-          <tr>
-            <th>Feature</th>
-            <th style={{ width: 200 }}>Default</th>
-            <th style={{ width: 220 }}>Override</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => {
-            const value = draft[row.key] || '__default__'
-            return (
-              <tr key={row.key} className={row.isSection ? 'table-active fw-500' : ''}>
-                <td>
-                  {row.isSection ? row.label : (<span className="ps-3">{row.label}</span>)}
-                </td>
-                <td><span className="text-muted small">{describeStaticDefault(row.personas)}</span></td>
-                <td>
-                  <Form.Select
-                    size="sm"
-                    value={value}
-                    onChange={(e) => setRow(row.key, e.target.value)}
-                    aria-label={`Override for ${row.label}`}
-                  >
-                    <option value="__default__">Default</option>
-                    <option value="both">Visible to all</option>
-                    <option value="household">Household only</option>
-                    <option value="landscaper">Landscaper only</option>
-                    <option value="hidden">Hidden</option>
-                  </Form.Select>
-                </td>
-              </tr>
-            )
-          })}
-        </tbody>
-      </Table>
-      <div className="d-flex align-items-center gap-2">
-        <Button variant="primary" size="sm" onClick={handleSave} disabled={!dirty || saving}>
-          {saving ? 'Saving…' : 'Save changes'}
-        </Button>
-        <Button variant="outline-secondary" size="sm" onClick={handleReset} disabled={saving || Object.keys(draft).length === 0}>
-          Reset to defaults
-        </Button>
-        {saved && <span className="text-success small ms-2">Saved</span>}
-        {saveError && <span className="text-danger small ms-2">{saveError}</span>}
-      </div>
-    </SettingSection>
-  )
-}
 
 const VALID_TABS = TABS.map((t) => t.id)
+const ADMIN_TABS = new Set(['features', 'api-keys', 'advanced'])
 
 export default function SettingsPage() {
   const { tab = 'property' } = useParams()
   const [search, setSearch] = useState('')
-  const { canEditFeatureFlags } = useProfile()
-
-  // Hide admin-only tabs from non-admins.
-  const visibleTabs = useMemo(
-    () => TABS.filter((t) => !t.adminOnly || canEditFeatureFlags),
-    [canEditFeatureFlags],
-  )
-  const visibleTabIds = useMemo(() => visibleTabs.map((t) => t.id), [visibleTabs])
 
   // Which tabs match the current search query (used to badge the tab links)
   const matchingTabs = useMemo(() => {
     if (!search.trim()) return null
     const q = search.toLowerCase()
-    return new Set(visibleTabs.filter((t) => t.tags.includes(q) || t.label.toLowerCase().includes(q)).map((t) => t.id))
-  }, [search, visibleTabs])
+    return new Set(TABS.filter((t) => t.tags.includes(q) || t.label.toLowerCase().includes(q)).map((t) => t.id))
+  }, [search])
 
-  if (!VALID_TABS.includes(tab) || !visibleTabIds.includes(tab)) {
+  // Legacy URLs for tabs that have moved to the Admin page.
+  if (ADMIN_TABS.has(tab)) {
+    return <Navigate to={`/admin/${tab}`} replace />
+  }
+  if (!VALID_TABS.includes(tab)) {
     return <Navigate to="/settings/property" replace />
   }
 
@@ -1679,7 +1357,7 @@ export default function SettingsPage() {
       {/* Tab bar + search */}
       <div className="d-flex align-items-center gap-3 mb-4 flex-wrap">
         <Nav variant="tabs" className="flex-grow-1" role="tablist">
-          {visibleTabs.map((t) => (
+          {TABS.map((t) => (
             <Nav.Item key={t.id}>
               <Nav.Link
                 as={Link}
@@ -1726,11 +1404,8 @@ export default function SettingsPage() {
         {tab === 'preferences' && <PreferencesTab search={search} />}
         {tab === 'household' && <HouseholdTab search={search} />}
         {tab === 'data' && <DataTab search={search} />}
-        {tab === 'api-keys' && <ApiKeysTab search={search} />}
         {tab === 'client-properties' && <ClientPropertiesTab search={search} />}
         {tab === 'branding' && <BrandingTab search={search} />}
-        {tab === 'features' && <FeaturesTab search={search} />}
-        {tab === 'advanced' && <AdvancedTab search={search} />}
       </div>
     </div>
   )

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -11,6 +11,7 @@ const TodayPage = lazy(() => import('../pages/TodayPage.jsx'))
 const AnalyticsPage = lazy(() => import('../pages/AnalyticsPage.jsx'))
 const CalendarPage = lazy(() => import('../pages/CalendarPage.jsx'))
 const SettingsPage = lazy(() => import('../pages/SettingsPage.jsx'))
+const AdminPage = lazy(() => import('../pages/AdminPage.jsx'))
 const ForecastPage = lazy(() => import('../pages/ForecastPage.jsx'))
 const InsightsPage = lazy(() => import('../pages/InsightsPage.jsx'))
 const BulkUploadPage = lazy(() => import('../pages/BulkUploadPage.jsx'))
@@ -56,6 +57,8 @@ export const routes = [
           { path: 'settings', element: <Navigate to="/settings/property" replace /> },
           { path: 'settings/billing', element: <BillingPage /> },
           { path: 'settings/:tab', element: <SettingsPage />, handle: { breadcrumb: 'Settings' } },
+          { path: 'admin', element: <Navigate to="/admin/features" replace /> },
+          { path: 'admin/:tab', element: <AdminPage />, handle: { breadcrumb: 'Admin' } },
           { path: 'pricing', element: <PricingPage />, handle: { breadcrumb: 'Pricing' } },
         ],
       },


### PR DESCRIPTION
## Summary
- New `/admin/:tab` page hosting **Features**, **API Keys**, and **Advanced** (moved out of `/settings`); whole page is gated by `canEditFeatureFlags`, so non-admins are redirected to `/settings/property`.
- Legacy `/settings/features`, `/settings/api-keys`, `/settings/advanced` URLs auto-redirect to their new `/admin/...` home.
- Sidebar grows an **Admin** section (Features / API Keys / Advanced) that's only visible to workspace admins.
- Extracts the shared `SettingSection` panel into `src/components/SettingSection.jsx` so both pages can use it without duplication.

## Test plan
- [x] `npm run preflight:fast`
- [x] `npx vitest run src/__tests__/AdminPage.test.jsx src/__tests__/SettingsPage.test.jsx src/__tests__/Sidebar.test.jsx` (54 tests pass)
- [ ] Smoke: log in as admin → sidebar shows Admin section → `/admin/features` toggles save, `/admin/api-keys` lists/creates/revokes, `/admin/advanced` shows version
- [ ] Smoke: log in as non-admin → `/admin/features` redirects to `/settings/property`, sidebar has no Admin section
- [ ] Smoke: bookmark `/settings/api-keys` → redirects to `/admin/api-keys`

🤖 Generated with [Claude Code](https://claude.com/claude-code)