### PR TITLE
fix(billing): Stripe webhook idempotency — don't wedge retries on first-delivery failure

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -282,19 +282,25 @@ async function handleGiftPurchaseCompleted(db, session) {
   if (!purchaserUid) return;
   const durationMonths = parseInt(meta.durationMonths, 10) || 3;
 
+  // Deterministic giftId from the Stripe checkout session — makes the
+  // whole handler safe to retry. Stripe session IDs are unique per purchase.
+  const giftId = `gift_${session.id}`;
+  const giftRef = db.collection('gifts').doc(giftId);
+  const existing = await giftRef.get();
+  if (existing.exists) return;
+
   // Retry up to 3 times for a unique code.
   let code, codeHashed;
   for (let attempt = 0; attempt < 3; attempt++) {
     code = generateGiftCode();
     codeHashed = hashGiftCode(code);
-    const existing = await db.collection('giftCodeHashes').doc(codeHashed).get();
-    if (!existing.exists) break;
+    const collision = await db.collection('giftCodeHashes').doc(codeHashed).get();
+    if (!collision.exists) break;
     if (attempt === 2) throw new Error('Failed to generate a unique gift code');
   }
 
   const now = new Date().toISOString();
   const expiresAt = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
-  const giftId = `${purchaserUid.slice(0, 8)}-${Date.now()}`;
 
   const giftData = {
     code,
@@ -305,13 +311,17 @@ async function handleGiftPurchaseCompleted(db, session) {
     recipientName: meta.recipientName || null,
     tier: 'home_pro',
     durationMonths,
+    stripeCheckoutSessionId: session.id,
     stripePaymentIntentId: session.payment_intent || null,
     status: 'active',
     purchasedAt: now,
     expiresAt,
   };
 
-  await db.collection('gifts').doc(giftId).set(giftData);
+  // Order matters: write the hash + giftsSent first so the gift is
+  // redeemable end-to-end, then write the gifts/{giftId} doc last as
+  // the "completed" marker. If a partial failure happens between writes,
+  // the next webhook retry sees no gift doc and reruns to completion.
   await db.collection('giftCodeHashes').doc(codeHashed).set({ giftId });
   await db.collection('users').doc(purchaserUid).collection('giftsSent').doc(giftId).set({
     giftId, status: 'active', tier: 'home_pro', durationMonths,
@@ -319,6 +329,7 @@ async function handleGiftPurchaseCompleted(db, session) {
     recipientName: meta.recipientName || null,
     purchasedAt: now, expiresAt,
   });
+  await giftRef.set(giftData);
 }
 
 // ── Rebate catalog (loaded at boot; served from memory) ───────────────────────
@@ -367,11 +378,16 @@ app.post('/billing/webhook', express.raw({ type: 'application/json' }), async (r
     return res.status(400).json({ error: `Webhook signature verification failed: ${err.message}` });
   }
 
-  // Idempotency — Stripe may retry; use event.id as the dedup key.
+  // Idempotency — Stripe retries on non-2xx. Only short-circuit on retries
+  // once the handler has FINISHED successfully (status='completed'). Both
+  // handlers below are safe to run more than once: applySubscriptionEvent
+  // uses merge-true writes on deterministic paths, and the gift handler
+  // early-exits if a gift for this checkout session already exists.
   const eventRef = db.collection('stripeEvents').doc(event.id);
   const seen = await eventRef.get();
-  if (seen.exists) return res.status(200).json({ received: true, duplicate: true });
-  await eventRef.set({ type: event.type, receivedAt: new Date().toISOString() });
+  if (seen.exists && seen.data()?.status === 'completed') {
+    return res.status(200).json({ received: true, duplicate: true });
+  }
 
   try {
     const obj = event.data?.object || {};
@@ -380,6 +396,11 @@ app.post('/billing/webhook', express.raw({ type: 'application/json' }), async (r
     } else {
       await billing.applySubscriptionEvent(db, event);
     }
+    await eventRef.set({
+      type: event.type,
+      status: 'completed',
+      receivedAt: new Date().toISOString(),
+    });
     return res.status(200).json({ received: true });
   } catch (err) {
     return res.status(500).json({ error: err.message });

--- a/api/plants/index.test.js
+++ b/api/plants/index.test.js
@@ -7378,6 +7378,57 @@ describe('POST /billing/webhook — gift checkout.session.completed', () => {
       .send(JSON.stringify(event));
     expect(res.status).toBe(400);
   });
+
+  it('is idempotent: a Stripe retry for the same event does not mint a second gift', async () => {
+    const purchaserUid = USER_SUB;
+    const session = {
+      id: 'cs_test_gift_retry',
+      object: 'checkout.session',
+      payment_intent: 'pi_test_retry',
+      customer_email: 'buyer@example.com',
+      metadata: {
+        giftPurchase: 'true',
+        purchaserUid,
+        durationMonths: '3',
+        recipientEmail: 'recipient@example.com',
+      },
+    };
+    const event = {
+      id: 'evt_gift_retry',
+      type: 'checkout.session.completed',
+      data: { object: session },
+    };
+    const payload = JSON.stringify(event);
+    const header = makeStripeHeader(payload);
+
+    const first = await request(app)
+      .post('/billing/webhook')
+      .set('Content-Type', 'application/json')
+      .set('stripe-signature', header)
+      .send(payload);
+    expect(first.status).toBe(200);
+    expect(first.body.duplicate).toBeUndefined();
+
+    const hashesAfterFirst = Object.keys(store).filter(k => k.startsWith('giftCodeHashes/'));
+    const sentAfterFirst = Object.keys(store).filter(k => k.startsWith(`users/${purchaserUid}/giftsSent/`));
+    expect(hashesAfterFirst.length).toBe(1);
+    expect(sentAfterFirst.length).toBe(1);
+
+    const second = await request(app)
+      .post('/billing/webhook')
+      .set('Content-Type', 'application/json')
+      .set('stripe-signature', header)
+      .send(payload);
+    expect(second.status).toBe(200);
+    expect(second.body.duplicate).toBe(true);
+
+    expect(Object.keys(store).filter(k => k.startsWith('giftCodeHashes/'))).toHaveLength(1);
+    expect(Object.keys(store).filter(k => k.startsWith(`users/${purchaserUid}/giftsSent/`))).toHaveLength(1);
+
+    // The dedup record carries the completed marker — proves failures (which
+    // never reach the set() call) cannot wedge subsequent retries.
+    expect(store[`stripeEvents/${event.id}`]?.status).toBe('completed');
+  });
 });
 
 // ── GET /rebates/categories ───────────────────────────────────────────────────

--- a/api/plants/isolation-and-webhook.test.js
+++ b/api/plants/isolation-and-webhook.test.js
@@ -413,22 +413,39 @@ describe('POST /billing/webhook', () => {
       expect(store['stripeEvents/evt_b']).toBeDefined();
     });
 
-    it('surfaces 500 when applySubscriptionEvent throws, but event is still recorded', async () => {
+    it('surfaces 500 when applySubscriptionEvent throws AND does not mark the event completed so Stripe retries can re-run the handler', async () => {
+      let throws = true;
+      const applySpy = vi.fn(async () => {
+        if (throws) throw new Error('firestore write failed');
+      });
       stripeConstructEventFn = () => ({ id: 'evt_err_1', type: 'customer.subscription.deleted', data: { object: {} } });
-      applySubscriptionEventFn = async () => { throw new Error('firestore write failed'); };
+      applySubscriptionEventFn = applySpy;
 
-      const res = await request(app)
+      const first = await request(app)
         .post('/billing/webhook')
         .set('stripe-signature', 't=1,v1=a')
         .set('Content-Type', 'application/json')
         .send({});
 
-      expect(res.status).toBe(500);
-      expect(res.body.error).toMatch(/firestore write failed/);
-      // Event is marked seen — Stripe will retry, which is the intended behavior;
-      // the duplicate guard will then short-circuit. This test documents that
-      // contract so future refactors don't accidentally un-record failed events.
-      expect(store['stripeEvents/evt_err_1']).toBeDefined();
+      expect(first.status).toBe(500);
+      expect(first.body.error).toMatch(/firestore write failed/);
+      // After a failed first delivery the dedup record must NOT be marked
+      // completed — otherwise every Stripe retry would short-circuit and the
+      // subscription doc would never be written. This was a real bug.
+      expect(store['stripeEvents/evt_err_1']?.status).not.toBe('completed');
+
+      // Simulate Stripe's retry succeeding now that the transient failure is gone.
+      throws = false;
+      const second = await request(app)
+        .post('/billing/webhook')
+        .set('stripe-signature', 't=1,v1=a')
+        .set('Content-Type', 'application/json')
+        .send({});
+
+      expect(second.status).toBe(200);
+      expect(second.body).toEqual({ received: true });
+      expect(applySpy).toHaveBeenCalledTimes(2);
+      expect(store['stripeEvents/evt_err_1']?.status).toBe('completed');
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Move dedup write to AFTER handler success** at `api/plants/index.js:371–386`. The previous order wrote `stripeEvents/{event.id}` *before* running the handler, so any transient first-delivery failure (Firestore blip, malformed payload, downstream throw) silently wedged every Stripe retry — the retry short-circuited on `seen.exists` and the subscription doc was never written. This is the most plausible class of "Stripe charged me but my tier didn't update" reports.
- **Make `handleGiftPurchaseCompleted` self-idempotent**: deterministic `gift_${session.id}` as the gift doc id, early-exit if a gift for that session already exists, and reorder writes so the gift doc is written last as the completion marker. Partial failures between hash + giftsSent + gift writes now self-heal on retry.
- **New test** asserts that a second delivery of the same `checkout.session.completed` event returns `duplicate: true`, doesn't mint a second gift, and the `stripeEvents/{event.id}` record carries `status: 'completed'`.

`billing.applySubscriptionEvent` was already idempotent (merge-true writes on deterministic paths), so no change there.

## Context

Surfaced while debugging an upgrade-doesn't-work report. Root cause of that specific report is TLS handshake failure on `api.plants.lopezcloud.dev` (Cloudflare cert issue) — being fixed separately in `platform-infra`. This PR is the defence-in-depth fix so that once the webhook is reachable again, a single transient failure can't wedge all subsequent retries.

## Test plan

- [x] `cd api/plants && npx vitest run index.test.js -t "billing/webhook"` — 4/4 pass (3 existing + 1 new idempotency test)
- [x] `npm run preflight:fast` clean
- [x] Full `npm run preflight` — 882 tests pass; 2 vitest-worker spawn timeouts on `menuData.test.js` (pre-existing env flake, unrelated)
- [ ] After merge + deploy: in Stripe Dashboard, resend a previously-failed `checkout.session.completed`; verify `users/{uid}/subscription/current` populates with `tier: home_pro, status: active`

🤖 Generated with [Claude Code](https://claude.com/claude-code)