### PR TITLE
fix(billing): use req.rawBody for Stripe signature verification

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -361,19 +361,22 @@ const { createTierGate } = require('./tierGate');
 const app = express();
 app.set('trust proxy', true); // Behind API Gateway — trust X-Forwarded-For
 
-// ── Stripe webhook — declared BEFORE app.use(express.json()) so we receive
-// the raw request body for signature verification. Signature is checked via
-// STRIPE_WEBHOOK_SECRET; the webhook deliberately has no api_key auth in the
-// API Gateway spec.
+// ── Stripe webhook — must use the raw request body for signature verification.
+// In production, @google-cloud/functions-framework parses JSON bodies before any
+// Express middleware runs, so `req.body` is already a parsed object. The framework
+// preserves the original bytes on `req.rawBody`. In unit tests the framework is
+// mocked out and express.raw() runs unimpeded, leaving the Buffer on `req.body`.
+// STRIPE_WEBHOOK_SECRET secures this endpoint; it has no api_key auth at the gateway.
 app.post('/billing/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
   const stripe = billing.getStripe();
   const secret = process.env.STRIPE_WEBHOOK_SECRET;
   if (!stripe || !secret) return res.status(503).json({ error: 'billing_disabled' });
 
   const sig = req.headers['stripe-signature'];
+  const rawPayload = req.rawBody || req.body;
   let event;
   try {
-    event = stripe.webhooks.constructEvent(req.body, sig, secret);
+    event = stripe.webhooks.constructEvent(rawPayload, sig, secret);
   } catch (err) {
     return res.status(400).json({ error: `Webhook signature verification failed: ${err.message}` });
   }


### PR DESCRIPTION
## Summary

After #427 unblocked webhook idempotency and the platform-infra TLS fix made the endpoint reachable, the first real Stripe delivery failed with:

> Webhook payload must be provided as a string or a Buffer ... Payload was provided as a parsed JavaScript object instead.

`@google-cloud/functions-framework` parses JSON request bodies before any user-defined Express middleware runs, so `express.raw()` is a no-op in production — `req.body` is already a parsed object. The framework preserves the raw bytes on `req.rawBody`.

The fix is one line: `const rawPayload = req.rawBody || req.body` so we use the Buffer in production while keeping the existing test path working (tests mock out functions-framework, so `express.raw()` populates `req.body` with the Buffer there).

## Why no new regression test

The production failure mode (framework-pre-parsed body) can't be cleanly simulated through supertest without test-only middleware injection. The fix matches the documented `req.rawBody` contract for functions-framework HTTP functions; existing webhook tests (11 in `isolation-and-webhook.test.js` + `index.test.js`) all pass unchanged.

## Test plan

- [x] `npx vitest run isolation-and-webhook.test.js index.test.js -t "billing/webhook|/billing/webhook"` — 11/11 pass
- [ ] After deploy, in Stripe Dashboard resend the failed `checkout.session.completed`; verify response is 200 and `users/{uid}/subscription/current` populates with `tier: home_pro, status: active`

🤖 Generated with [Claude Code](https://claude.com/claude-code)