### PR TITLE
chore(ci): drop platform-infra secret bump after function ZIP upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -190,14 +190,11 @@ jobs:
       - name: Upload to GCS
         run: gsutil cp "${{ env.ZIP_NAME }}" gs://${{ secrets.FUNCTION_SOURCE_BUCKET }}/${{ env.ZIP_NAME }}
 
-      - name: Persist latest source object name
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.PLATFORM_INFRA_TOKEN }}
-        run: |
-          gh secret set HOME_PLANT_TRACKER_FUNCTION_SOURCE_OBJECT \
-            --repo lopeztech/platform-infra \
-            --body "${{ env.ZIP_NAME }}"
+      # platform-infra resolves the function source by listing the bucket and picking
+      # the newest .zip (see lopeztech/platform-infra PR #60). The workflow_dispatch
+      # input below wins as an explicit override; the HOME_PLANT_TRACKER_FUNCTION_SOURCE_OBJECT
+      # secret in platform-infra is now only a bootstrap fallback for empty buckets,
+      # so we no longer need to push our ZIP name into that secret on every deploy.
 
       - name: Trigger platform-infra Terraform apply
         env:


### PR DESCRIPTION
## Summary

Upstream change in **lopeztech/platform-infra#60** made the home-plant-tracker apply workflow resolve the Cloud Function source by listing `gs://home-plant-tracker-lcd-fn-source-prod` and picking the newest `.zip`. Resolution order is now:

1. \`workflow_dispatch\` input on the apply workflow (explicit override)
2. Newest `.zip` in the source bucket
3. \`HOME_PLANT_TRACKER_FUNCTION_SOURCE_OBJECT\` secret (bootstrap fallback only — kept so a fresh project with an empty bucket can still apply)

This PR drops the now-redundant **"Persist latest source object name"** step in `.github/workflows/deploy.yml` that was pushing every ZIP name into the upstream secret. The step was a tripwire: the 30-day GCS lifecycle on the source bucket could delete the secret-referenced object between deploys, wedging the next terraform apply.

## What stays

- The GCS upload to `gs://home-plant-tracker-lcd-fn-source-prod` (the only thing platform-infra actually needs from us).
- The `workflow_dispatch` trigger that passes `function_source_object=<ZIP>` to the apply workflow as the explicit override (resolution rule #1 above).
- The `PLATFORM_INFRA_TOKEN` PAT secret — still used by the trigger and verify steps.

## Verification (per the upstream plan)

- [ ] After merge, the next push to `main` should re-run the function deploy and upload `plants-<sha>.zip` to the source bucket.
- [ ] The platform-infra apply log should print `Resolved function_source_object=plants-<sha>.zip` (either from the dispatch input or the bucket listing). If it prints "Bucket has no .zip objects; falling back to secret" — something is wrong with the upload, not the coordination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)