### PR TITLE
fix: reload on stale chunk import + auto-paginate plant list

### DIFF
--- a/src/__tests__/lazyWithRetry.test.jsx
+++ b/src/__tests__/lazyWithRetry.test.jsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React, { Suspense } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { lazyWithRetry } from '../utils/lazyWithRetry.js'
+
+class Catch extends React.Component {
+  constructor(p) { super(p); this.state = { err: null } }
+  static getDerivedStateFromError(err) { return { err } }
+  render() { return this.state.err ? <div>caught</div> : this.props.children }
+}
+
+const RELOAD_KEY = 'plantTracker_chunkReloadAt'
+
+beforeEach(() => {
+  sessionStorage.clear()
+  // jsdom location.reload isn't writable by default — replace it.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, reload: vi.fn() },
+  })
+})
+
+afterEach(() => {
+  sessionStorage.clear()
+  vi.restoreAllMocks()
+})
+
+function Boom({ children }) {
+  return <Suspense fallback={<div>loading</div>}>{children}</Suspense>
+}
+
+describe('lazyWithRetry', () => {
+  it('renders the imported component on success', async () => {
+    const Lazy = lazyWithRetry(() =>
+      Promise.resolve({ default: () => <div>OK</div> }),
+    )
+    render(<Boom><Lazy /></Boom>)
+    await waitFor(() => expect(screen.getByText('OK')).toBeInTheDocument())
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+
+  it('reloads the page when a chunk fails to fetch (stale deploy)', async () => {
+    const Lazy = lazyWithRetry(() =>
+      Promise.reject(new Error('Failed to fetch dynamically imported module: /assets/Foo.js')),
+    )
+    render(<Boom><Lazy /></Boom>)
+    await waitFor(() => expect(window.location.reload).toHaveBeenCalledTimes(1))
+    expect(sessionStorage.getItem(RELOAD_KEY)).toBeTruthy()
+  })
+
+  it('does not reload twice in quick succession (guards against loops)', async () => {
+    sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
+    const Lazy = lazyWithRetry(() =>
+      Promise.reject(new Error('Failed to fetch dynamically imported module')),
+    )
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(<Catch><Boom><Lazy /></Boom></Catch>)
+    await waitFor(() => expect(screen.getByText('caught')).toBeInTheDocument())
+    expect(window.location.reload).not.toHaveBeenCalled()
+    consoleErr.mockRestore()
+  })
+
+  it('rethrows non-chunk errors without reloading', async () => {
+    const Lazy = lazyWithRetry(() =>
+      Promise.reject(new Error('boom: not a chunk problem')),
+    )
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(<Catch><Boom><Lazy /></Boom></Catch>)
+    await waitFor(() => expect(screen.getByText('caught')).toBeInTheDocument())
+    expect(window.location.reload).not.toHaveBeenCalled()
+    consoleErr.mockRestore()
+  })
+})

--- a/src/context/PlantContext.jsx
+++ b/src/context/PlantContext.jsx
@@ -34,7 +34,10 @@ export function PlantProvider({ children }) {
   const [plantsNextCursor, setPlantsNextCursor] = useState(null)
   const [plantsLoadingMore, setPlantsLoadingMore] = useState(false)
 
-  const PAGE_SIZE = 50
+  const PAGE_SIZE = 200
+  // Hard cap to prevent runaway requests if the cursor stream is misbehaving.
+  // 50 pages × 200 = 10,000 plants — well past any landscaper_pro library.
+  const MAX_AUTO_PAGES = 50
   const [floors, setFloors] = useState(DEFAULT_FLOORS)
   const [activeFloorId, setActiveFloorId] = useState(null)
   const [isAnalysingFloorplan, setIsAnalysingFloorplan] = useState(false)
@@ -60,6 +63,7 @@ export function PlantProvider({ children }) {
         .then(({ flushed }) => {
           if (flushed > 0) plantsApi.list({ limit: PAGE_SIZE }).then(({ plants: p, hasMore, nextCursor }) => {
             setPlants(p); setPlantsHasMore(hasMore); setPlantsNextCursor(nextCursor)
+            if (hasMore && nextCursor) drainRemainingPages(nextCursor)
           }).catch(() => {})
         })
         .catch(() => {})
@@ -71,6 +75,10 @@ export function PlantProvider({ children }) {
       window.removeEventListener('online', goOnline)
       window.removeEventListener('offline', goOffline)
     }
+    // drainRemainingPages is referenced in goOnline but is stable across
+    // renders (useCallback with empty deps); intentionally omitted to avoid
+    // re-binding listeners on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isGuest])
 
   // Auto-mark every outdoor plant as watered once per rainy day.
@@ -110,6 +118,31 @@ export function PlantProvider({ children }) {
   const logoutRef = useRef(logout)
   useEffect(() => { logoutRef.current = logout }, [logout])
 
+  // Drain remaining pages in the background after the first page renders.
+  // Keeps time-to-first-paint fast while ensuring users with large libraries
+  // (>PAGE_SIZE plants) see every marker on the floorplan, not just the
+  // first page. Without this, anyone over the page size sees fewer plants
+  // than the server reports.
+  const drainRemainingPages = useCallback(async (firstCursor) => {
+    let cursor = firstCursor
+    let pages = 0
+    while (cursor && pages < MAX_AUTO_PAGES) {
+      try {
+        const { plants: more, hasMore, nextCursor } = await plantsApi.list({ limit: PAGE_SIZE, after: cursor })
+        setPlants((prev) => {
+          const seen = new Set(prev.map((p) => p.id))
+          return [...prev, ...more.filter((p) => !seen.has(p.id))]
+        })
+        setPlantsHasMore(hasMore)
+        setPlantsNextCursor(nextCursor)
+        cursor = hasMore ? nextCursor : null
+        pages += 1
+      } catch {
+        break
+      }
+    }
+  }, [])
+
   const reloadPlants = useCallback(() => {
     if (!isAuthenticated || isGuest) return Promise.resolve()
     setPlantsLoading(true)
@@ -120,6 +153,7 @@ export function PlantProvider({ children }) {
         setPlants(loaded)
         setPlantsHasMore(hasMore)
         setPlantsNextCursor(nextCursor)
+        if (hasMore && nextCursor) drainRemainingPages(nextCursor)
       })
       .catch((err) => {
         const friendly = toFriendlyError(err, { context: 'plants' })
@@ -146,19 +180,23 @@ export function PlantProvider({ children }) {
       .then(({ flushed }) => {
         if (flushed > 0) plantsApi.list({ limit: PAGE_SIZE }).then(({ plants: p, hasMore, nextCursor }) => {
           setPlants(p); setPlantsHasMore(hasMore); setPlantsNextCursor(nextCursor)
+          if (hasMore && nextCursor) drainRemainingPages(nextCursor)
         }).catch(() => {})
       })
       .catch(() => {})
 
     return Promise.all([loadPlants, loadFloors]).finally(() => setPlantsLoading(false))
-  }, [isAuthenticated, isGuest])
+  }, [isAuthenticated, isGuest, drainRemainingPages])
 
   const loadMorePlants = useCallback(async () => {
     if (!plantsHasMore || plantsLoadingMore || !plantsNextCursor) return
     setPlantsLoadingMore(true)
     try {
       const { plants: more, hasMore, nextCursor } = await plantsApi.list({ limit: PAGE_SIZE, after: plantsNextCursor })
-      setPlants((prev) => [...prev, ...more])
+      setPlants((prev) => {
+        const seen = new Set(prev.map((p) => p.id))
+        return [...prev, ...more.filter((p) => !seen.has(p.id))]
+      })
       setPlantsHasMore(hasMore)
       setPlantsNextCursor(nextCursor)
     } catch {

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,35 +1,36 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Navigate } from 'react-router'
 import App from '../App.jsx'
 import MainLayout from '../layouts/MainLayout.jsx'
 import AuthLayout from '../layouts/AuthLayout.jsx'
+import { lazyWithRetry } from '../utils/lazyWithRetry.js'
 
-const LoginPage = lazy(() => import('../pages/LoginPage.jsx'))
-const DashboardPage = lazy(() => import('../pages/DashboardPage.jsx'))
-const PlantDetailPage = lazy(() => import('../pages/PlantDetailPage.jsx'))
-const TodayPage = lazy(() => import('../pages/TodayPage.jsx'))
-const AnalyticsPage = lazy(() => import('../pages/AnalyticsPage.jsx'))
-const CalendarPage = lazy(() => import('../pages/CalendarPage.jsx'))
-const SettingsPage = lazy(() => import('../pages/SettingsPage.jsx'))
-const AdminPage = lazy(() => import('../pages/AdminPage.jsx'))
-const ForecastPage = lazy(() => import('../pages/ForecastPage.jsx'))
-const InsightsPage = lazy(() => import('../pages/InsightsPage.jsx'))
-const BulkUploadPage = lazy(() => import('../pages/BulkUploadPage.jsx'))
-const BillingPage = lazy(() => import('../pages/BillingPage.jsx'))
-const PricingPage = lazy(() => import('../pages/PricingPage.jsx'))
-const PrivacyPage = lazy(() => import('../pages/PrivacyPage.jsx'))
-const TermsPage = lazy(() => import('../pages/TermsPage.jsx'))
-const ScanPage = lazy(() => import('../pages/ScanPage.jsx'))
-const PropagationPage = lazy(() => import('../pages/PropagationPage.jsx'))
-const VisitsPage = lazy(() => import('../pages/VisitsPage.jsx'))
-const TemplatesPage = lazy(() => import('../pages/TemplatesPage.jsx'))
-const MaterialsPage = lazy(() => import('../pages/MaterialsPage.jsx'))
-const PortalPage = lazy(() => import('../pages/PortalPage.jsx'))
-const SitPage = lazy(() => import('../pages/SitPage.jsx'))
-const RebatesPage = lazy(() => import('../pages/RebatesPage.jsx'))
-const GiftPage = lazy(() => import('../pages/GiftPage.jsx'))
-const CommunityPage = lazy(() => import('../pages/CommunityPage.jsx'))
-const CommunityGuidelinesPage = lazy(() => import('../pages/CommunityGuidelinesPage.jsx'))
+const LoginPage = lazyWithRetry(() => import('../pages/LoginPage.jsx'))
+const DashboardPage = lazyWithRetry(() => import('../pages/DashboardPage.jsx'))
+const PlantDetailPage = lazyWithRetry(() => import('../pages/PlantDetailPage.jsx'))
+const TodayPage = lazyWithRetry(() => import('../pages/TodayPage.jsx'))
+const AnalyticsPage = lazyWithRetry(() => import('../pages/AnalyticsPage.jsx'))
+const CalendarPage = lazyWithRetry(() => import('../pages/CalendarPage.jsx'))
+const SettingsPage = lazyWithRetry(() => import('../pages/SettingsPage.jsx'))
+const AdminPage = lazyWithRetry(() => import('../pages/AdminPage.jsx'))
+const ForecastPage = lazyWithRetry(() => import('../pages/ForecastPage.jsx'))
+const InsightsPage = lazyWithRetry(() => import('../pages/InsightsPage.jsx'))
+const BulkUploadPage = lazyWithRetry(() => import('../pages/BulkUploadPage.jsx'))
+const BillingPage = lazyWithRetry(() => import('../pages/BillingPage.jsx'))
+const PricingPage = lazyWithRetry(() => import('../pages/PricingPage.jsx'))
+const PrivacyPage = lazyWithRetry(() => import('../pages/PrivacyPage.jsx'))
+const TermsPage = lazyWithRetry(() => import('../pages/TermsPage.jsx'))
+const ScanPage = lazyWithRetry(() => import('../pages/ScanPage.jsx'))
+const PropagationPage = lazyWithRetry(() => import('../pages/PropagationPage.jsx'))
+const VisitsPage = lazyWithRetry(() => import('../pages/VisitsPage.jsx'))
+const TemplatesPage = lazyWithRetry(() => import('../pages/TemplatesPage.jsx'))
+const MaterialsPage = lazyWithRetry(() => import('../pages/MaterialsPage.jsx'))
+const PortalPage = lazyWithRetry(() => import('../pages/PortalPage.jsx'))
+const SitPage = lazyWithRetry(() => import('../pages/SitPage.jsx'))
+const RebatesPage = lazyWithRetry(() => import('../pages/RebatesPage.jsx'))
+const GiftPage = lazyWithRetry(() => import('../pages/GiftPage.jsx'))
+const CommunityPage = lazyWithRetry(() => import('../pages/CommunityPage.jsx'))
+const CommunityGuidelinesPage = lazyWithRetry(() => import('../pages/CommunityGuidelinesPage.jsx'))
 
 export const routes = [
   {

--- a/src/utils/lazyWithRetry.js
+++ b/src/utils/lazyWithRetry.js
@@ -1,0 +1,38 @@
+import { lazy } from 'react'
+
+// After a new deploy, the user's cached index.html still references old chunk
+// filenames (e.g. AnalyticsPage-<hash>.js) that no longer exist on the server,
+// so React.lazy() throws "Failed to fetch dynamically imported module" the
+// first time that route is navigated to. Reloading fetches a fresh index.html
+// and resolves the new hashed chunks; sessionStorage guards against a reload
+// loop if the import is genuinely broken.
+
+const RELOAD_KEY = 'plantTracker_chunkReloadAt'
+const RELOAD_WINDOW_MS = 10_000
+
+function isChunkLoadError(err) {
+  const msg = err && (err.message || String(err)) || ''
+  return (
+    err?.name === 'ChunkLoadError' ||
+    /Failed to fetch dynamically imported module/i.test(msg) ||
+    /Importing a module script failed/i.test(msg) ||
+    /error loading dynamically imported module/i.test(msg)
+  )
+}
+
+export function lazyWithRetry(importer) {
+  return lazy(() =>
+    importer().catch((err) => {
+      if (!isChunkLoadError(err)) throw err
+
+      const now = Date.now()
+      let last = 0
+      try { last = Number(sessionStorage.getItem(RELOAD_KEY) || 0) } catch {}
+      if (now - last < RELOAD_WINDOW_MS) throw err
+
+      try { sessionStorage.setItem(RELOAD_KEY, String(now)) } catch {}
+      window.location.reload()
+      return new Promise(() => {})
+    }),
+  )
+}


### PR DESCRIPTION
## Summary

Two unrelated bug reports surfaced in the same session — fixed together since both are small.

**1. Analytics page (and other lazy routes) intermittently throws "Error loading dynamically imported module"**
After a new deploy, the user's cached `index.html` references old hashed chunk filenames (e.g. `AnalyticsPage-DRtbqA38.js`) that no longer exist on the server. Wrap every `lazy()` route import with a new `lazyWithRetry()` helper that detects the chunk-load error and triggers a one-time `window.location.reload()` to refetch a fresh `index.html`. `sessionStorage` guards against an infinite reload loop if the import is genuinely broken.

**2. Only ~half of plants show on the ground floor when total > 50**
Root cause: cursor pagination with `PAGE_SIZE = 50`, and `loadMorePlants` was only wired to a "Load more" button in the **list** view. In 2D / 3D / game floorplan views there was no way to trigger more pages, so users with >50 plants only saw markers from the first page.

- Bumped `PAGE_SIZE` 50 → 200 (matches the backend cap of 200 per request — one round-trip covers the common case).
- Added `drainRemainingPages(cursor)` that loops in the background after the first page renders, fetching subsequent pages until `hasMore=false`. Capped at 50 pages = 10k plants as a runaway-guard.
- Called from both `reloadPlants()` and the offline-replay paths.
- Both `loadMorePlants` (button-driven) and `drainRemainingPages` (background) dedupe by plant id to avoid races.

## Test plan

- [x] `npm run preflight:fast` (build + lint + audits)
- [x] `npm run preflight` (full — 912 tests pass; 1 pre-existing flake in `App.test.jsx` "renders the dashboard when authenticated" reproduces on `main` without these changes)
- [x] 4 new unit tests in `lazyWithRetry.test.jsx` cover success, chunk-error reload, loop guard, non-chunk rethrow.
- [ ] Verify on `https://plants.lopezcloud.dev` after deploy: Analytics page loads after a fresh deploy; user with 98 plants sees all markers on ground floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)