### PR TITLE
fix: raise plant list cap so all plants load

### DIFF
--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -2926,7 +2926,9 @@ app.get('/plants', requireUser, async (req, res) => {
     const after    = req.query.after || null;
     const propertyId = req.query.propertyId || null;
     const paginated = rawLimit !== null || after !== null;
-    const limit = rawLimit ? Math.min(rawLimit, 200) : 200;
+    // Sanity cap of 5000 — large enough for any realistic plant library, small
+    // enough to prevent runaway responses if a buggy client passes 1e9.
+    const limit = rawLimit ? Math.min(rawLimit, 5000) : 5000;
 
     let query = userPlants(req.userId).orderBy('createdAt', 'desc').limit(limit + 1);
     if (after) query = query.startAfter(after);

--- a/src/context/PlantContext.jsx
+++ b/src/context/PlantContext.jsx
@@ -34,9 +34,11 @@ export function PlantProvider({ children }) {
   const [plantsNextCursor, setPlantsNextCursor] = useState(null)
   const [plantsLoadingMore, setPlantsLoadingMore] = useState(false)
 
-  const PAGE_SIZE = 200
-  // Hard cap to prevent runaway requests if the cursor stream is misbehaving.
-  // 50 pages × 200 = 10,000 plants — well past any landscaper_pro library.
+  // Request every plant in a single round-trip — the backend caps at 5000
+  // (sanity bound). Asking for the cap keeps the response in paginated
+  // shape ({plants, hasMore, nextCursor}) so the drain helper stays
+  // available as a safety net if a future user exceeds the cap.
+  const PAGE_SIZE = 5000
   const MAX_AUTO_PAGES = 50
   const [floors, setFloors] = useState(DEFAULT_FLOORS)
   const [activeFloorId, setActiveFloorId] = useState(null)


### PR DESCRIPTION
## Summary

User reported that with 98 plants only ~50 were rendering on the floorplan, even after #430 bumped `PAGE_SIZE` to 200. Raising the cap entirely so a single request returns the full library — no realistic user library needs a per-request limit.

- Backend `/plants` cap raised 200 → 5000 per request (sanity bound only).
- Frontend `PAGE_SIZE` raised to 5000 to match — one round-trip returns everything. The drain helper stays in place as a safety net for users who somehow exceed the cap.

## Test plan

- [x] `npm run preflight:fast` (build + lint + audits)
- [x] Backend `/plants` unit tests pass (107/107).
- [ ] Verify on production after deploy: user with 98 plants sees all markers on ground floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)