### PR TITLE
feat(billing): Family Plan add-on wiring (#411, scoped v1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,7 @@ All HTTP handlers in **`index.js`** (~4000 lines). Supporting modules: `billing.
 - `BILLING_ENABLED` — `'true'` to activate tier/quota enforcement; anything else makes `requireTier` and `checkQuota` no-ops (dark-ship switch)
 - `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`
 - `STRIPE_PRICE_*_MONTHLY`, `STRIPE_PRICE_*_ANNUAL` — per-tier price IDs
+- `STRIPE_PRICE_FAMILY_MONTHLY`, `STRIPE_PRICE_FAMILY_ANNUAL` — Family Plan add-on price IDs (see `docs/family-plan-activation.md`)
 
 Injected by Terraform / Cloud Run. Not needed for unit tests (mocked).
 
@@ -357,7 +358,7 @@ Sub-collections (all under a plant doc): `soilTests`, `amendments`, `substrateCh
 - `branding` — (landscaper_pro only) `businessName`, `primaryColor` (hex), `logoUrl` (signed), contact info
 
 ### Subscription — `users/{userId}/subscription/current`
-`tier`, `status` (active/trialing/past_due/cancelled), `currentPeriodStart`, `currentPeriodEnd`, `cancelAtPeriodEnd`, `stripeCustomerId`, `stripeSubscriptionId`, `usage: { plants, ai_analyses, photo_storage_mb }`.
+`tier`, `status` (active/trialing/past_due/cancelled), `currentPeriodStart`, `currentPeriodEnd`, `cancelAtPeriodEnd`, `stripeCustomerId`, `stripeSubscriptionId`, `usage: { plants, ai_analyses, photo_storage_mb }`, `addons: { family?: true }` (add-on map populated from Stripe `subscription_items`; `family` lifts `household_members` quota from 1 → 5 when `appliesTo` matches the active tier).
 
 ### API keys — `users/{userId}/apiKeys/{id}` + `apiKeyHashes/{hash}` (top-level lookup)
 Hash-only storage; plaintext key displayed once on creation.
@@ -365,11 +366,13 @@ Hash-only storage; plaintext key displayed once on creation.
 ## Billing & tier gating
 
 `api/plants/billing.js` — `TIERS`:
-| Tier | Level | Plants | AI analyses/mo | Photos | Properties | Team |
-|---|---|---|---|---|---|---|
-| `free` | 0 | 10 | 5 | 50 MB | 1 | 0 |
-| `home_pro` | 1 | ∞ | ∞ | 2 GB | 1 | 0 |
-| `landscaper_pro` | 2 | ∞ | ∞ | 10 GB | ∞ | 10 |
+| Tier | Level | Plants | AI analyses/mo | Photos | Properties | Team | Household |
+|---|---|---|---|---|---|---|---|
+| `free` | 0 | 10 | 5 | 50 MB | 1 | 0 | 1 |
+| `home_pro` | 1 | ∞ | ∞ | 2 GB | 3 | 0 | 1 (5 with `family` add-on) |
+| `landscaper_pro` | 2 | ∞ | ∞ | 10 GB | ∞ | 10 | 10 |
+
+**Add-ons (`billing.ADDONS`)** — paid extensions layered onto a base tier as extra Stripe `subscription_items`. Lift specific quotas without changing the tier itself. `family` (`$4.99/mo` or `$49/yr`) attaches to `home_pro` and raises `household_members` to 5. Backend wiring shipped in #411; UI prompt + member-cap enforcement land in follow-ups. See `docs/family-plan-activation.md` for one-time Stripe setup.
 
 `getCurrentTier(db, userId)` resolves from Firestore subscription doc. Past-due within a 7-day grace still returns stored tier; after that → `free`. `BILLING_ENABLED !== 'true'` short-circuits everything to free and no-ops the middlewares — **this is the dark-ship switch**.
 

--- a/api/plants/billing.js
+++ b/api/plants/billing.js
@@ -12,6 +12,7 @@ const TIERS = {
       photo_storage_mb:  50,
       properties:        1,
       team_members:      0,
+      household_members: 1,
     },
   },
   home_pro: {
@@ -22,6 +23,7 @@ const TIERS = {
       photo_storage_mb:  2048,
       properties:        3,
       team_members:      0,
+      household_members: 1,
     },
   },
   landscaper_pro: {
@@ -32,11 +34,29 @@ const TIERS = {
       photo_storage_mb:  10240,
       properties:        Infinity,
       team_members:      10,
+      household_members: 10,
     },
   },
 };
 
 const TIER_ORDER = ['free', 'home_pro', 'landscaper_pro'];
+
+// ── Add-ons ──────────────────────────────────────────────────────────────────
+// Add-ons are paid extensions attached to an existing subscription as extra
+// `subscription_items` on the Stripe side. They lift specific quotas on the
+// base tier (rather than upgrading the tier itself). #411 Family Plan v1.
+//
+// `priceEnv` lookups mirror PRICE_ENV for base tiers in index.js so manual
+// activation (docs/family-plan-activation.md) follows the same pattern as
+// the original Stripe activation flow (#239).
+
+const ADDONS = {
+  family: {
+    appliesTo:    ['home_pro'],            // base tier(s) that can attach it
+    quotaOverrides: { household_members: 5 },
+    priceEnv:     { month: 'STRIPE_PRICE_FAMILY_MONTHLY', year: 'STRIPE_PRICE_FAMILY_ANNUAL' },
+  },
+};
 
 function billingEnabled() {
   return process.env.BILLING_ENABLED === 'true';
@@ -110,6 +130,48 @@ function tierQuota(tier, quotaType) {
   return TIERS[tier]?.quotas?.[quotaType] ?? 0;
 }
 
+// ── Add-on resolution ────────────────────────────────────────────────────────
+
+/**
+ * Returns the active add-on names attached to the user's subscription.
+ * Reads `subscription.addons` (object map of name → true/false) — entries
+ * present and truthy are considered active. An add-on whose base tier is no
+ * longer met (e.g. user downgraded from home_pro to free) is filtered out
+ * so it cannot leak benefits into a lower tier.
+ */
+async function getActiveAddons(db, userId) {
+  if (!billingEnabled()) return [];
+  const sub = await readSubscription(db, userId);
+  if (!sub?.addons) return [];
+  const tier = await getCurrentTier(db, userId);
+  return Object.keys(sub.addons)
+    .filter((name) => sub.addons[name] && ADDONS[name])
+    .filter((name) => ADDONS[name].appliesTo.includes(tier));
+}
+
+async function hasAddon(db, userId, name) {
+  const active = await getActiveAddons(db, userId);
+  return active.includes(name);
+}
+
+/**
+ * Returns the user's effective quotas after applying any active add-ons.
+ * Add-on overrides take the MAX of the base tier quota and the add-on's
+ * quota value, so attaching an add-on never reduces a quota.
+ */
+function effectiveQuotas(tier, addonNames = []) {
+  const base = TIERS[tier]?.quotas || {};
+  const out = { ...base };
+  for (const name of addonNames) {
+    const addon = ADDONS[name];
+    if (!addon) continue;
+    for (const [key, val] of Object.entries(addon.quotaOverrides || {})) {
+      out[key] = Math.max(out[key] ?? 0, val);
+    }
+  }
+  return out;
+}
+
 // ── Usage counters ──────────────────────────────────────────────────────────
 
 function monthKey(d = new Date()) {
@@ -165,17 +227,22 @@ async function applySubscriptionEvent(db, event) {
     userId = obj.client_reference_id || null;
     stripeCustomerId = obj.customer || null;
     const tier = obj.metadata?.tier || null;
+    const addonsFromMetadata = parseAddonsMetadata(obj.metadata?.addons);
     if (userId && stripeCustomerId) {
       await db.collection('stripeCustomers').doc(stripeCustomerId).set({
         userId, updatedAt: new Date().toISOString(),
       }, { merge: true });
-      await db.collection('users').doc(userId).collection('subscription').doc('current').set({
+      const subWrite = {
         tier,
         stripeCustomerId,
         stripeSubscriptionId: obj.subscription || null,
         status: 'active',
         updatedAt: new Date().toISOString(),
-      }, { merge: true });
+      };
+      if (addonsFromMetadata) subWrite.addons = addonsFromMetadata;
+      await db.collection('users').doc(userId).collection('subscription').doc('current').set(
+        subWrite, { merge: true },
+      );
     }
     return;
   }
@@ -196,6 +263,13 @@ async function applySubscriptionEvent(db, event) {
     if (obj.current_period_end) update.currentPeriodEnd = new Date(obj.current_period_end * 1000).toISOString();
     if (typeof obj.cancel_at_period_end === 'boolean') update.cancelAtPeriodEnd = obj.cancel_at_period_end;
     if (obj.metadata?.tier) update.tier = obj.metadata.tier;
+
+    // Re-derive add-ons from the live subscription items so add/remove via the
+    // Stripe Customer Portal flows through without needing a fresh checkout.
+    const itemList = obj.items?.data || [];
+    if (itemList.length > 0) {
+      update.addons = deriveAddonsFromItems(itemList);
+    }
   } else if (event.type === 'invoice.payment_failed') {
     update.status = 'past_due';
   } else if (event.type === 'invoice.payment_succeeded') {
@@ -205,20 +279,52 @@ async function applySubscriptionEvent(db, event) {
   await ref.set(update, { merge: true });
 }
 
+// ── Add-on helpers ───────────────────────────────────────────────────────────
+
+// Parse the `addons` checkout-session metadata field into a Firestore-shaped
+// map (e.g. "family,bonus" → { family: true, bonus: true }).
+function parseAddonsMetadata(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  const names = raw.split(',').map((s) => s.trim()).filter(Boolean);
+  if (names.length === 0) return null;
+  return Object.fromEntries(names.map((n) => [n, true]));
+}
+
+// Inspect a `subscription.items.data` array and return a Firestore-shaped
+// add-on map, matching priceIds against ADDONS[*].priceEnv values. The same
+// shape used by parseAddonsMetadata so reads downstream don't branch.
+function deriveAddonsFromItems(items) {
+  const out = {};
+  for (const [name, addon] of Object.entries(ADDONS)) {
+    const envVars = Object.values(addon.priceEnv || {});
+    const priceIds = envVars.map((v) => process.env[v]).filter(Boolean);
+    if (priceIds.length === 0) continue;
+    const matched = items.some((it) => priceIds.includes(it?.price?.id));
+    if (matched) out[name] = true;
+  }
+  return out;
+}
+
 module.exports = {
   TIERS,
   TIER_ORDER,
+  ADDONS,
   billingEnabled,
   getStripe,
   readSubscription,
   getCurrentTier,
   tierMeetsMinimum,
   tierQuota,
+  getActiveAddons,
+  hasAddon,
+  effectiveQuotas,
   countPlants,
   countProperties,
   readAiAnalysesUsage,
   incrementAiAnalyses,
   readStorageUsageMb,
   applySubscriptionEvent,
+  parseAddonsMetadata,
+  deriveAddonsFromItems,
   monthKey,
 };

--- a/api/plants/billing.test.js
+++ b/api/plants/billing.test.js
@@ -197,6 +197,101 @@ describe('billing.applySubscriptionEvent', () => {
   });
 });
 
+describe('billing add-ons (#411)', () => {
+  beforeEach(() => {
+    process.env.BILLING_ENABLED = 'true';
+    process.env.STRIPE_PRICE_FAMILY_MONTHLY = 'price_fam_m';
+    process.env.STRIPE_PRICE_FAMILY_ANNUAL  = 'price_fam_y';
+  });
+
+  it('exposes the family add-on definition with home_pro applicability', () => {
+    expect(billing.ADDONS.family).toMatchObject({
+      appliesTo: ['home_pro'],
+      quotaOverrides: { household_members: 5 },
+    });
+  });
+
+  it('parseAddonsMetadata splits a comma-separated metadata string', () => {
+    expect(billing.parseAddonsMetadata('family')).toEqual({ family: true });
+    expect(billing.parseAddonsMetadata('family,foo')).toEqual({ family: true, foo: true });
+    expect(billing.parseAddonsMetadata('')).toBeNull();
+    expect(billing.parseAddonsMetadata(null)).toBeNull();
+  });
+
+  it('deriveAddonsFromItems matches Stripe items against ADDONS priceEnv', () => {
+    const items = [{ price: { id: 'price_home_pro' } }, { price: { id: 'price_fam_m' } }];
+    expect(billing.deriveAddonsFromItems(items)).toEqual({ family: true });
+  });
+
+  it('getActiveAddons returns family when stored and tier is home_pro', async () => {
+    const db = makeDb({
+      'users/u1/subscription/current': {
+        tier: 'home_pro', status: 'active', addons: { family: true },
+      },
+    });
+    expect(await billing.getActiveAddons(db, 'u1')).toEqual(['family']);
+    expect(await billing.hasAddon(db, 'u1', 'family')).toBe(true);
+  });
+
+  it('getActiveAddons filters out addons whose appliesTo no longer matches', async () => {
+    // User cancelled home_pro → tier resolves to free, family should not leak.
+    const db = makeDb({
+      'users/u1/subscription/current': {
+        tier: 'home_pro', status: 'canceled', addons: { family: true },
+      },
+    });
+    expect(await billing.getActiveAddons(db, 'u1')).toEqual([]);
+  });
+
+  it('getActiveAddons is empty when billing is disabled', async () => {
+    process.env.BILLING_ENABLED = 'false';
+    const db = makeDb({
+      'users/u1/subscription/current': {
+        tier: 'home_pro', status: 'active', addons: { family: true },
+      },
+    });
+    expect(await billing.getActiveAddons(db, 'u1')).toEqual([]);
+  });
+
+  it('effectiveQuotas lifts household_members from 1 to 5 with family add-on', () => {
+    expect(billing.effectiveQuotas('home_pro').household_members).toBe(1);
+    expect(billing.effectiveQuotas('home_pro', ['family']).household_members).toBe(5);
+  });
+
+  it('effectiveQuotas never reduces a quota below the tier baseline', () => {
+    // landscaper_pro baseline is 10 — family addon's 5 must NOT override down.
+    const q = billing.effectiveQuotas('landscaper_pro', ['family']);
+    expect(q.household_members).toBe(10);
+  });
+
+  it('applySubscriptionEvent persists addons from checkout metadata', async () => {
+    const db = makeDb();
+    await billing.applySubscriptionEvent(db, {
+      type: 'checkout.session.completed',
+      data: { object: {
+        client_reference_id: 'u1', customer: 'cus_test', subscription: 'sub_test',
+        metadata: { tier: 'home_pro', addons: 'family' },
+      }},
+    });
+    expect(db._store['users/u1/subscription/current'].addons).toEqual({ family: true });
+  });
+
+  it('applySubscriptionEvent re-derives addons from live subscription items', async () => {
+    const db = makeDb({
+      'stripeCustomers/cus_test': { userId: 'u1' },
+      'users/u1/subscription/current': { tier: 'home_pro', status: 'active', stripeCustomerId: 'cus_test' },
+    });
+    await billing.applySubscriptionEvent(db, {
+      type: 'customer.subscription.updated',
+      data: { object: {
+        id: 'sub_test', customer: 'cus_test', status: 'active',
+        items: { data: [{ price: { id: 'price_home_pro' } }, { price: { id: 'price_fam_m' } }] },
+      }},
+    });
+    expect(db._store['users/u1/subscription/current'].addons).toEqual({ family: true });
+  });
+});
+
 describe('billing.countPlants + ai_analyses usage', () => {
   it('counts plants under users/{uid}/plants', async () => {
     const db = makeDb({

--- a/api/plants/index.js
+++ b/api/plants/index.js
@@ -745,12 +745,31 @@ app.post('/billing/create-checkout-session', requireUser, async (req, res) => {
   const stripe = billing.getStripe();
   if (!stripe) return res.status(503).json({ error: 'billing_disabled' });
   try {
-    const { tier, interval = 'month', successUrl, cancelUrl } = req.body || {};
+    const { tier, interval = 'month', successUrl, cancelUrl, addons = [] } = req.body || {};
     if (!PRICE_ENV[tier] || !PRICE_ENV[tier][interval]) {
       return res.status(400).json({ error: 'Invalid tier/interval' });
     }
     const priceId = process.env[PRICE_ENV[tier][interval]];
     if (!priceId) return res.status(500).json({ error: `Price ID env var ${PRICE_ENV[tier][interval]} is not configured` });
+
+    // Resolve add-on line items. An add-on is rejected if it isn't applicable
+    // to the requested base tier; missing env vars surface as 500 the same way
+    // base-tier prices do.
+    const lineItems = [{ price: priceId, quantity: 1 }];
+    const validatedAddons = [];
+    if (Array.isArray(addons)) {
+      for (const name of addons) {
+        const addon = billing.ADDONS[name];
+        if (!addon)                          return res.status(400).json({ error: `Unknown add-on: ${name}` });
+        if (!addon.appliesTo.includes(tier)) return res.status(400).json({ error: `Add-on ${name} not available on ${tier}` });
+        const envVar = addon.priceEnv?.[interval];
+        if (!envVar)                         return res.status(400).json({ error: `Add-on ${name} not available on ${interval} interval` });
+        const addonPriceId = process.env[envVar];
+        if (!addonPriceId)                   return res.status(500).json({ error: `Price ID env var ${envVar} is not configured` });
+        lineItems.push({ price: addonPriceId, quantity: 1 });
+        validatedAddons.push(name);
+      }
+    }
 
     // Reuse an existing Stripe Customer if the user already has one.
     const existing = await billing.readSubscription(db, req.userId);
@@ -760,15 +779,18 @@ app.post('/billing/create-checkout-session', requireUser, async (req, res) => {
       customerId = customer.id;
     }
 
+    const metadata = { userId: req.userId, tier };
+    if (validatedAddons.length > 0) metadata.addons = validatedAddons.join(',');
+
     const session = await stripe.checkout.sessions.create({
       mode:                  'subscription',
       customer:              customerId,
       client_reference_id:   req.userId,
-      line_items:            [{ price: priceId, quantity: 1 }],
+      line_items:            lineItems,
       success_url:           successUrl || `${process.env.BILLING_SUCCESS_URL || 'https://plants.lopezcloud.dev'}/settings/billing?status=success`,
       cancel_url:            cancelUrl  || `${process.env.BILLING_CANCEL_URL  || 'https://plants.lopezcloud.dev'}/pricing?status=cancelled`,
-      subscription_data:     { metadata: { userId: req.userId, tier } },
-      metadata:              { userId: req.userId, tier },
+      subscription_data:     { metadata },
+      metadata,
     });
     return res.status(200).json({ url: session.url, id: session.id });
   } catch (err) {
@@ -796,10 +818,11 @@ app.get('/billing/subscription', requireUser, async (req, res) => {
   try {
     const tier = await billing.getCurrentTier(db, req.userId);
     const sub  = await billing.readSubscription(db, req.userId);
-    const [plantsCount, aiAnalyses, storageMb] = await Promise.all([
+    const [plantsCount, aiAnalyses, storageMb, addons] = await Promise.all([
       billing.countPlants(db, req.userId),
       billing.readAiAnalysesUsage(db, req.userId),
       billing.readStorageUsageMb(db, req.userId),
+      billing.getActiveAddons(db, req.userId),
     ]);
     const trialDaysRemaining = sub?.isTrial && sub?.trialEnd
       ? Math.max(0, Math.ceil((new Date(sub.trialEnd).getTime() - Date.now()) / 86400000))
@@ -813,7 +836,8 @@ app.get('/billing/subscription', requireUser, async (req, res) => {
       isTrial:           sub?.isTrial || false,
       trialDaysRemaining,
       hasStripeCustomer: Boolean(sub?.stripeCustomerId),
-      quotas: billing.TIERS[tier].quotas,
+      addons,
+      quotas:            billing.effectiveQuotas(tier, addons),
       usage: {
         plants:           plantsCount,
         ai_analyses:      aiAnalyses,

--- a/docs/family-plan-activation.md
+++ b/docs/family-plan-activation.md
@@ -1,0 +1,75 @@
+# Activate the Family Plan add-on
+
+This is the one-time manual setup to go live with the Family Plan ($4.99/mo or $49/yr) add-on on top of `home_pro`. Pre-reqs: Stripe is already activated for the main subscription tiers (the steps in #239 are complete).
+
+## Step 1 — Create the Family Plan Product + Prices
+
+1. Sign in to https://dashboard.stripe.com — verify the test/live toggle matches the mode you're configuring.
+2. Go to https://dashboard.stripe.com/products (drop `/test/` for live).
+3. Click **+ Add product**:
+   - **Name:** `Family Plan`
+   - **Description:** `Share a Home Pro garden with up to 5 household members. Each member signs in, shares the plant collection and floorplan.`
+   - Under **Pricing**, choose **Recurring**.
+   - **Price 1 — monthly:** Amount `4.99 USD`, Billing period `Monthly`.
+   - Click **Add another price**.
+   - **Price 2 — annual:** Amount `49.00 USD`, Billing period `Yearly`.
+   - Save.
+4. Open the saved product, click each `price_...` ID and copy both into a scratch note.
+
+```
+STRIPE_PRICE_FAMILY_MONTHLY = price_...
+STRIPE_PRICE_FAMILY_ANNUAL  = price_...
+```
+
+## Step 2 — Add the price IDs to Terraform
+
+In `platform-infra/projects/home-plant-tracker/environments/prod.tfvars` add:
+
+```hcl
+stripe_price_family_monthly = "price_..."
+stripe_price_family_annual  = "price_..."
+```
+
+Commit and push to `platform-infra/master` — the apply workflow redeploys the Cloud Function with the new env vars within a few minutes. Verify:
+
+```sh
+gcloud run revisions list --service plant-tracker-plants-api --region <region> --limit 1
+```
+
+## Step 3 — Verify the add-on resolves end-to-end
+
+**Backend sanity check:**
+
+```sh
+curl -sS https://api.plants.lopezcloud.dev/billing/subscription \
+  -H "x-api-key: $API_KEY" -H "Authorization: Bearer <JWT>"
+```
+
+Expected (when the user has no add-ons): `"addons": []`, `"quotas": { ..., "household_members": 1 }` for `home_pro`.
+
+**Checkout with the add-on:**
+
+```sh
+curl -sS -X POST https://api.plants.lopezcloud.dev/billing/create-checkout-session \
+  -H "x-api-key: $API_KEY" -H "Authorization: Bearer <JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{"tier":"home_pro","interval":"month","addons":["family"]}'
+```
+
+Should return a `checkout.stripe.com` URL with both line items. Pay with test card `4242 4242 4242 4242`. Within a few seconds the user's `subscription.addons.family` should be `true` and `quotas.household_members` should be `5`.
+
+**Webhook verification:** at https://dashboard.stripe.com/test/webhooks open your existing endpoint → Events tab → confirm `checkout.session.completed` arrived with status 200.
+
+## What this does NOT do
+
+This is the **backend & Stripe wiring** only. It deliberately leaves the user-facing flow untouched:
+
+- The frontend pricing page does NOT yet show a Family Plan upgrade CTA.
+- The household members API does NOT yet enforce `household_members` quota at the route layer (existing households remain uncapped).
+- No grandfathering migration runs.
+
+A follow-up PR will wire the UI prompt (Settings → Family, pricing page) and turn on the `household_members` quota check in `households.js` with a grandfather rule for existing multi-member households.
+
+## Switch to live mode
+
+Repeat Step 1 in live mode, set the new live `price_...` IDs in `prod.tfvars` (replace the existing values; don't add new variables), and re-apply.


### PR DESCRIPTION
## Summary

Scoped v1 of #411 — **backend & Stripe wiring only**. Lays the tier+quota+Stripe machinery for a \$4.99/mo Family Plan that attaches to \`home_pro\` as a Stripe \`subscription_item\`. Deliberately leaves the user-facing flow untouched: no UI, no member-cap enforcement, no grandfathering migration. Those follow up so existing multi-member households aren't disrupted on day one.

## Backend changes

- **\`billing.js\`** — \`ADDONS\` catalogue with \`appliesTo\` guard and \`priceEnv\` lookups (mirrors \`PRICE_ENV\` for base tiers). New helpers: \`getActiveAddons\`, \`hasAddon\`, \`effectiveQuotas\`. \`applySubscriptionEvent\` persists add-ons from checkout metadata AND re-derives them from live \`subscription_items\` so add/remove via the Stripe Customer Portal flows through without re-checkout. Active add-ons are filtered against \`appliesTo\` so a downgraded base tier can't leak benefits.
- **\`index.js\`** — \`/billing/create-checkout-session\` accepts \`addons: []\` and appends extra line items (validating each against ADDONS + interval). \`GET /billing/subscription\` surfaces \`addons\` + \`effectiveQuotas\` so the UI eventually gets a single source of truth for quota copy.
- **Tier quotas** — \`household_members\` added to every tier (free=1, home_pro=1, landscaper_pro=10). Family add-on lifts home_pro to 5.

## What's deliberately out of scope

| Out of scope | Tracked in |
|---|---|
| Frontend pricing page / Settings → Family UI | Follow-up |
| \`household_members\` quota enforcement in \`households.js\` | Follow-up |
| Grandfathering existing multi-member households | Follow-up |

The route logic is dark-shipped behind the existing \`BILLING_ENABLED\` env flag; the new \`STRIPE_PRICE_FAMILY_*\` env vars are independent so the manual activation (\`docs/family-plan-activation.md\`) can happen without code redeploy.

## Tests

9 new \`billing.test.js\` cases — ADDONS shape, \`parseAddonsMetadata\` / \`deriveAddonsFromItems\`, \`getActiveAddons\` (including the appliesTo guard and billing-disabled short-circuit), \`effectiveQuotas\` (lift + don't-reduce), and webhook persistence from both metadata and live items.

Route-level success-path tests are skipped because the existing \`/billing/*\` test setup doesn't mock Stripe (only the 503-disabled path is covered). Validation logic is straight early-returns; the substantive logic is covered at the helper layer. Will add route integration tests when the UI ships.

## Test plan
- [x] \`npm run preflight\` clean (modulo two pre-existing flakes in \`App.test.jsx\` and \`/voice/plants/.../status\` that pass on re-run + were untouched by this PR)
- [x] \`cd api/plants && npx vitest run billing.test.js\` — 32 pass
- [ ] After Stripe Product + Prices configured per \`docs/family-plan-activation.md\`, \`curl POST /billing/create-checkout-session\` with \`addons:['family']\` returns a checkout URL with both line items

🤖 Generated with [Claude Code](https://claude.com/claude-code)