### PR TITLE
feat(plants): mobile bottom-sheet shell for PlantModal (#401, PR 1/n)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ Factory that returns a `request()` helper (adds `x-api-key`, `Authorization: Bea
 - `useRtl.js` — detects RTL languages (ar, he, fa, ur), injects Bootstrap RTL CSS, sets `document.dir`.
 - `useTimezone.js` — IANA timezone picker (grouped UTC / Americas / Europe / Africa-ME / Asia / Pacific), stored in localStorage, applied to reminders and calendar.
 - `useUnitSystem.js` — metric/imperial preference (auto-detect from `en-US/en-LR/my` → imperial; else metric), localStorage persist.
+- `useMediaQuery.js` — generic `matchMedia` subscription; SSR-safe default-false on first paint.
 
 ### `src/layouts/`
 - `MainLayout.jsx` — Smart Admin CSS-Grid shell (topbar + sidebar + `<Outlet>` + footer); redirects to `/login` when unauthenticated.
@@ -162,7 +163,7 @@ Factory that returns a `request()` helper (adds `x-api-key`, `Authorization: Bea
 
 ### `src/components/` (~42 files, flat)
 Grouped by function:
-- **Plant CRUD**: `PlantModal.jsx` (large; tabs: Plant / Care / Watering / Fertilise / Journal / Soil / Harvest / Health), `BulkPlantCard.jsx`, `PlantQRTag.jsx`, `SoilTab.jsx`
+- **Plant CRUD**: `PlantModal.jsx` (large; tabs: Plant / Care / Watering / Fertilise / Journal / Soil / Harvest / Health), `PlantSheet.jsx` (Framer Motion bottom-sheet shell used by PlantModal on <768px when `VITE_PLANT_MODAL_V2=true`, #401), `BulkPlantCard.jsx`, `PlantQRTag.jsx`, `SoilTab.jsx`
 - **Floorplan**: `Floorplan3D.jsx` (Three.js + R3F), `FloorplanGame.jsx` (playable 3D), `LeafletFloorplan.jsx` (2D), `FloorplanPanel.jsx`, `PlantMarker.jsx`, `PlantIcon.jsx`, `FloorNav.jsx`
 - **Panels / lists**: `PlantListPanel.jsx` (virtualised via react-window), `FloorplanPanel.jsx`
 - **Care logs**: `FeedRecordModal.jsx`, `WateringSheet.jsx`
@@ -416,6 +417,7 @@ VITE_GOOGLE_CLIENT_ID=           # OAuth 2.0 Web client ID
 VITE_API_BASE_URL=               # API Gateway URL
 VITE_API_KEY=                    # x-api-key for API Gateway
 VITE_ML_INSIGHTS_ENABLED=        # 'true' to show /insights
+VITE_PLANT_MODAL_V2=             # 'true' renders the mobile bottom-sheet shell (#401, off by default; <768px only)
 ```
 
 Build-time globals injected by `vite.config.js`: commit SHA, build timestamp.

--- a/src/__tests__/PlantSheet.test.jsx
+++ b/src/__tests__/PlantSheet.test.jsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import PlantSheet from '../components/PlantSheet.jsx'
+
+describe('PlantSheet (#401 PR 1)', () => {
+  it('renders children inside a role="dialog" with aria-modal when show=true', () => {
+    render(
+      <PlantSheet show onClose={() => {}} ariaLabelledBy="my-title">
+        <h2 id="my-title">Inner</h2>
+        <div data-testid="content">Hello sheet</div>
+      </PlantSheet>,
+    )
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAttribute('aria-labelledby', 'my-title')
+    expect(screen.getByTestId('content')).toHaveTextContent('Hello sheet')
+  })
+
+  it('renders nothing when show=false', () => {
+    render(
+      <PlantSheet show={false} onClose={() => {}}>
+        <div data-testid="content">Should not appear</div>
+      </PlantSheet>,
+    )
+    expect(screen.queryByTestId('content')).not.toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('calls onClose when the drag-handle button is activated', () => {
+    const onClose = vi.fn()
+    render(
+      <PlantSheet show onClose={onClose}>
+        <div>body</div>
+      </PlantSheet>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when the backdrop is clicked', () => {
+    const onClose = vi.fn()
+    const { container } = render(
+      <PlantSheet show onClose={onClose}>
+        <div>body</div>
+      </PlantSheet>,
+    )
+    // Backdrop is the presentation div wrapping the dialog.
+    const backdrop = container.querySelector('.plant-sheet-backdrop')
+    expect(backdrop).not.toBeNull()
+    fireEvent.click(backdrop)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT call onClose when the sheet body is clicked (event stops propagation)', () => {
+    const onClose = vi.fn()
+    render(
+      <PlantSheet show onClose={onClose}>
+        <div data-testid="content">body</div>
+      </PlantSheet>,
+    )
+    fireEvent.click(screen.getByTestId('content'))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('closes on Escape key while the sheet is open', async () => {
+    const onClose = vi.fn()
+    render(
+      <PlantSheet show onClose={onClose}>
+        <div>body</div>
+      </PlantSheet>,
+    )
+    fireEvent.keyDown(window, { key: 'Escape' })
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+  })
+
+  it('locks body scroll while open and restores on unmount', () => {
+    document.body.style.overflow = 'auto'
+    const { unmount } = render(
+      <PlantSheet show onClose={() => {}}>
+        <div>body</div>
+      </PlantSheet>,
+    )
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe('auto')
+  })
+})

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -7,6 +7,8 @@ import WateringSheet from './WateringSheet.jsx'
 import SoilTab from './SoilTab.jsx'
 import LifecycleTab from './LifecycleTab.jsx'
 import BloomTab from './BloomTab.jsx'
+import PlantSheet from './PlantSheet.jsx'
+import { useMediaQuery } from '../hooks/useMediaQuery.js'
 import { imagesApi, recommendApi, plantsApi, analyseApi, measurementsApi, phenologyApi, journalApi, harvestApi, wildlifeApi, incidentApi, dormancyApi } from '../api/plants.js'
 import HardinessBadge from './HardinessBadge.jsx'
 import LuxMeterButton from './LuxMeterButton.jsx'
@@ -269,8 +271,21 @@ function DiagnosticUpload({ plantId, plant, onComplete }) {
   )
 }
 
+// Breakpoint for switching from the centred desktop modal to the mobile
+// bottom sheet (#401). 768px = Bootstrap `md` — keeps tablets on the modal.
+const MOBILE_SHEET_QUERY = '(max-width: 767px)'
+
+// Feature flag for #401 Phase 1 rollout. When this evaluates true AND the
+// viewport is below MOBILE_SHEET_QUERY, the non-embedded shell is the
+// Framer Motion bottom sheet rather than React-Bootstrap's modal.
+function isPlantSheetEnabled() {
+  try { return import.meta.env?.VITE_PLANT_MODAL_V2 === 'true' } catch { return false }
+}
+
 export default function PlantModal({ plant, position, floors, activeFloorId, weather, onSave, onDelete, onWater, onMoisture, onClose, embedded = false, initialTab, onTabChange, onDirtyChange }) {
   const isEditing = !!plant
+  const isMobile = useMediaQuery(MOBILE_SHEET_QUERY)
+  const useSheet = !embedded && isMobile && isPlantSheetEnabled()
   const [mode, setMode] = useState(() => (plant ? 'edit' : null))
   const [activeTab, setActiveTabInternal] = useState(initialTab || 'edit')
   const setActiveTab = useCallback((next) => {
@@ -2512,6 +2527,10 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
       <div className="modal-content position-relative shadow-sm plant-detail-shell" aria-labelledby="plant-modal-title">
         {innerContent}
       </div>
+    ) : useSheet ? (
+      <PlantSheet show onClose={handleClose} ariaLabelledBy="plant-modal-title">
+        {innerContent}
+      </PlantSheet>
     ) : (
       <Modal show onHide={handleClose} size="lg" centered scrollable fullscreen="sm-down" aria-labelledby="plant-modal-title">
         {innerContent}

--- a/src/components/PlantSheet.jsx
+++ b/src/components/PlantSheet.jsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useRef } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { DURATION, EASE, SPRING } from '../motion/tokens.js'
+
+// Mobile bottom-sheet shell for PlantModal V2 (#401 Phase 1).
+//
+// Renders children inside a sheet that slides up from the bottom edge. The
+// shell is responsible only for the surface (open / close / drag-to-dismiss /
+// backdrop / safe-area / scroll lock) — content composition stays inside
+// PlantModal so the desktop modal and the mobile sheet share one source of
+// truth for tabs, fields, and behaviour.
+//
+// PR-1 scope deliberately stops at single-stop open + drag-to-close. Multi-
+// snap points (50% / 90% / full), swipeable-tab gestures, and the sticky
+// footer split happen in follow-up PRs (#401 v2 / v3).
+export default function PlantSheet({ show, onClose, children, ariaLabelledBy }) {
+  const sheetRef = useRef(null)
+
+  // Body scroll lock while the sheet is open. We restore the previous value
+  // rather than blanking it, so a host page that uses overflow:hidden for its
+  // own reasons keeps its style after the sheet closes.
+  useEffect(() => {
+    if (!show) return undefined
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => { document.body.style.overflow = prev }
+  }, [show])
+
+  // Esc to close — matches the React-Bootstrap Modal contract callers expect.
+  useEffect(() => {
+    if (!show) return undefined
+    const onKey = (e) => { if (e.key === 'Escape') onClose?.() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [show, onClose])
+
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          className="plant-sheet-backdrop"
+          role="presentation"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: DURATION.normal, ease: EASE.out }}
+          onClick={onClose}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.45)',
+            zIndex: 1055,           // matches Bootstrap modal layer (DESIGN.md)
+            display: 'flex',
+            alignItems: 'flex-end',
+            justifyContent: 'center',
+          }}
+        >
+          <motion.div
+            ref={sheetRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={ariaLabelledBy}
+            className="plant-sheet"
+            initial={{ y: '100%' }}
+            animate={{ y: 0 }}
+            exit={{ y: '100%' }}
+            transition={SPRING}
+            // Drag-down to dismiss. Constrained to >= 0 so users can't pull
+            // the sheet upward past its open position. dragElastic gives a
+            // tiny rubber-band on overshoot.
+            drag="y"
+            dragConstraints={{ top: 0, bottom: 0 }}
+            dragElastic={{ top: 0, bottom: 0.4 }}
+            onDragEnd={(_, info) => {
+              const distance = info.offset.y
+              const velocity = info.velocity.y
+              // Dismiss if user dragged > 120px OR flicked downward fast.
+              if (distance > 120 || velocity > 600) onClose?.()
+            }}
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: '100%',
+              maxWidth: 720,
+              maxHeight: '90vh',
+              background: 'var(--bs-body-bg)',
+              borderTopLeftRadius: 16,
+              borderTopRightRadius: 16,
+              boxShadow: '0 -8px 24px rgba(0,0,0,0.2)',
+              paddingBottom: 'env(safe-area-inset-bottom)',
+              overflow: 'hidden',
+              display: 'flex',
+              flexDirection: 'column',
+              touchAction: 'pan-y',
+            }}
+          >
+            {/* Drag handle — visual affordance + tap target for keyboard
+                users who can press Enter on it to fire close. */}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="plant-sheet-handle"
+              style={{
+                appearance: 'none',
+                border: 0,
+                background: 'transparent',
+                padding: '10px 0 6px',
+                margin: 0,
+                cursor: 'grab',
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  display: 'block',
+                  width: 40,
+                  height: 4,
+                  borderRadius: 2,
+                  margin: '0 auto',
+                  background: 'var(--bs-border-color)',
+                }}
+              />
+            </button>
+
+            <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+              {children}
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/hooks/useMediaQuery.js
+++ b/src/hooks/useMediaQuery.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+
+// Subscribes to a CSS media query. Returns `false` during SSR / jsdom.
+// Default-false on first paint avoids hydration flicker for content that
+// should only appear on small screens — the post-mount effect upgrades to
+// the real value within one tick.
+export function useMediaQuery(query) {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false
+    return window.matchMedia(query).matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return undefined
+    const mq = window.matchMedia(query)
+    const handler = (e) => setMatches(e.matches)
+    setMatches(mq.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [query])
+
+  return matches
+}


### PR DESCRIPTION
## Summary

First PR of the #401 multi-PR redesign. Sets up the shell + breakpoint plumbing so subsequent PRs can migrate tab content into mobile-first layouts without disturbing the desktop modal. **Dark behind \`VITE_PLANT_MODAL_V2\`** — flag defaults off so production is unchanged.

## What ships

- **\`PlantSheet.jsx\`** — Framer Motion bottom-sheet wrapper: backdrop, drag-to-dismiss, Esc-to-close, body-scroll lock with restore, \`env(safe-area-inset-bottom)\`, \`role="dialog"\`+\`aria-modal\`+\`aria-labelledby\` preserved to match the React-Bootstrap Modal contract.
- **\`useMediaQuery.js\`** — minimal \`matchMedia\` subscription, SSR-safe default-false.
- **PlantModal wiring** — non-embedded shell renders \`<PlantSheet>\` when viewport \`<768px\` AND \`VITE_PLANT_MODAL_V2 === 'true'\`. Otherwise unchanged (centred Modal on ≥ 768px, fullscreen Modal on <576px). \`embedded\` mode (PlantDetailPage) untouched.

## What's deliberately deferred to follow-up PRs

| Out of scope here | Why |
|---|---|
| Multi-snap points (50% / 90% / full) | Polish; shell needs only one stop for v1 |
| Swipeable tabs (drag-between) | Belongs with the tab-layout migration PR |
| Sticky-footer CTA restructure | Per-tab work, needs tab body changes |
| \`PlantModal.test.jsx\` index → semantic queries | Touches 107 passing tests; cleaner as its own PR alongside the test rewrite |

## Test plan

- [x] 7 new \`PlantSheet.test.jsx\` cases pass (render gating, all close paths, scroll-lock+restore)
- [x] All 107 existing \`PlantModal.test.jsx\` tests still green (flag off)
- [x] \`npm run preflight:fast\` clean
- [ ] After merge: manually open a plant on a <768px viewport with \`VITE_PLANT_MODAL_V2=true\` in \`.env.local\` → sheet slides up, drag-down dismisses, Esc dismisses, backdrop tap dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)