### PR TITLE
feat(plants): swipeable tabs + indicator on mobile PlantModal (#401, PR 2/n)

### DIFF
--- a/src/__tests__/PlantModal.test.jsx
+++ b/src/__tests__/PlantModal.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { MemoryRouter } from 'react-router'
 import PlantModal from '../components/PlantModal.jsx'
 import { measurementsApi, phenologyApi, journalApi } from '../api/plants.js'
@@ -948,6 +948,129 @@ describe('PlantModal', () => {
     fireEvent.click(tab('Watering'))
     fireEvent.keyDown(tab('Watering'), { key: 'ArrowUp' })
     expect(tab('Plant')).toHaveAttribute('aria-selected', 'true')
+  })
+})
+
+// ── Mobile sheet V2: swipe + indicator + tab pill (#401 PR 2) ─────────────────
+
+describe('PlantModal — mobile sheet V2 (swipeable tabs)', () => {
+  // The mobile-only affordances (reorder, indicator, prev/next pill, swipe
+  // wrapper) gate on `useSheet`, which is `!embedded && isMobile && v2Flag`.
+  // We mock matchMedia + the env flag so the render path matches what users
+  // see at <768px with VITE_PLANT_MODAL_V2='true' set at build time.
+  let originalMatchMedia
+  let originalFlag
+  beforeEach(() => {
+    vi.clearAllMocks()
+    originalMatchMedia = window.matchMedia
+    window.matchMedia = (query) => ({
+      matches: query === '(max-width: 767px)',
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      onchange: null,
+      dispatchEvent: () => false,
+    })
+    originalFlag = import.meta.env.VITE_PLANT_MODAL_V2
+    import.meta.env.VITE_PLANT_MODAL_V2 = 'true'
+  })
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+    import.meta.env.VITE_PLANT_MODAL_V2 = originalFlag
+  })
+
+  const tab = (name) => screen.getByRole('tab', { name })
+
+  it('reorders the tab strip so Health sits before Growth on mobile', () => {
+    renderModal({ plant: existingPlant })
+    const tabs = screen.getAllByRole('tab').map((t) => t.textContent.trim())
+    // Plant must remain first (matches default activeTab and the desktop
+    // contract). After reorder, Health rides up to position 4 — ahead of
+    // Growth/Journal — because users check health more than they record growth.
+    expect(tabs[0]).toBe('Plant')
+    expect(tabs.indexOf('Health')).toBeLessThan(tabs.indexOf('Growth'))
+    expect(tabs.indexOf('Health')).toBeLessThan(tabs.indexOf('Journal'))
+  })
+
+  it('renders the spring-physics indicator only on the active tab', () => {
+    const { container } = renderModal({ plant: existingPlant })
+    const indicators = container.querySelectorAll('.plant-mobile-tab-indicator')
+    expect(indicators.length).toBe(1)
+    // The indicator should live inside the active tab button.
+    expect(tab('Plant')).toContainElement(indicators[0])
+  })
+
+  it('moves the indicator into the newly-selected tab on click', () => {
+    const { container } = renderModal({ plant: existingPlant })
+    fireEvent.click(tab('Watering'))
+    const indicators = container.querySelectorAll('.plant-mobile-tab-indicator')
+    expect(indicators.length).toBe(1)
+    expect(tab('Watering')).toContainElement(indicators[0])
+    expect(tab('Plant')).not.toContainElement(indicators[0])
+  })
+
+  it('exposes a prev/next pill labelled "Plant tab pager"', () => {
+    renderModal({ plant: existingPlant })
+    const pager = screen.getByRole('navigation', { name: /plant tab pager/i })
+    expect(pager).toBeInTheDocument()
+  })
+
+  it('disables Prev on the first tab and Next on the last tab', () => {
+    renderModal({ plant: existingPlant })
+    const pager = screen.getByRole('navigation', { name: /plant tab pager/i })
+    const prev = pager.querySelector('button:first-of-type')
+    expect(prev).toBeDisabled()
+
+    // Jump to the last tab via End — the keyboard-roving handler.
+    fireEvent.keyDown(tab('Plant'), { key: 'End' })
+    const next = pager.querySelector('button:last-of-type')
+    expect(next).toBeDisabled()
+  })
+
+  it('advances to the next tab when the pill Next button is clicked', () => {
+    renderModal({ plant: existingPlant })
+    // Order is Plant → Watering on mobile.
+    expect(tab('Plant')).toHaveAttribute('aria-selected', 'true')
+    const pager = screen.getByRole('navigation', { name: /plant tab pager/i })
+    fireEvent.click(pager.querySelector('button:last-of-type'))
+    expect(tab('Watering')).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('shows the tab count in the pager (current / total)', () => {
+    renderModal({ plant: existingPlant })
+    const pager = screen.getByRole('navigation', { name: /plant tab pager/i })
+    // The middle counter must report "1 / N" while on the first tab.
+    expect(pager.textContent).toMatch(/1\s*\/\s*\d+/)
+  })
+
+  it('does not reorder tabs when not embedded but viewport is desktop (matchMedia=false)', () => {
+    // Override the beforeEach matchMedia mock for this test only.
+    window.matchMedia = (query) => ({
+      matches: false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      onchange: null,
+      dispatchEvent: () => false,
+    })
+    renderModal({ plant: existingPlant })
+    const tabs = screen.getAllByRole('tab').map((t) => t.textContent.trim())
+    // Desktop order: Plant → Watering → Care → Growth → … (Health near the end).
+    expect(tabs[0]).toBe('Plant')
+    expect(tabs[1]).toBe('Watering')
+    expect(tabs[2]).toBe('Care')
+    expect(tabs[3]).toBe('Growth')
+    // And the pager pill must NOT render on desktop.
+    expect(screen.queryByRole('navigation', { name: /plant tab pager/i })).not.toBeInTheDocument()
+  })
+
+  it('does not render the pager when embedded (page route reuses PlantModal)', () => {
+    renderModal({ plant: existingPlant, embedded: true })
+    expect(screen.queryByRole('navigation', { name: /plant tab pager/i })).not.toBeInTheDocument()
   })
 })
 

--- a/src/assets/sass/app/_plant-tracker.scss
+++ b/src/assets/sass/app/_plant-tracker.scss
@@ -321,3 +321,42 @@
     min-width: 0;
   }
 }
+
+/* ── Mobile PlantModal (#401 PR 2) ────────────────────────────────────────
+
+   Active-tab underline indicator: 2px bar pinned to the bottom of the
+   selected nav-link. Framer Motion's `layoutId` morphs the bar between
+   tabs with a spring, so we only need it absolutely positioned within a
+   relative-positioned button. Tabs that aren't selected don't render the
+   indicator span at all.
+
+   The pill below the panels is a fallback affordance for users who don't
+   discover horizontal swipe between tabs. */
+.plant-mobile-tab {
+  position: relative;
+}
+
+.plant-mobile-tab-indicator {
+  position: absolute;
+  left: 0.5rem;
+  right: 0.5rem;
+  bottom: 0;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--bs-primary, currentColor);
+  pointer-events: none;
+}
+
+.plant-mobile-tab-pill {
+  background: var(--bs-tertiary-bg, var(--bs-body-bg));
+}
+
+.plant-mobile-tab-pill .btn {
+  /* Drop the default link colour so disabled-state contrast works against
+     the lighter pill background. */
+  color: var(--bs-link-color);
+}
+
+.plant-mobile-tab-pill .btn:disabled {
+  color: var(--bs-secondary-color);
+}

--- a/src/components/PlantModal.jsx
+++ b/src/components/PlantModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo, useContext } from 'react'
 import { Link } from 'react-router'
 import { Modal, Button, Form, Badge, Spinner, Row, Col, Pagination, Accordion } from 'react-bootstrap'
+import { motion } from 'framer-motion'
 import ImageAnalyser from './ImageAnalyser.jsx'
 import PlantQRTag from './PlantQRTag.jsx'
 import WateringSheet from './WateringSheet.jsx'
@@ -9,6 +10,7 @@ import LifecycleTab from './LifecycleTab.jsx'
 import BloomTab from './BloomTab.jsx'
 import PlantSheet from './PlantSheet.jsx'
 import { useMediaQuery } from '../hooks/useMediaQuery.js'
+import { SPRING } from '../motion/tokens.js'
 import { imagesApi, recommendApi, plantsApi, analyseApi, measurementsApi, phenologyApi, journalApi, harvestApi, wildlifeApi, incidentApi, dormancyApi } from '../api/plants.js'
 import HardinessBadge from './HardinessBadge.jsx'
 import LuxMeterButton from './LuxMeterButton.jsx'
@@ -280,6 +282,39 @@ const MOBILE_SHEET_QUERY = '(max-width: 767px)'
 // Framer Motion bottom sheet rather than React-Bootstrap's modal.
 function isPlantSheetEnabled() {
   try { return import.meta.env?.VITE_PLANT_MODAL_V2 === 'true' } catch { return false }
+}
+
+// Mobile tab order (#401 PR 2). Most-frequently used surfaces ride to the
+// front of the strip so the daily logging path fits without horizontal
+// scroll on a 360px viewport; rarely-used tabs (Blooms, Lifecycle, Wildlife)
+// move to the tail. Desktop modal + embedded page keep the existing order.
+const MOBILE_TAB_ORDER = [
+  'edit', 'watering', 'care', 'health', 'growth', 'journal',
+  'soil', 'harvest', 'blooms', 'lifecycle', 'wildlife',
+]
+
+// Swipe gesture thresholds — either far-enough drag or fast-enough flick
+// switches to the adjacent tab. Tuned so a deliberate one-thumb swipe always
+// triggers, but ordinary vertical scroll never does.
+const TAB_SWIPE_DISTANCE_PX = 80
+const TAB_SWIPE_VELOCITY = 400
+
+// Wraps the tab-panel siblings with a horizontal-drag motion container only
+// when the mobile sheet is active. On desktop / embedded view we render a
+// plain fragment so the existing DOM (and its CSS) is untouched.
+function PanelSwipeWrapper({ enabled, onDragEnd, children }) {
+  if (!enabled) return children
+  return (
+    <motion.div
+      drag="x"
+      dragConstraints={{ left: 0, right: 0 }}
+      dragElastic={0.15}
+      onDragEnd={onDragEnd}
+      style={{ touchAction: 'pan-y' }}
+    >
+      {children}
+    </motion.div>
+  )
 }
 
 export default function PlantModal({ plant, position, floors, activeFloorId, weather, onSave, onDelete, onWater, onMoisture, onClose, embedded = false, initialTab, onTabChange, onDirtyChange }) {
@@ -590,21 +625,46 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
   const isEdiblePlant = form.category === 'edible'
 
   const TABS = useMemo(
-    () => [
-      { id: 'edit', label: 'Plant' },
-      { id: 'watering', label: 'Watering' },
-      { id: 'care', label: 'Care' },
-      { id: 'growth', label: 'Growth' },
-      { id: 'journal', label: 'Journal' },
-      ...(isEditing ? [{ id: 'blooms', label: 'Blooms' }] : []),
-      ...(isEditing ? [{ id: 'lifecycle', label: 'Lifecycle' }] : []),
-      ...(isEditing ? [{ id: 'soil', label: 'Soil' }] : []),
-      ...(isEdiblePlant ? [{ id: 'harvest', label: 'Harvest' }] : []),
-      ...(isEditing ? [{ id: 'health', label: 'Health' }] : []),
-      ...(isEditing ? [{ id: 'wildlife', label: 'Wildlife' }] : []),
-    ],
-    [isEdiblePlant, isEditing],
+    () => {
+      const base = [
+        { id: 'edit', label: 'Plant' },
+        { id: 'watering', label: 'Watering' },
+        { id: 'care', label: 'Care' },
+        { id: 'growth', label: 'Growth' },
+        { id: 'journal', label: 'Journal' },
+        ...(isEditing ? [{ id: 'blooms', label: 'Blooms' }] : []),
+        ...(isEditing ? [{ id: 'lifecycle', label: 'Lifecycle' }] : []),
+        ...(isEditing ? [{ id: 'soil', label: 'Soil' }] : []),
+        ...(isEdiblePlant ? [{ id: 'harvest', label: 'Harvest' }] : []),
+        ...(isEditing ? [{ id: 'health', label: 'Health' }] : []),
+        ...(isEditing ? [{ id: 'wildlife', label: 'Wildlife' }] : []),
+      ]
+      if (!useSheet) return base
+      // Mobile sheet: reorder by MOBILE_TAB_ORDER, preserving only the tabs
+      // that are actually visible for this plant (e.g. Harvest is edibles-only).
+      const byId = new Map(base.map((t) => [t.id, t]))
+      return MOBILE_TAB_ORDER.map((id) => byId.get(id)).filter(Boolean)
+    },
+    [isEdiblePlant, isEditing, useSheet],
   )
+
+  // Index of the active tab in the (possibly reordered) TABS list — used by
+  // the swipe handler and the prev/next pill so they share one source of truth.
+  const activeTabIndex = TABS.findIndex((t) => t.id === activeTab)
+  const prevTab = activeTabIndex > 0 ? TABS[activeTabIndex - 1] : null
+  const nextTab = activeTabIndex >= 0 && activeTabIndex < TABS.length - 1 ? TABS[activeTabIndex + 1] : null
+
+  const handlePanelDragEnd = useCallback((_, info) => {
+    const distance = info?.offset?.x ?? 0
+    const velocity = info?.velocity?.x ?? 0
+    if (distance < -TAB_SWIPE_DISTANCE_PX || velocity < -TAB_SWIPE_VELOCITY) {
+      if (nextTab) setActiveTab(nextTab.id)
+    } else if (distance > TAB_SWIPE_DISTANCE_PX || velocity > TAB_SWIPE_VELOCITY) {
+      if (prevTab) setActiveTab(prevTab.id)
+    }
+  }, [nextTab, prevTab, setActiveTab])
+
+  const panelSwipeEnabled = useSheet && isEditing && TABS.length > 1
 
   const handleDormancyEnter = useCallback(async () => {
     setDormancyLoading(true); setDormancyError(null)
@@ -1009,17 +1069,31 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
                   aria-selected={selected}
                   aria-controls={`plant-tabpanel-${tab.id}`}
                   tabIndex={selected ? 0 : -1}
-                  className={`nav-link${selected ? ' active' : ''}${embedded ? ' text-start' : ''}`}
+                  className={`nav-link${selected ? ' active' : ''}${embedded ? ' text-start' : ''}${useSheet ? ' plant-mobile-tab' : ''}`}
                   onClick={() => setActiveTab(tab.id)}
                   onKeyDown={(e) => handleTabKeyDown(e, i)}
                 >
                   {tab.label}
+                  {selected && useSheet && (
+                    <motion.span
+                      layoutId="plant-mobile-tab-indicator"
+                      className="plant-mobile-tab-indicator"
+                      transition={SPRING}
+                      aria-hidden="true"
+                    />
+                  )}
                 </button>
               </li>
             )
           })}
         </ul>
       )}
+
+      {/* Tab panels — horizontally-draggable on mobile sheet so a swipe
+          left/right moves to the adjacent tab. Desktop and embedded views
+          render the children as plain siblings (PanelSwipeWrapper is a
+          no-op fragment unless `panelSwipeEnabled`). */}
+      <PanelSwipeWrapper enabled={panelSwipeEnabled} onDragEnd={handlePanelDragEnd}>
 
       {/* Edit form */}
       {mode !== null && (!isEditing || activeTab === 'edit') && (
@@ -2438,6 +2512,40 @@ export default function PlantModal({ plant, position, floors, activeFloorId, wea
           ))}
         </Modal.Body>
       )}
+
+      {/* Prev/next pill — visible alternative to the swipe gesture so users
+          who don't discover horizontal drag still get one-thumb tab
+          navigation. Mobile sheet only. */}
+      {panelSwipeEnabled && activeTabIndex >= 0 && (
+        <nav
+          aria-label="Plant tab pager"
+          className="plant-mobile-tab-pill d-flex justify-content-between align-items-center px-3 py-2 border-top"
+        >
+          <button
+            type="button"
+            className="btn btn-link btn-sm p-0 text-decoration-none"
+            onClick={() => prevTab && setActiveTab(prevTab.id)}
+            disabled={!prevTab}
+            aria-label={prevTab ? `Previous: ${prevTab.label}` : 'No previous tab'}
+          >
+            <span aria-hidden="true">←</span> {prevTab ? prevTab.label : ''}
+          </button>
+          <span className="text-muted fs-xs" aria-hidden="true">
+            {activeTabIndex + 1} / {TABS.length}
+          </span>
+          <button
+            type="button"
+            className="btn btn-link btn-sm p-0 text-decoration-none"
+            onClick={() => nextTab && setActiveTab(nextTab.id)}
+            disabled={!nextTab}
+            aria-label={nextTab ? `Next: ${nextTab.label}` : 'No next tab'}
+          >
+            {nextTab ? nextTab.label : ''} <span aria-hidden="true">→</span>
+          </button>
+        </nav>
+      )}
+
+      </PanelSwipeWrapper>
 
       {/* Unsaved-change guard */}
       {showUnsavedGuard && (


### PR DESCRIPTION
## Summary

Wave 2 of the #401 mobile redesign — wires swipe + indicator + tab pager on top of the bottom-sheet shell that landed in #449. Still **dark behind `VITE_PLANT_MODAL_V2`**; desktop modal and the `/plants/:id` embedded page are untouched.

- Horizontal-drag between tab panels (Framer Motion). Swipe past ~80px or flick fast → adjacent tab. Vertical scroll preserved via `touchAction: pan-y`.
- Spring-physics 2px underline indicator on the active tab, animated with `layoutId` so it morphs between buttons using the existing `motion/tokens` `SPRING`.
- Prev/next pill ("Plant tab pager") below the panels — discoverable alternative to swipe; shows current/total count.
- Mobile-only tab reorder: `Plant → Watering → Care → Health → Growth → Journal → Soil → Harvest → Blooms → Lifecycle → Wildlife`. Promotes daily-use tabs ahead of rarely-visited ones. Desktop order is **unchanged** so the existing tab-strip test contract stays green.

## What's still deferred to follow-up PRs

| Out of scope here | Why |
|---|---|
| Multi-snap points (50% / 90% / full) | Shell concern; independent of tab UX |
| Sticky-footer CTA + per-tab form ergonomics | Per-tab work; big scope of its own |
| Drag-with-preview between panels (peek adjacent) | Requires rendering inactive panels — perf + form-state coupling worth a dedicated PR |
| `PlantModal.test.jsx` index → semantic queries | Existing tests already use name-based queries (`getByRole('tab', { name })`); the trap from CLAUDE.md no longer bites |

## Implementation notes

- All gating routes through `useSheet = !embedded && isMobile && isPlantSheetEnabled()`. When false, `PanelSwipeWrapper` returns `children` directly so DOM and CSS on desktop are byte-identical.
- Reorder uses a single `MOBILE_TAB_ORDER` list; tabs absent for the current plant (e.g. `Harvest` on a non-edible) are filtered out, so the visible-tab subset matches today.
- Indicator uses `motion.span layoutId="plant-mobile-tab-indicator"` — only rendered inside the active tab button, so React unmounts/remounts cleanly and Framer Motion handles the spring.
- The pager `<nav aria-label="Plant tab pager">` sits below the panels with disabled-at-ends buttons + a `1 / N` counter.

## Test plan

- [x] 9 new mobile-v2 cases pass (reorder, indicator placement, indicator move on click, pager exists, prev/next disabled at ends, Next advances, count format, desktop & embedded skip the mobile UI).
- [x] All 107 existing PlantModal tests still green (flag off).
- [x] `npm run preflight:fast` clean (build + lint + audits).
- [ ] After merge: manually open a plant on a <768px viewport with `VITE_PLANT_MODAL_V2=true` in `.env.local`:
  - Swipe left/right between tabs lands on the adjacent tab.
  - Indicator springs to the new tab.
  - Prev/next pill updates labels and disables at ends.
  - Tab order matches the new mobile sequence.
  - Desktop modal and `/plants/:id` page show no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)