### PR TITLE
feat(plants): multi-snap PlantSheet — 50% / 90% / 100% (#401, PR 3/n)

### DIFF
--- a/src/__tests__/PlantSheet.test.jsx
+++ b/src/__tests__/PlantSheet.test.jsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
-import PlantSheet from '../components/PlantSheet.jsx'
+import PlantSheet, {
+  SNAP_PCT,
+  DEFAULT_SNAP_INDEX,
+  nextSnapFromDrag,
+} from '../components/PlantSheet.jsx'
 
 describe('PlantSheet (#401 PR 1)', () => {
   it('renders children inside a role="dialog" with aria-modal when show=true', () => {
@@ -84,5 +88,112 @@ describe('PlantSheet (#401 PR 1)', () => {
     expect(document.body.style.overflow).toBe('hidden')
     unmount()
     expect(document.body.style.overflow).toBe('auto')
+  })
+})
+
+describe('PlantSheet — multi-snap (#401 PR 3)', () => {
+  it('exposes three snap points: 50% / 90% / 100%', () => {
+    expect(SNAP_PCT).toEqual([50, 90, 100])
+    // Default opens to 90% — the middle stop matches the original PR 1
+    // behaviour, so users who never drag perceive no change.
+    expect(SNAP_PCT[DEFAULT_SNAP_INDEX]).toBe(90)
+  })
+
+  it('renders at the 90% snap by default when opened', () => {
+    const { container } = render(
+      <PlantSheet show onClose={() => {}}>
+        <div>body</div>
+      </PlantSheet>,
+    )
+    expect(container.querySelector('.plant-sheet')).toHaveAttribute('data-snap-pct', '90')
+  })
+
+  it('resets to the 90% snap each time the sheet re-opens', () => {
+    // Render closed, then open, then close, then re-open. The data-snap-pct
+    // attribute must always read 90 on a fresh open — otherwise the user's
+    // last drag would leak across sessions.
+    const { rerender, container } = render(
+      <PlantSheet show={false} onClose={() => {}}>
+        <div>body</div>
+      </PlantSheet>,
+    )
+    rerender(
+      <PlantSheet show onClose={() => {}}>
+        <div>body</div>
+      </PlantSheet>,
+    )
+    expect(container.querySelector('.plant-sheet')).toHaveAttribute('data-snap-pct', '90')
+
+    rerender(
+      <PlantSheet show={false} onClose={() => {}}>
+        <div>body</div>
+      </PlantSheet>,
+    )
+    rerender(
+      <PlantSheet show onClose={() => {}}>
+        <div>body</div>
+      </PlantSheet>,
+    )
+    expect(container.querySelector('.plant-sheet')).toHaveAttribute('data-snap-pct', '90')
+  })
+
+  // ── nextSnapFromDrag — pure decision helper ──────────────────────────────
+  // jsdom can't simulate a real pointer drag, so the snap logic is hoisted
+  // into a pure helper and exhaustively branch-covered here.
+
+  describe('nextSnapFromDrag', () => {
+    it('does nothing when neither distance nor velocity crosses the threshold', () => {
+      expect(nextSnapFromDrag({ currentSnap: 1, distance: 30, velocity: 100 }))
+        .toEqual({ snap: 1 })
+      expect(nextSnapFromDrag({ currentSnap: 1, distance: -30, velocity: -100 }))
+        .toEqual({ snap: 1 })
+    })
+
+    it('drags down → shrinks one snap level', () => {
+      expect(nextSnapFromDrag({ currentSnap: 2, distance: 120, velocity: 0 }))
+        .toEqual({ snap: 1 })
+      expect(nextSnapFromDrag({ currentSnap: 1, distance: 120, velocity: 0 }))
+        .toEqual({ snap: 0 })
+    })
+
+    it('fast downward flick → shrinks even with small distance', () => {
+      expect(nextSnapFromDrag({ currentSnap: 2, distance: 10, velocity: 900 }))
+        .toEqual({ snap: 1 })
+    })
+
+    it('drags down past the lowest snap → closes', () => {
+      expect(nextSnapFromDrag({ currentSnap: 0, distance: 200, velocity: 0 }))
+        .toEqual({ close: true })
+      expect(nextSnapFromDrag({ currentSnap: 0, distance: 0, velocity: 900 }))
+        .toEqual({ close: true })
+    })
+
+    it('drags up → grows one snap level', () => {
+      expect(nextSnapFromDrag({ currentSnap: 0, distance: -120, velocity: 0 }))
+        .toEqual({ snap: 1 })
+      expect(nextSnapFromDrag({ currentSnap: 1, distance: -120, velocity: 0 }))
+        .toEqual({ snap: 2 })
+    })
+
+    it('fast upward flick → grows even with small distance', () => {
+      expect(nextSnapFromDrag({ currentSnap: 0, distance: -10, velocity: -900 }))
+        .toEqual({ snap: 1 })
+    })
+
+    it('drags up at the top snap → stays at top (capped)', () => {
+      expect(nextSnapFromDrag({ currentSnap: 2, distance: -200, velocity: 0 }))
+        .toEqual({ snap: 2 })
+    })
+
+    it('honours custom thresholds for unit-test tuning', () => {
+      // Tight threshold: 30px of drag is enough to trigger.
+      expect(nextSnapFromDrag({
+        currentSnap: 1, distance: 40, velocity: 0, distanceThreshold: 30,
+      })).toEqual({ snap: 0 })
+      // Loose threshold: 100px doesn't cross.
+      expect(nextSnapFromDrag({
+        currentSnap: 1, distance: 100, velocity: 0, distanceThreshold: 200,
+      })).toEqual({ snap: 1 })
+    })
   })
 })

--- a/src/components/PlantSheet.jsx
+++ b/src/components/PlantSheet.jsx
@@ -1,24 +1,91 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { DURATION, EASE, SPRING } from '../motion/tokens.js'
 
-// Mobile bottom-sheet shell for PlantModal V2 (#401 Phase 1).
+// Mobile bottom-sheet shell for PlantModal V2 (#401).
 //
-// Renders children inside a sheet that slides up from the bottom edge. The
-// shell is responsible only for the surface (open / close / drag-to-dismiss /
-// backdrop / safe-area / scroll lock) — content composition stays inside
-// PlantModal so the desktop modal and the mobile sheet share one source of
-// truth for tabs, fields, and behaviour.
+// PR 1 (#449) shipped the single-stop slide-up + drag-to-dismiss surface.
+// PR 3 (this file) adds three snap stops — 50% / 90% / 100% — so the user
+// can pull the sheet up to fullscreen for forms with long content, snap
+// back to a half-height peek to see the floorplan behind, or flick away to
+// dismiss. Snap heights are issued in the original #401 spec.
 //
-// PR-1 scope deliberately stops at single-stop open + drag-to-close. Multi-
-// snap points (50% / 90% / full), swipeable-tab gestures, and the sticky
-// footer split happen in follow-up PRs (#401 v2 / v3).
+// Implementation: the sheet is rendered at full viewport height and
+// position:absolute / bottom:0. A vertical y motion-value translates the
+// sheet *down*, exposing more of the backdrop above it as snaps decrease.
+// We avoid animating CSS height because that triggers layout reflow on
+// every spring frame; translating y is GPU-cheap.
+
+export const SNAP_PCT = [50, 90, 100]
+export const DEFAULT_SNAP_INDEX = 1 // 90%
+
+// Pure decision helper for what to do at drag-end. Exported so tests can
+// cover every branch without simulating a real pointer drag in jsdom.
+//
+// `distance` is the total y offset (px) from the drag start; `velocity` is
+// the instantaneous y velocity (px/s) at release. Positive = downward.
+//
+// Returns `{ close: true }` when the user has dragged the sheet below the
+// lowest snap (50%), otherwise `{ snap: <new index> }` (which may equal
+// `currentSnap` when neither threshold is crossed — the spring then pulls
+// the element back to its resting position).
+export function nextSnapFromDrag({
+  currentSnap,
+  distance,
+  velocity,
+  totalSnaps = SNAP_PCT.length,
+  distanceThreshold = 80,
+  velocityThreshold = 600,
+}) {
+  // Downward drag/flick → shrink one stop, or close if already at the
+  // lowest stop.
+  if (distance > distanceThreshold || velocity > velocityThreshold) {
+    if (currentSnap === 0) return { close: true }
+    return { snap: currentSnap - 1 }
+  }
+  // Upward drag/flick → grow one stop, capped at the top.
+  if (distance < -distanceThreshold || velocity < -velocityThreshold) {
+    return { snap: Math.min(currentSnap + 1, totalSnaps - 1) }
+  }
+  // Neither threshold met — caller animates back to the current rest snap.
+  return { snap: currentSnap }
+}
+
 export default function PlantSheet({ show, onClose, children, ariaLabelledBy }) {
   const sheetRef = useRef(null)
+  const [snap, setSnap] = useState(DEFAULT_SNAP_INDEX)
+
+  // Reset to the default 90% snap on each open. Persisting the user's last
+  // snap across opens hides info (e.g. the floorplan) that the close
+  // gesture was meant to reveal — fresh open should always land at the
+  // default surface.
+  useEffect(() => {
+    if (show) setSnap(DEFAULT_SNAP_INDEX)
+  }, [show])
+
+  // Track the live viewport height so snap targets recompute on rotate /
+  // resize. SSR fallback keeps Framer Motion's pre-mount maths sane.
+  const [viewportH, setViewportH] = useState(() =>
+    typeof window === 'undefined' ? 800 : window.innerHeight,
+  )
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    const onResize = () => setViewportH(window.innerHeight)
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
+  // Pixel offset for snap index `s`. y=0 = sheet covers full viewport;
+  // larger y pushes the sheet's top edge further down, revealing more
+  // backdrop.
+  const snapToY = useCallback(
+    (s) => ((100 - SNAP_PCT[s]) * viewportH) / 100,
+    [viewportH],
+  )
 
   // Body scroll lock while the sheet is open. We restore the previous value
-  // rather than blanking it, so a host page that uses overflow:hidden for its
-  // own reasons keeps its style after the sheet closes.
+  // rather than blanking it, so a host page that uses overflow:hidden for
+  // its own reasons keeps its style after the sheet closes.
   useEffect(() => {
     if (!show) return undefined
     const prev = document.body.style.overflow
@@ -33,6 +100,18 @@ export default function PlantSheet({ show, onClose, children, ariaLabelledBy }) 
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [show, onClose])
+
+  const handleDragEnd = useCallback((_, info) => {
+    const decision = nextSnapFromDrag({
+      currentSnap: snap,
+      distance: info.offset.y,
+      velocity: info.velocity.y,
+    })
+    if (decision.close) { onClose?.(); return }
+    if (decision.snap !== snap) setSnap(decision.snap)
+    // If decision.snap === snap, the `animate` prop's spring will pull the
+    // element back to its rest position automatically — no setState needed.
+  }, [snap, onClose])
 
   return (
     <AnimatePresence>
@@ -61,27 +140,30 @@ export default function PlantSheet({ show, onClose, children, ariaLabelledBy }) 
             aria-modal="true"
             aria-labelledby={ariaLabelledBy}
             className="plant-sheet"
-            initial={{ y: '100%' }}
-            animate={{ y: 0 }}
-            exit={{ y: '100%' }}
+            data-snap-pct={SNAP_PCT[snap]}
+            initial={{ y: viewportH }}
+            animate={{ y: snapToY(snap) }}
+            exit={{ y: viewportH }}
             transition={SPRING}
-            // Drag-down to dismiss. Constrained to >= 0 so users can't pull
-            // the sheet upward past its open position. dragElastic gives a
-            // tiny rubber-band on overshoot.
+            // Drag is constrained to [0, viewportH]: 0 = fully open at top
+            // of the viewport, viewportH = fully off-screen below. The
+            // snap decision in onDragEnd picks the resting position; we
+            // give a touch of elastic past the top edge so the user feels
+            // a soft wall rather than a hard stop.
             drag="y"
-            dragConstraints={{ top: 0, bottom: 0 }}
-            dragElastic={{ top: 0, bottom: 0.4 }}
-            onDragEnd={(_, info) => {
-              const distance = info.offset.y
-              const velocity = info.velocity.y
-              // Dismiss if user dragged > 120px OR flicked downward fast.
-              if (distance > 120 || velocity > 600) onClose?.()
-            }}
+            dragConstraints={{ top: 0, bottom: viewportH }}
+            dragElastic={{ top: 0.1, bottom: 0.3 }}
+            onDragEnd={handleDragEnd}
             onClick={(e) => e.stopPropagation()}
             style={{
+              position: 'absolute',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              margin: '0 auto',
               width: '100%',
               maxWidth: 720,
-              maxHeight: '90vh',
+              height: '100vh',
               background: 'var(--bs-body-bg)',
               borderTopLeftRadius: 16,
               borderTopRightRadius: 16,


### PR DESCRIPTION
## Summary

Wave 3 of the #401 mobile redesign — the bottom-sheet shell now supports three snap stops so the user can:

- pull the sheet up to **100%** (fullscreen) for forms with long content,
- keep the default **90%** peek (matches PR 1's single-stop behaviour, so nothing changes for users who never drag),
- shrink to a **50%** half-sheet that lets the floorplan show through behind,
- or drag past 50% to dismiss (same gesture as PR 1).

Still **dark behind `VITE_PLANT_MODAL_V2`**; desktop modal and the embedded `/plants/:id` page are unaffected.

## Mechanics

- Sheet renders at `height: 100vh` pinned `bottom:0`; a `y` motion-value translates the top edge down to reveal more backdrop as snaps shrink. Animating transform instead of CSS height keeps the spring GPU-bound and avoids layout reflow each frame.
- Drag-end decision lives in an exported `nextSnapFromDrag()` helper — branch-covered in tests so the snap logic is proven without simulating a real pointer drag in jsdom. Thresholds: 80px distance or 600 px/s flick velocity.
- Snap resets to the default 90% on every open — a previous session's drag should not leak across opens.
- Viewport height is tracked via a resize listener so rotate / PiP resize recomputes snap targets in pixels.

## What's still deferred

| Out of scope here | Why |
|---|---|
| Sticky-footer CTA + per-tab form ergonomics | Per-tab work — biggest UX win still to come |
| Drag-with-preview between tab panels | Couples form-state across panels; needs its own PR |
| Snap-aware content (e.g. compact list at 50%, full at 100%) | Polish |

## Test plan

- [x] 11 new PlantSheet cases pass (snap shape, default-open at 90%, reset-on-reopen, eight `nextSnapFromDrag` branches).
- [x] All 7 existing PlantSheet tests still green.
- [x] All 116 PlantModal tests still green (Wave 2 untouched).
- [x] `npm run preflight:fast` clean (lint + audits + build).
- [ ] After merge: manually open a plant on a <768px viewport with `VITE_PLANT_MODAL_V2=true` in `.env.local`:
  - Opens at 90%.
  - Drag-up past 80px → snaps to 100%, sheet covers viewport.
  - Drag-down past 80px from 100% → snaps to 90%.
  - Drag-down past 80px from 90% → snaps to 50%, floorplan visible above.
  - Drag-down past 80px from 50% → dismisses.
  - Fast downward flick from 90% → snaps to 50% (or dismisses from 50%).
  - Rotate device — snap targets recompute, sheet stays at the current snap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)