### PR TITLE
chore: onboard as an agent-forge target product

### DIFF
--- a/.agent-forge/areas.yml
+++ b/.agent-forge/areas.yml
@@ -1,0 +1,43 @@
+# Top-level areas for agent-forge. Dev locks at this granularity so two Devs
+# can work non-overlapping areas in parallel. The BA maps an issue's scope to
+# `area:<name>` labels using the `paths:` globs below. Keep areas broad; split
+# one only when a real subsystem boundary plus lock-contention concern justifies
+# it. (Seeded during agent-forge onboarding — refine via human PR.)
+
+areas:
+  frontend:
+    paths:
+      - src/**
+      - index.html
+      - public/**
+      - .storybook/**
+
+  api:
+    paths:
+      - api/**
+
+  e2e:
+    paths:
+      - e2e/**
+
+  docs:
+    paths:
+      - docs/**
+      - README.md
+      - DESIGN.md
+      - CLAUDE.md
+
+  ci:
+    paths:
+      - .github/**
+      - .githooks/**
+      - scripts/**
+      - package.json
+      - package-lock.json
+      - vite.config.js
+      - vitest.config.js
+      - firebase.json
+      - firestore.rules
+      - .firebaserc
+      - codecov.yml
+      - .env.example

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,43 @@
+# Home Plant Tracker — Product Spec
+
+> **Onboarding skeleton** seeded for agent-forge. This `spec/` is the source of
+> truth the BA reads to hydrate and de-duplicate the backlog. Spec edits come
+> **only from human PRs** — expand and correct these files over time.
+
+## Mission
+
+Help people care for their houseplants: place plants on an interactive floorplan
+of their home, track when each needs watering, and get AI-powered identification
+and care advice.
+
+Live app: https://plants.lopezcloud.dev
+
+## Core capabilities
+
+- **Interactive floorplan** — place and drag plant markers on a home floor plan;
+  multi-floor support (ground floor, upper floors, garden) managed separately.
+- **Watering tracker** — days-until-watering per plant; overdue plants flagged;
+  outdoor plants get a skip-watering alert when rain is forecast.
+- **AI plant analysis (Gemini)** — identify the species from a photo, assess
+  health, and recommend a watering frequency.
+- **AI floorplan analysis (Gemini)** — generate a labelled multi-floor layout
+  from a photo of a floor plan.
+- **Care recommendations** — per-plant guidance: watering, light, soil, humidity,
+  temperature, and common issues.
+- **Weather integration** — live weather plus a 3-day forecast.
+- **Accounts** — Google sign-in; each user's plants are private, stored in a
+  per-user Firestore namespace.
+
+## Architecture (summary)
+
+- **Frontend** — React 18 + Vite single-page app (`src/`); Storybook design
+  system (see `DESIGN.md`).
+- **Backend** — Node 20 / Express on Cloud Run Functions (`api/`), fronted by GCP
+  API Gateway (OpenAPI 2.0, Google-OAuth JWT + API-key auth).
+- **Data** — Cloud Firestore (per-user plant + floor config); Cloud Storage for
+  plant photos via signed URLs.
+- **AI** — Google Gemini (`@google/generative-ai`).
+- **Testing** — Vitest unit/component tests; Playwright end-to-end (`e2e/`).
+
+See the repo `README.md` for setup and `DESIGN.md` for the design-system tokens
+and Storybook catalogue.

--- a/spec/non-goals.md
+++ b/spec/non-goals.md
@@ -1,0 +1,15 @@
+# Non-goals
+
+> **Placeholder** — inferred during onboarding; confirm or correct via human PR
+> before the backlog hydrates around these assumptions.
+
+Current understanding of what is out of scope:
+
+- **Not a marketplace / e-commerce.** No plant purchasing, ordering, or payments.
+- **Not a social network.** Plant data is private per user; no public feeds,
+  sharing, or following (at least for now).
+- **No native mobile apps.** The product is a responsive web app / PWA.
+- **No organization / multi-tenant accounts.** Scope is an individual user's
+  home(s), not shared team or company accounts.
+
+If any of these are actually in scope, update this file (human PR) first.


### PR DESCRIPTION
Onboards **home-plant-tracker** as an [agent-forge](https://github.com/lopeztech/agent-forge) target product — the autonomous Claude-agent software team will manage issues labeled `state:idea` through to a PR.

## What this adds
- **`.agent-forge/areas.yml`** (mandatory) — Dev locks at this granularity so parallel runs don't collide, and the BA maps each issue's scope to `area:<name>` labels. Five broad areas to start: `frontend` (`src/`), `api` (`api/`), `e2e`, `docs`, `ci`. Split later only if lock contention warrants.
- **`spec/`** skeleton (`README.md` + `non-goals.md`) sourced from this repo's `README.md` + `DESIGN.md`. The BA reads `spec/` to hydrate and de-duplicate the backlog. **Spec edits come only from human PRs** — expand/correct over time. The `non-goals.md` items are *inferred* — please correct anything wrong.

## What happens after merge
1. agent-forge seeds the `products` row (writer/merger App install IDs already verified) + the `state:*` / `area:*` label vocabulary on this repo.
2. A small validation issue is filed at `state:idea` to confirm the pipeline runs end-to-end.
3. The pipeline (BA → cost-estimate → Dev → Test → Functional → Security → PO) handles `state:idea` issues. **PO auto-merge is gated for the first 30 days** — it recommends, a human merges.

## Not included (manual follow-up)
- **Branch protection** on `main` — the onboarding scripts don't set it; worth adding before autonomous merges are enabled.

No application code is touched — only agent-forge config + spec docs.