### PR TITLE
feat(conservatory): desktop UI — 13-screen Conservatory design at /app

### DIFF
--- a/e2e/console-smoke.spec.js
+++ b/e2e/console-smoke.spec.js
@@ -21,6 +21,7 @@ import { attachErrorListeners, enterGuestMode } from './_helpers.js'
 
 const ROUTES = [
   { path: '/mobile',               label: 'Mobile (Conservatory UI)' },
+  { path: '/app',                  label: 'Desktop Conservatory UI' },
   { path: '/today',                label: 'Today (daily tasks)' },
   { path: '/',                     label: 'Dashboard (Garden)' },
   { path: '/propagation',          label: 'Propagation' },

--- a/src/conservatory/desktop/DesktopApp.jsx
+++ b/src/conservatory/desktop/DesktopApp.jsx
@@ -1,0 +1,138 @@
+import React, { useState, useCallback, useMemo, useEffect } from 'react'
+import { usePlantContext } from '../../context/PlantContext.jsx'
+import { useAuth } from '../../contexts/AuthContext.jsx'
+import { useSubscription } from '../../context/SubscriptionContext.jsx'
+import { propagationApi, journalApi } from '../../api/plants.js'
+import { getWateringStatus } from '../../utils/watering.js'
+import { Garden } from './screens/Garden.jsx'
+import { Today } from './screens/Today.jsx'
+import { Plant } from './screens/Plant.jsx'
+import { Calendar } from './screens/Calendar.jsx'
+import { Forecast } from './screens/Forecast.jsx'
+import { Propagation } from './screens/Propagation.jsx'
+import { Library } from './screens/Library.jsx'
+import { Insights } from './screens/Insights.jsx'
+import { AddPlant } from './screens/AddPlant.jsx'
+import { Settings } from './screens/Settings.jsx'
+import { Billing } from './screens/Billing.jsx'
+import { Members } from './screens/Members.jsx'
+import { Login } from './screens/Login.jsx'
+
+function speciesIcon(species = '') {
+  const s = species.toLowerCase()
+  if (s.includes('monstera')) return 'monstera'
+  if (s.includes('snake') || s.includes('sansevieria')) return 'snake'
+  if (s.includes('pothos') || s.includes('epipremnum')) return 'pothos'
+  if (s.includes('fiddle') || s.includes('ficus lyrata')) return 'fiddle'
+  if (s.includes('aloe')) return 'succulent'
+  if (s.includes('cactus') || s.includes('barrel')) return 'cactus'
+  if (s.includes('fern') || s.includes('boston')) return 'fern'
+  if (s.includes('palm')) return 'palm'
+  if (s.includes('lily') || s.includes('peace') || s.includes('spathiphyllum')) return 'lily'
+  if (s.includes('herb') || s.includes('basil') || s.includes('mint') || s.includes('rosemary')) return 'herb'
+  return 'monstera'
+}
+
+function normalizePlant(plant, weather, floors, timezone) {
+  const ws = getWateringStatus(plant, weather, floors, timezone)
+  const _status = ws.daysUntil < 0 ? 'overdue' : ws.daysUntil === 0 ? 'today' : 'ok'
+  return { ...plant, _status, _daysUntil: ws.daysUntil ?? 0, icon: speciesIcon(plant.species) }
+}
+
+export function DesktopApp() {
+  const { plants, floors, activeFloorId, weather, timezone, handleWaterPlant } = usePlantContext()
+  const { user, logout, isAuthenticated } = useAuth()
+  const { tier, ...subscription } = useSubscription()
+
+  const [screen, setScreen] = useState('garden')
+  const [activePlantId, setActivePlantId] = useState(null)
+  const [wateredSet, setWateredSet] = useState(() => new Set())
+  const [propagations, setPropagations] = useState([])
+  const [careHistory, setCareHistory] = useState({})
+
+  useEffect(() => {
+    if (!isAuthenticated) return
+    propagationApi.list?.()?.then((data) => setPropagations(Array.isArray(data) ? data : data?.items || [])).catch(() => {})
+  }, [isAuthenticated])
+
+  const normalizedPlants = useMemo(
+    () => plants.map((p) => normalizePlant(p, weather, floors, timezone)),
+    [plants, weather, floors, timezone],
+  )
+
+  const water = useCallback(async (id) => {
+    setWateredSet((prev) => { const s = new Set(prev); s.has(id) ? s.delete(id) : s.add(id); return s })
+    handleWaterPlant(id, {}).catch(() => {})
+  }, [handleWaterPlant])
+
+  const waterAll = useCallback((ids) => {
+    setWateredSet((prev) => { const s = new Set(prev); ids.forEach((id) => s.add(id)); return s })
+    ids.forEach((id) => handleWaterPlant(id, {}).catch(() => {}))
+  }, [handleWaterPlant])
+
+  const openPlant = useCallback((id) => {
+    setActivePlantId(id)
+    setScreen('plant')
+    journalApi.list(id).then((entries) => {
+      const history = (entries || []).slice(0, 6).map((e) => ({
+        date: e.date ? new Date(e.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '—',
+        kind: e.type === 'watering' ? 'water' : e.type === 'fertiliser' ? 'feed' : 'note',
+        label: e.title || (e.type === 'watering' ? 'Watered' : 'Note'),
+        detail: e.body || e.notes || '',
+      }))
+      setCareHistory((prev) => ({ ...prev, [id]: history }))
+    }).catch(() => {})
+  }, [])
+
+  const navigate = useCallback((s) => setScreen(s), [])
+
+  const userInfo = {
+    name: user?.name || user?.email?.split('@')[0] || 'Plant Keeper',
+    initial: (user?.name || user?.email || 'A')[0].toUpperCase(),
+    email: user?.email || '',
+  }
+
+  const ctx = {
+    navigate, openPlant, water, waterAll,
+    wateredSet, user: userInfo, weather,
+    activeFloorId, onSignOut: logout,
+  }
+
+  if (!isAuthenticated) {
+    return <Login onGoogleSignIn={() => setScreen('garden')} />
+  }
+
+  switch (screen) {
+    case 'today':
+      return <Today plants={normalizedPlants} wateredSet={wateredSet} onWater={water} waterAll={waterAll} openPlant={openPlant} ctx={ctx} />
+    case 'plant':
+      return <Plant plantId={activePlantId} plants={normalizedPlants} careHistory={careHistory[activePlantId] || []} onWater={water} ctx={ctx} />
+    case 'calendar':
+      return <Calendar plants={normalizedPlants} ctx={ctx} />
+    case 'forecast':
+      return <Forecast plants={normalizedPlants} ctx={ctx} />
+    case 'propagation':
+      return <Propagation propagations={propagations} ctx={ctx} />
+    case 'insights':
+      return <Insights plants={normalizedPlants} wateredSet={wateredSet} ctx={ctx} />
+    case 'library':
+      return <Library plants={normalizedPlants} wateredSet={wateredSet} ctx={ctx} />
+    case 'addplant':
+      return <AddPlant floors={floors} plants={normalizedPlants} ctx={ctx} />
+    case 'settings':
+      return <Settings user={userInfo} subscription={{ tier, ...subscription }} ctx={ctx} />
+    case 'billing':
+      return <Billing subscription={{ tier, ...subscription }} ctx={ctx} />
+    case 'members':
+      return <Members household={{}} ctx={ctx} />
+    case 'garden':
+    default:
+      return (
+        <Garden
+          plants={normalizedPlants} floors={floors} activeFloorId={activeFloorId}
+          weather={weather} wateredSet={wateredSet} onWater={water} waterAll={waterAll}
+          openPlant={openPlant} ctx={ctx}
+        />
+      )
+  }
+}

--- a/src/conservatory/desktop/DesktopApp.jsx
+++ b/src/conservatory/desktop/DesktopApp.jsx
@@ -41,7 +41,7 @@ function normalizePlant(plant, weather, floors, timezone) {
 
 export function DesktopApp() {
   const { plants, floors, activeFloorId, weather, timezone, handleWaterPlant } = usePlantContext()
-  const { user, logout, isAuthenticated } = useAuth()
+  const { user, logout, isAuthenticated, isGuest } = useAuth()
   const { tier, ...subscription } = useSubscription()
 
   const [screen, setScreen] = useState('garden')
@@ -51,9 +51,9 @@ export function DesktopApp() {
   const [careHistory, setCareHistory] = useState({})
 
   useEffect(() => {
-    if (!isAuthenticated) return
+    if (!isAuthenticated || isGuest) return
     propagationApi.list?.()?.then((data) => setPropagations(Array.isArray(data) ? data : data?.items || [])).catch(() => {})
-  }, [isAuthenticated])
+  }, [isAuthenticated, isGuest])
 
   const normalizedPlants = useMemo(
     () => plants.map((p) => normalizePlant(p, weather, floors, timezone)),
@@ -73,6 +73,7 @@ export function DesktopApp() {
   const openPlant = useCallback((id) => {
     setActivePlantId(id)
     setScreen('plant')
+    if (isGuest) return
     journalApi.list(id).then((entries) => {
       const history = (entries || []).slice(0, 6).map((e) => ({
         date: e.date ? new Date(e.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '—',

--- a/src/conservatory/desktop/DesktopHeader.jsx
+++ b/src/conservatory/desktop/DesktopHeader.jsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { C } from '../tokens.js'
+import { CIcon, IC } from '../icons.jsx'
+
+const NAV = [
+  ['Garden',      'garden',      'garden'],
+  ['Today',       'today',       'today'],
+  ['Calendar',    'calendar',    'calendar'],
+  ['Forecast',    'forecast',    'forecast'],
+  ['Propagation', 'propagation', 'prop'],
+  ['Insights',    'insights',    'chart'],
+]
+
+function CWordmark() {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+      <div style={{
+        width: 34, height: 34, borderRadius: '50%', background: C.terra,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        boxShadow: `0 2px 0 ${C.terraDeep}`,
+      }}>
+        <CIcon d={IC.leaf} size={17} color={C.goldSoft} fill={C.goldSoft} w={0} />
+      </div>
+      <span style={{
+        fontFamily: C.serif, fontSize: 22, fontStyle: 'italic',
+        fontWeight: 500, color: C.ink, letterSpacing: 0.2,
+      }}>Conservatory</span>
+    </div>
+  )
+}
+
+export function DesktopHeader({ activeScreen = 'garden', onNav = () => {}, user = {}, weather = null }) {
+  const initial = user.initial || (user.name ? user.name[0].toUpperCase() : 'A')
+  return (
+    <div>
+      {/* 5px gradient top rule */}
+      <div style={{
+        height: 5,
+        background: `linear-gradient(90deg, ${C.terra} 0%, ${C.terra} 60%, ${C.gold} 60%, ${C.gold} 100%)`,
+      }} />
+      {/* 66px nav bar */}
+      <header style={{
+        height: 66, display: 'flex', alignItems: 'center',
+        justifyContent: 'space-between', padding: '0 34px',
+        background: C.card, borderBottom: `1px solid ${C.line}`,
+      }}>
+        <CWordmark />
+        <nav style={{ display: 'flex', gap: 4 }}>
+          {NAV.map(([label, key, ic]) => {
+            const on = key === activeScreen
+            return (
+              <button key={key} onClick={() => onNav(key)}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 7,
+                  fontFamily: C.serif, fontSize: 17,
+                  fontStyle: on ? 'italic' : 'normal',
+                  color: on ? C.terra : C.muted,
+                  padding: '7px 14px',
+                  borderBottom: on ? `2px solid ${C.gold}` : '2px solid transparent',
+                  border: 'none', borderTop: 'none', borderLeft: 'none', borderRight: 'none',
+                  background: 'transparent', cursor: 'pointer',
+                  outline: 'none',
+                }}>
+                <CIcon d={IC[ic]} size={16} color={on ? C.terra : C.muted} w={1.7} />
+                {label}
+              </button>
+            )
+          })}
+        </nav>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+          {weather && (
+            <span style={{
+              fontFamily: C.sans, fontSize: 12.5, color: C.muted,
+              display: 'flex', alignItems: 'center', gap: 7,
+              background: C.paper, padding: '6px 12px', borderRadius: 20,
+            }}>
+              <CIcon d={IC.rain} size={15} color={C.sage} w={1.6} />
+              {weather.temp}° · {weather.condition}
+            </span>
+          )}
+          <button style={{ border: 'none', background: 'transparent', padding: 6, cursor: 'pointer' }}
+            aria-label="Notifications">
+            <CIcon d={IC.bell} size={19} color={C.muted} w={1.6} />
+          </button>
+          <div style={{
+            width: 36, height: 36, borderRadius: '50%', background: C.green,
+            color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontFamily: C.serif, fontSize: 16,
+          }} aria-hidden="true">{initial}</div>
+        </div>
+      </header>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/AddPlant.jsx
+++ b/src/conservatory/desktop/screens/AddPlant.jsx
@@ -1,0 +1,124 @@
+import React, { useState, useCallback } from 'react'
+import { C, CSTAT } from '../../tokens.js'
+import { CIcon, IC } from '../../icons.jsx'
+import { CKicker, CBtn, pressProps } from '../../primitives.jsx'
+import { PlantIcon } from '../../PlantIcon.jsx'
+import { FloorPlan } from '../../FloorPlan.jsx'
+import { DesktopHeader } from '../DesktopHeader.jsx'
+
+function APStep({ n, label, active, done }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+      <div style={{ width: 28, height: 28, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, background: done ? C.greenBright : active ? C.terra : 'transparent', border: `1.5px solid ${done ? C.greenBright : active ? C.terra : C.line}`, color: (done || active) ? '#fff' : C.muted, fontFamily: C.serif, fontSize: 14 }}>
+        {done ? <CIcon d={IC.check} size={15} color="#fff" w={2.6} /> : n}
+      </div>
+      <span style={{ fontFamily: C.serif, fontSize: 17, fontStyle: active ? 'italic' : 'normal', color: active ? C.ink : done ? C.green : C.muted }}>{label}</span>
+    </div>
+  )
+}
+
+const ROOM_FILL = { kitchen: '#EFE7D0', bath: '#E5EFE6', bathroom: '#E5EFE6', bedroom: '#F2E7D8', living: '#EFDDC8', 'living room': '#EFDDC8', study: '#ECE4CD' }
+function roomFill(r) { return ROOM_FILL[(r.name || '').toLowerCase()] || '#F2EBDB' }
+
+export function AddPlant({ floors, plants, ctx }) {
+  const [step, setStep] = useState(2) // show the Place step by default
+  const [identified, setIdentified] = useState(null)
+  const [placing, setPlacing] = useState({ room: null, x: 74, y: 60 })
+  const activeFloor = floors.find((f) => f.id === ctx.activeFloorId) || floors[0]
+  const floorRooms = activeFloor?.rooms || []
+  const wx = ctx.weather?.current ? { temp: Math.round(ctx.weather.current.temp), condition: ctx.weather.current.condition?.sky || 'Clear' } : null
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'flex', flexDirection: 'column' }}>
+      <DesktopHeader activeScreen="garden" onNav={ctx.navigate} user={ctx.user} weather={wx} />
+      <div style={{ flex: 1, padding: '24px 34px 30px', display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
+        {/* title + steps */}
+        <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 4 }}>
+          <div>
+            <CKicker>Welcome a new plant</CKicker>
+            <h1 style={{ fontFamily: C.serif, fontSize: 32, fontWeight: 400, margin: '6px 0 0', letterSpacing: -0.3, whiteSpace: 'nowrap' }}>
+              Add to your <span style={{ fontStyle: 'italic', color: C.terra }}>collection.</span>
+            </h1>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 22 }}>
+            <APStep n={1} label="Identify" done={step > 1} active={step === 1} />
+            <div style={{ width: 30, height: 1, background: C.line }} />
+            <APStep n={2} label="Place" active={step === 2} done={step > 2} />
+            <div style={{ width: 30, height: 1, background: C.line }} />
+            <APStep n={3} label="Schedule" active={step === 3} />
+          </div>
+        </div>
+
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '380px 1fr', gap: 30, marginTop: 18, minHeight: 0, overflow: 'hidden' }}>
+          {/* left: identify result */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16, minHeight: 0, overflowY: 'auto' }}>
+            <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)', padding: 20, position: 'relative', overflow: 'hidden' }}>
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+              <CKicker>Photo</CKicker>
+              <div style={{ marginTop: 12, height: 168, borderRadius: 10, border: `2px dashed ${C.line}`, background: C.panel, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 8, position: 'relative' }}>
+                <PlantIcon type={identified?.icon || 'monstera'} size={76} />
+                <div style={{ position: 'absolute', bottom: 10, display: 'flex', alignItems: 'center', gap: 7, background: C.card, borderRadius: 20, padding: '5px 12px', border: `1px solid ${C.line}`, boxShadow: '0 2px 8px rgba(40,30,20,.08)', cursor: 'pointer' }}>
+                  <CIcon d={IC.camera} size={14} color={C.terra} w={1.7} />
+                  <span style={{ fontFamily: C.sans, fontSize: 12.5, fontWeight: 600, color: C.ink }}>Retake photo</span>
+                </div>
+              </div>
+              <div style={{ marginTop: 16, background: C.sageBg, borderRadius: 8, padding: '14px 16px' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+                  <CIcon d={IC.sparkle} size={16} color={C.gold} fill={C.gold} w={0} />
+                  <span style={{ fontFamily: C.sans, fontSize: 11.5, fontWeight: 700, letterSpacing: 1, textTransform: 'uppercase', color: C.green }}>Identified</span>
+                  <span style={{ marginLeft: 'auto', fontFamily: C.sans, fontSize: 12, fontWeight: 700, color: C.greenBright }}>97% match</span>
+                </div>
+                <div style={{ fontFamily: C.serif, fontSize: 22, color: C.ink, lineHeight: 1.05 }}>{identified?.species || 'Monstera deliciosa'}</div>
+                <div style={{ fontFamily: C.serif, fontSize: 14, fontStyle: 'italic', color: C.muted }}>Swiss cheese plant</div>
+              </div>
+              <div style={{ display: 'flex', gap: 18, marginTop: 14 }}>
+                {[['Light', 'Bright, indirect'], ['Water', 'Every 7 days'], ['Difficulty', 'Easy']].map(([k, v]) => (
+                  <div key={k}>
+                    <div style={{ fontFamily: C.sans, fontSize: 11, color: C.muted, marginBottom: 2 }}>{k}</div>
+                    <div style={{ fontFamily: C.serif, fontSize: 14, color: C.ink }}>{v}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div style={{ background: C.goldSoft, borderLeft: `3px solid ${C.gold}`, borderRadius: 4, padding: '13px 15px' }}>
+              <div style={{ fontFamily: C.serif, fontSize: 16, fontStyle: 'italic', color: C.goldDeep, marginBottom: 2 }}>Not quite right?</div>
+              <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.muted, lineHeight: 1.5 }}>Tap to pick from 3 close matches, or search the catalogue by name.</div>
+            </div>
+          </div>
+
+          {/* right: place on floorplan */}
+          <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+            <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)', padding: 20, position: 'relative', overflow: 'hidden', flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: 12 }}>
+                <div><CKicker>Place it on the map</CKicker><div style={{ fontFamily: C.serif, fontSize: 21, marginTop: 2 }}>Where will this plant live?</div></div>
+                <span style={{ fontFamily: C.serif, fontSize: 15, fontStyle: 'italic', color: C.terra }}>Tap a room, then a spot</span>
+              </div>
+              <div style={{ flex: 1, background: C.panel, borderRadius: 10, border: `1px solid ${C.line2}`, padding: 18, display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
+                <div style={{ position: 'relative', width: 660, height: 360 }}>
+                  <FloorPlan width={660} height={360} bg={C.panel}
+                    rooms={floorRooms} plants={plants}
+                    activeId="__none"
+                    renderMarker={(p) => <div style={{ width: 9, height: 9, borderRadius: '50%', background: CSTAT[p._status]?.color || '#ccc', opacity: 0.45, boxShadow: `0 0 0 2px ${C.panel}` }} />} />
+                  <div style={{ position: 'absolute', left: `${placing.x}%`, top: `${placing.y}%`, transform: 'translate(-50%,-100%)', display: 'flex', flexDirection: 'column', alignItems: 'center', zIndex: 6 }}>
+                    <div style={{ background: C.card, borderRadius: 10, padding: '6px 11px', boxShadow: '0 8px 22px rgba(80,50,20,.22)', display: 'flex', alignItems: 'center', gap: 8, whiteSpace: 'nowrap', border: `1.5px solid ${C.terra}`, marginBottom: 6 }}>
+                      <PlantIcon type="monstera" size={26} />
+                      <span style={{ fontFamily: C.serif, fontSize: 14, fontStyle: 'italic', color: C.ink }}>New plant</span>
+                    </div>
+                    <div style={{ width: 20, height: 20, borderRadius: '50% 50% 50% 0', transform: 'rotate(-45deg)', background: C.terra, boxShadow: '0 3px 8px rgba(40,30,20,.3)' }} />
+                  </div>
+                </div>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 16 }}>
+                <CBtn kind="ghost" style={{ borderRadius: 6 }} onClick={() => setStep(1)}>← Back to identify</CBtn>
+                <CBtn kind="primary" style={{ borderRadius: 6 }} onClick={() => setStep(3)}>Continue to schedule →</CBtn>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/Billing.jsx
+++ b/src/conservatory/desktop/screens/Billing.jsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import { C } from '../../tokens.js'
+import { CIcon, IC } from '../../icons.jsx'
+import { CKicker, CBtn } from '../../primitives.jsx'
+import { PlantIcon } from '../../PlantIcon.jsx'
+import { DesktopHeader } from '../DesktopHeader.jsx'
+
+const PLANS = [
+  { id: 'free', apiId: 'free', name: 'Windowsill', price: '£0', cadence: 'free forever', icon: 'succulent', blurb: 'For a small, happy collection.', features: ['Up to 8 plants', 'One floorplan', 'Watering reminders'] },
+  { id: 'home_pro', apiId: 'home_pro', name: 'Greenhouse', price: '£4', cadence: 'per month', icon: 'monstera', blurb: 'For a home that\'s filling up.', features: ['Unlimited plants', 'Weather-aware care', 'Propagation bench', 'Care journal'] },
+  { id: 'landscaper_pro', apiId: 'landscaper_pro', name: 'Glasshouse', price: '£8', cadence: 'per month', icon: 'palm', blurb: 'For the devoted, many-roomed grower.', features: ['Everything in Greenhouse', 'Multiple floorplans', 'Household sharing', 'AI plant doctor'] },
+]
+
+function PlanCard({ plan, isCurrent, onSelect }) {
+  return (
+    <div style={{ flex: 1, background: isCurrent ? C.green : C.card, color: isCurrent ? '#FBF7EE' : C.ink, borderRadius: 12, border: `1px solid ${isCurrent ? C.green : C.line}`, padding: 22, display: 'flex', flexDirection: 'column', position: 'relative', overflow: 'hidden', boxShadow: isCurrent ? '0 18px 40px -22px rgba(40,60,40,.6)' : '0 6px 20px -16px rgba(120,90,40,.35)' }}>
+      {isCurrent && <div style={{ position: 'absolute', top: 14, right: 14, fontFamily: C.sans, fontSize: 10.5, fontWeight: 800, letterSpacing: 1, textTransform: 'uppercase', color: C.green, background: C.gold, padding: '4px 10px', borderRadius: 20 }}>Current</div>}
+      <div style={{ width: 54, height: 54, borderRadius: 15, background: isCurrent ? 'rgba(255,255,255,0.12)' : C.panel, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 14 }}>
+        <PlantIcon type={plan.icon} size={40} tint={isCurrent ? '#A9C0A2' : undefined} pot={isCurrent ? '#C9784F' : undefined} />
+      </div>
+      <div style={{ fontFamily: C.serif, fontSize: 24, fontStyle: 'italic' }}>{plan.name}</div>
+      <div style={{ fontFamily: C.sans, fontSize: 13, color: isCurrent ? '#D8E4D3' : C.muted, marginTop: 2, marginBottom: 14 }}>{plan.blurb}</div>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 7, marginBottom: 16 }}>
+        <span style={{ fontFamily: C.serif, fontSize: 38, lineHeight: 0.9 }}>{plan.price}</span>
+        <span style={{ fontFamily: C.sans, fontSize: 13, color: isCurrent ? '#D8E4D3' : C.muted }}>{plan.cadence}</span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 9, flex: 1 }}>
+        {plan.features.map((f) => (
+          <div key={f} style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+            <CIcon d={IC.check} size={15} color={isCurrent ? C.gold : C.greenBright} w={2.4} />
+            <span style={{ fontFamily: C.sans, fontSize: 13.5, color: isCurrent ? '#EAF0E4' : C.ink }}>{f}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop: 18 }}>
+        {isCurrent
+          ? <div style={{ textAlign: 'center', fontFamily: C.serif, fontSize: 15, fontStyle: 'italic', color: C.gold }}>Your current plan</div>
+          : <CBtn kind={plan.id === 'landscaper_pro' ? 'primary' : 'ghost'} full style={{ borderRadius: 7, fontSize: 15 }} onClick={() => onSelect(plan)}>
+              {plan.id === 'free' ? 'Downgrade' : 'Upgrade →'}
+            </CBtn>}
+      </div>
+    </div>
+  )
+}
+
+export function Billing({ subscription, ctx }) {
+  const currentTier = subscription?.tier || 'free'
+  const wx = ctx.weather?.current ? { temp: Math.round(ctx.weather.current.temp), condition: ctx.weather.current.condition?.sky || 'Clear' } : null
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'flex', flexDirection: 'column' }}>
+      <DesktopHeader activeScreen="garden" onNav={ctx.navigate} user={ctx.user} weather={wx} />
+      <div style={{ flex: 1, padding: '28px 34px', display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 14, fontFamily: C.sans, fontSize: 13, color: C.muted }}>
+          <button onClick={() => ctx.navigate('settings')} style={{ border: 'none', background: 'none', padding: 0, cursor: 'pointer', color: C.muted, fontFamily: C.sans, fontSize: 13 }}>Settings</button>
+          <CIcon d={IC.chevR} size={14} color={C.muted} />
+          <span style={{ color: C.ink, fontStyle: 'italic', fontFamily: C.serif, fontSize: 15 }}>Plan &amp; billing</span>
+        </div>
+        <div style={{ marginBottom: 18 }}>
+          <CKicker>Choose how much you grow</CKicker>
+          <h1 style={{ fontFamily: C.serif, fontSize: 33, fontWeight: 400, margin: '6px 0 0', letterSpacing: -0.3 }}>
+            A plan for every <span style={{ fontStyle: 'italic', color: C.terra }}>green thumb.</span>
+          </h1>
+        </div>
+
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 330px', gap: 26, minHeight: 0, overflow: 'hidden' }}>
+          <div style={{ display: 'flex', gap: 16, alignItems: 'stretch' }}>
+            {PLANS.map((plan) => (
+              <PlanCard key={plan.id} plan={plan} isCurrent={plan.apiId === currentTier} onSelect={() => {}} />
+            ))}
+          </div>
+
+          <aside style={{ display: 'flex', flexDirection: 'column', gap: 16, minHeight: 0, overflowY: 'auto' }}>
+            <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)', padding: 20, position: 'relative', overflow: 'hidden' }}>
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+              <CKicker>This billing period</CKicker>
+              <div style={{ fontFamily: C.serif, fontSize: 21, color: C.ink, margin: '4px 0 14px' }}>
+                {PLANS.find((p) => p.apiId === currentTier)?.name || 'Windowsill'}
+                {subscription?.currentPeriodEnd ? ` · renews ${new Date(subscription.currentPeriodEnd * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}` : ''}
+              </div>
+              {[['Plants', `${subscription?.usage?.plants ?? 0} used`], ['Floorplans', '1'], ['Household', 'Just you']].map(([k, v]) => (
+                <div key={k} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 12 }}>
+                  <span style={{ fontFamily: C.sans, fontSize: 13.5, color: C.muted }}>{k}</span>
+                  <span style={{ fontFamily: C.serif, fontSize: 16, color: C.ink }}>{v}</span>
+                </div>
+              ))}
+              <div style={{ marginTop: 4, paddingTop: 14, borderTop: `1px solid ${C.line2}`, display: 'flex', alignItems: 'center', gap: 12 }}>
+                <div style={{ width: 40, height: 28, borderRadius: 5, background: C.ink, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <span style={{ fontFamily: C.serif, fontSize: 11, fontStyle: 'italic', color: C.goldSoft }}>VISA</span>
+                </div>
+                <span style={{ flex: 1, fontFamily: C.sans, fontSize: 13.5, color: C.ink }}>•••• 4821</span>
+                <span style={{ fontFamily: C.serif, fontSize: 14, fontStyle: 'italic', color: C.terra, cursor: 'pointer' }}>Update</span>
+              </div>
+            </div>
+
+            <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05)', padding: 20, flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+                <CKicker>Recent invoices</CKicker>
+                <span style={{ fontFamily: C.serif, fontSize: 13.5, fontStyle: 'italic', color: C.terra, cursor: 'pointer' }}>View all</span>
+              </div>
+              {[['1 Jun 2026', 'Greenhouse · monthly', '£4.00'], ['1 May 2026', 'Greenhouse · monthly', '£4.00'], ['1 Apr 2026', 'Greenhouse · monthly', '£4.00']].map(([d, desc, amt], i, arr) => (
+                <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '11px 0', borderBottom: i === arr.length - 1 ? 'none' : `1px solid ${C.line2}` }}>
+                  <CIcon d={IC.check} size={15} color={C.greenBright} w={2.4} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontFamily: C.serif, fontSize: 15, color: C.ink, lineHeight: 1.1 }}>{d}</div>
+                    <div style={{ fontFamily: C.sans, fontSize: 12, color: C.muted }}>{desc}</div>
+                  </div>
+                  <span style={{ fontFamily: C.serif, fontSize: 15, color: C.ink }}>{amt}</span>
+                </div>
+              ))}
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/Calendar.jsx
+++ b/src/conservatory/desktop/screens/Calendar.jsx
@@ -1,0 +1,157 @@
+import React, { useState, useMemo } from 'react'
+import { C, CSTAT } from '../../tokens.js'
+import { CIcon, IC } from '../../icons.jsx'
+import { CSwash, CKicker, CBtn, CIconBadge, pressProps } from '../../primitives.jsx'
+import { PlantIcon } from '../../PlantIcon.jsx'
+import { DesktopHeader } from '../DesktopHeader.jsx'
+
+const WD = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+function buildEvents(plants) {
+  const events = {}
+  const now = new Date()
+  now.setHours(0, 0, 0, 0)
+  const year = now.getFullYear()
+  const month = now.getMonth()
+  plants.forEach((p) => {
+    if (!p.frequencyDays) return
+    const cadence = p.frequencyDays
+    const base = p.lastWatered ? new Date(p.lastWatered) : new Date(now.getTime() - p._daysUntil * 86400000)
+    // future events
+    let d = new Date(base.getTime() + cadence * 86400000)
+    while (d.getFullYear() === year && d.getMonth() === month) {
+      const day = d.getDate()
+      if (!events[day]) events[day] = []
+      events[day].push(p)
+      d = new Date(d.getTime() + cadence * 86400000)
+    }
+    // past events for texture
+    let b = new Date(base.getTime())
+    while (b >= new Date(year, month, 1) && b.getMonth() === month) {
+      const day = b.getDate()
+      if (!events[day]) events[day] = []
+      if (!events[day].some((x) => x.id === p.id)) events[day].push({ ...p, _past: true })
+      b = new Date(b.getTime() - cadence * 86400000)
+    }
+  })
+  return events
+}
+
+function CalCell({ day, events, isToday, isPast, openPlant }) {
+  if (day == null) return <div />
+  const evs = (events[day] || []).slice(0, 4)
+  return (
+    <div style={{
+      background: isToday ? C.terraSoft : C.card,
+      border: `1px solid ${isToday ? C.terra + '66' : C.line2}`,
+      borderRadius: 7, padding: '8px 9px', minHeight: 92,
+      display: 'flex', flexDirection: 'column', opacity: isPast ? 0.6 : 1,
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span style={{ fontFamily: C.serif, fontSize: 16, fontStyle: isToday ? 'italic' : 'normal', color: isToday ? C.terra : C.ink }}>{day}</span>
+        {isToday && <span style={{ fontFamily: C.sans, fontSize: 9, fontWeight: 800, letterSpacing: 1, textTransform: 'uppercase', color: C.terra }}>Today</span>}
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 7 }}>
+        {evs.map((p, i) => {
+          const s = CSTAT[p._past ? 'ok' : p._status] || CSTAT.ok
+          return (
+            <div key={i} title={p.name} style={{ width: 22, height: 22, borderRadius: '50%', background: p._past ? C.panel : s.soft, display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: p._past ? 'none' : `inset 0 0 0 1.2px ${s.color}` }}>
+              <PlantIcon type={p.icon || 'monstera'} size={16} />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function CalWeekRow({ plant, daysUntil, openPlant }) {
+  const d = new Date()
+  d.setDate(d.getDate() + daysUntil)
+  const label = d.toLocaleDateString('en-US', { weekday: 'short' })
+  const day = d.getDate()
+  const s = CSTAT[plant._status] || CSTAT.ok
+  return (
+    <div {...pressProps(() => openPlant(plant.id), `Open ${plant.name}`)}
+      style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 0', borderBottom: `1px solid ${C.line2}`, cursor: 'pointer' }}>
+      <div style={{ width: 38, textAlign: 'center', flexShrink: 0 }}>
+        <div style={{ fontFamily: C.sans, fontSize: 10, fontWeight: 700, textTransform: 'uppercase', color: C.muted, letterSpacing: 0.5 }}>{label}</div>
+        <div style={{ fontFamily: C.serif, fontSize: 20, color: C.ink, lineHeight: 1 }}>{day}</div>
+      </div>
+      <CIconBadge plant={plant} size={38} radius={11} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontFamily: C.serif, fontSize: 16, color: C.ink, lineHeight: 1.05 }}>{plant.name}</div>
+        <div style={{ fontFamily: C.sans, fontSize: 12, color: C.muted, fontStyle: 'italic' }}>{plant.room}</div>
+      </div>
+      <span style={{ width: 8, height: 8, borderRadius: '50%', background: s.color }} />
+    </div>
+  )
+}
+
+export function Calendar({ plants, ctx }) {
+  const today = new Date()
+  const [viewDate, setViewDate] = useState(today)
+  const year = viewDate.getFullYear()
+  const month = viewDate.getMonth()
+  const monthName = viewDate.toLocaleDateString('en-US', { month: 'long' })
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+  const firstDay = new Date(year, month, 1).getDay()
+  const calEvents = useMemo(() => buildEvents(plants), [plants])
+  const cells = [...Array(firstDay).fill(null), ...Array.from({ length: daysInMonth }, (_, i) => i + 1)]
+  while (cells.length % 7) cells.push(null)
+  const isCurrentMonth = today.getMonth() === month && today.getFullYear() === year
+  const todayDate = today.getDate()
+  const weekAhead = [...plants].filter((p) => p._daysUntil >= 0 && p._daysUntil <= 7).sort((a, b) => a._daysUntil - b._daysUntil).slice(0, 5)
+  const wx = ctx.weather?.current ? { temp: Math.round(ctx.weather.current.temp), condition: ctx.weather.current.condition?.sky || 'Clear' } : null
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'flex', flexDirection: 'column' }}>
+      <DesktopHeader activeScreen="calendar" onNav={ctx.navigate} user={ctx.user} weather={wx} />
+      <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 336px', gap: 30, padding: '28px 34px', minHeight: 0, overflow: 'hidden' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: 18 }}>
+            <div>
+              <CKicker>The watering calendar</CKicker>
+              <h1 style={{ fontFamily: C.serif, fontSize: 34, fontWeight: 400, margin: '6px 0 0', letterSpacing: -0.3 }}>
+                {monthName} <span style={{ fontStyle: 'italic', color: C.terra }}>{year}</span>
+              </h1>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <button onClick={() => setViewDate(new Date(year, month - 1, 1))} style={{ width: 36, height: 36, borderRadius: '50%', border: `1px solid ${C.line}`, background: C.card, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
+                <CIcon d={IC.chevL} size={18} color={C.ink} />
+              </button>
+              <button onClick={() => setViewDate(new Date(year, month + 1, 1))} style={{ width: 36, height: 36, borderRadius: '50%', border: `1px solid ${C.line}`, background: C.card, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
+                <CIcon d={IC.chevR} size={18} color={C.ink} />
+              </button>
+            </div>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7,1fr)', gap: 7, marginBottom: 7 }}>
+            {WD.map((d) => <div key={d} style={{ fontFamily: C.sans, fontSize: 11.5, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5, color: C.muted, textAlign: 'center', padding: '2px 0' }}>{d}</div>)}
+          </div>
+          <div style={{ flex: 1, display: 'grid', gridTemplateColumns: 'repeat(7,1fr)', gridAutoRows: '1fr', gap: 7 }}>
+            {cells.map((d, i) => <CalCell key={i} day={d} events={calEvents} isToday={isCurrentMonth && d === todayDate} isPast={isCurrentMonth && d < todayDate} openPlant={ctx.openPlant} />)}
+          </div>
+        </div>
+
+        <aside style={{ display: 'flex', flexDirection: 'column', gap: 16, minHeight: 0 }}>
+          <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)', padding: 20, position: 'relative', overflow: 'hidden' }}>
+            <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+            <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+            <CKicker>This week</CKicker>
+            <div style={{ fontFamily: C.serif, fontSize: 21, color: C.ink, margin: '4px 0 6px' }}>{weekAhead.length} waterings ahead</div>
+            {weekAhead.map((p) => <CalWeekRow key={p.id} plant={p} daysUntil={p._daysUntil} openPlant={ctx.openPlant} />)}
+            {weekAhead.length === 0 && <div style={{ fontFamily: C.serif, fontStyle: 'italic', fontSize: 15, color: C.muted, padding: '12px 0' }}>All caught up this week.</div>}
+          </div>
+          {ctx.weather?.rainSoon && (
+            <div style={{ background: C.goldSoft, borderLeft: `3px solid ${C.gold}`, borderRadius: 4, padding: '14px 16px' }}>
+              <div style={{ fontFamily: C.serif, fontSize: 17, fontStyle: 'italic', color: C.goldDeep, marginBottom: 3 }}>Due dates shifted.</div>
+              <div style={{ fontFamily: C.sans, fontSize: 13, color: C.muted, lineHeight: 1.5 }}>Rain in the forecast has automatically pushed outdoor plant waterings.</div>
+            </div>
+          )}
+          <div style={{ flex: 1 }} />
+          <CBtn kind="ghost" full><CIcon d={IC.plus} size={17} color={C.terra} w={2} /> Add a care reminder</CBtn>
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/Forecast.jsx
+++ b/src/conservatory/desktop/screens/Forecast.jsx
@@ -1,0 +1,145 @@
+import React from 'react'
+import { C, CSTAT } from '../../tokens.js'
+import { CIcon, IC } from '../../icons.jsx'
+import { CSwash, CKicker, CBtn, CStatusChip, CIconBadge } from '../../primitives.jsx'
+import { DesktopHeader } from '../DesktopHeader.jsx'
+
+function FCDay({ d, isToday }) {
+  const wet = (d.rain ?? d.rainChance ?? 0) >= 50
+  const iconKey = d.icon === 'sun' ? 'sun' : d.icon === 'rain' || wet ? 'rain' : 'cloud'
+  const iconColor = d.icon === 'sun' ? C.gold : wet ? C.sage : C.muted
+  return (
+    <div style={{ flex: 1, background: isToday ? C.terraSoft : C.card, border: `1px solid ${isToday ? C.terra + '55' : C.line2}`, borderRadius: 9, padding: '14px 8px', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+      <div style={{ fontFamily: C.sans, fontSize: 12, fontWeight: 700, color: isToday ? C.terra : C.muted, textTransform: 'uppercase', letterSpacing: 0.5 }}>{d.d || d.label}</div>
+      <CIcon d={IC[iconKey]} size={26} color={iconColor} w={1.7} />
+      <div style={{ fontFamily: C.serif, fontSize: 19, color: C.ink }}>{Math.round(d.hi ?? d.tempHigh ?? d.t ?? 20)}°</div>
+      <div style={{ fontFamily: C.sans, fontSize: 11.5, color: C.muted }}>{Math.round(d.lo ?? d.tempLow ?? 12)}°</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 3, fontFamily: C.sans, fontSize: 11, fontWeight: 700, color: wet ? C.sage : C.muted }}>
+        <CIcon d={IC.drop} size={11} color={wet ? C.sage : C.muted} fill={wet ? C.sage : 'none'} w={1.4} />
+        {d.rain ?? d.rainChance ?? 0}%
+      </div>
+    </div>
+  )
+}
+
+function FCAdjust({ iconKey, iconColor, title, body, tag, tagStatus }) {
+  return (
+    <div style={{ display: 'flex', gap: 14, padding: '15px 16px', background: C.card, border: `1px solid ${C.line2}`, borderRadius: 8, alignItems: 'flex-start' }}>
+      <div style={{ width: 40, height: 40, borderRadius: 11, background: C.panel, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+        <CIcon d={IC[iconKey]} size={22} color={iconColor} w={1.7} />
+      </div>
+      <div style={{ flex: 1 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 2 }}>
+          <span style={{ fontFamily: C.serif, fontSize: 18, color: C.ink }}>{title}</span>
+          {tag && <CStatusChip status={tagStatus}>{tag}</CStatusChip>}
+        </div>
+        <div style={{ fontFamily: C.sans, fontSize: 13.5, color: C.muted, lineHeight: 1.5 }}>{body}</div>
+      </div>
+    </div>
+  )
+}
+
+export function Forecast({ plants, ctx }) {
+  const weather = ctx.weather || {}
+  const current = weather.current || {}
+  const forecast = weather.days || []
+  const skipped = plants.filter((p) => {
+    const r = (p.room || '').toLowerCase()
+    return r.includes('garden') || r.includes('balcony') || r.includes('outdoor') || r.includes('patio')
+  }).slice(0, 3)
+  const wx = current.temp ? { temp: Math.round(current.temp), condition: current.condition?.sky || 'Clear' } : null
+
+  const days7 = forecast.length >= 7 ? forecast.slice(0, 7) : [...forecast, ...Array.from({ length: 7 - forecast.length }, (_, i) => {
+    const d = new Date(); d.setDate(d.getDate() + forecast.length + i)
+    return { d: d.toLocaleDateString('en-US', { weekday: 'short' }).slice(0, 3), hi: 20, lo: 12, rain: 5, icon: 'cloud' }
+  })]
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'flex', flexDirection: 'column' }}>
+      <DesktopHeader activeScreen="forecast" onNav={ctx.navigate} user={ctx.user} weather={wx} />
+      <div style={{ flex: 1, padding: '30px 34px', display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
+        <div style={{ marginBottom: 20 }}>
+          <CKicker>Weather-aware care</CKicker>
+          <h1 style={{ fontFamily: C.serif, fontSize: 37, fontWeight: 400, lineHeight: 1.1, margin: '8px 0 0', letterSpacing: -0.3 }}>
+            The sky does some of the <span style={{ fontStyle: 'italic', color: C.terra }}>watering.</span>
+          </h1>
+          <div style={{ marginTop: 8, marginLeft: 2 }}><CSwash width={260} /></div>
+        </div>
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 360px', gap: 30, minHeight: 0, overflow: 'hidden' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 18, minHeight: 0, overflowY: 'auto' }}>
+            {/* current conditions */}
+            <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)', padding: 22, position: 'relative', overflow: 'hidden', display: 'flex', alignItems: 'center', gap: 26 }}>
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+              <div style={{ display: 'flex', alignItems: 'center', gap: 18 }}>
+                <CIcon d={IC.rain} size={56} color={C.sage} w={1.5} />
+                <div>
+                  <div style={{ fontFamily: C.serif, fontSize: 52, lineHeight: 0.9, color: C.ink }}>{Math.round(current.temp ?? 18)}°</div>
+                  <div style={{ fontFamily: C.sans, fontSize: 13.5, color: C.muted, marginTop: 4 }}>{current.condition?.sky || 'Clear'}</div>
+                </div>
+              </div>
+              <div style={{ width: 1, height: 64, background: C.line }} />
+              <div style={{ display: 'flex', gap: 28 }}>
+                {[['Humidity', `${current.humidity ?? '—'}%`], ['Wind', `${current.windSpeed ?? '—'} km/h`], ['Rain today', `${current.precipMm ?? 0} mm`]].map(([k, v]) => (
+                  <div key={k}>
+                    <div style={{ fontFamily: C.sans, fontSize: 12, color: C.muted, marginBottom: 3 }}>{k}</div>
+                    <div style={{ fontFamily: C.serif, fontSize: 22, color: C.ink }}>{v}</div>
+                  </div>
+                ))}
+              </div>
+              <div style={{ marginLeft: 'auto', textAlign: 'right' }}>
+                <CKicker color={C.muted}>Your location</CKicker>
+                <div style={{ fontFamily: C.serif, fontSize: 16, fontStyle: 'italic', color: C.ink, marginTop: 2 }}>{new Date().toLocaleDateString('en-US', { weekday: 'long', day: 'numeric', month: 'long' })}</div>
+              </div>
+            </div>
+
+            {/* 7-day strip */}
+            <div>
+              <div style={{ fontFamily: C.serif, fontSize: 19, marginBottom: 10 }}>The next seven days</div>
+              <div style={{ display: 'flex', gap: 9 }}>
+                {days7.map((d, i) => <FCDay key={i} d={d} isToday={i === 0} />)}
+              </div>
+            </div>
+
+            {/* adaptations */}
+            <div>
+              <div style={{ fontFamily: C.serif, fontSize: 19, marginBottom: 10 }}>How your care adapts</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                {weather.rainSoon && (
+                  <FCAdjust iconKey="rain" iconColor={C.sage} title="Watering paused for outdoor plants" tag={`${skipped.length} plants`} tagStatus="ok" body="Rain in the next 48 hours covers your outdoor plants. They'll resume once the soil dries." />
+                )}
+                <FCAdjust iconKey="sun" iconColor={C.gold} title="Warm spell coming" tag="Heads up" tagStatus="today" body="Higher temperatures may mean plants near windows drink faster — monitor soil moisture." />
+              </div>
+            </div>
+          </div>
+
+          <aside style={{ display: 'flex', flexDirection: 'column', gap: 16, minHeight: 0 }}>
+            <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)', padding: 20, position: 'relative', overflow: 'hidden', flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+              <CKicker>Skipped by the rain</CKicker>
+              <div style={{ fontFamily: C.serif, fontSize: 21, color: C.ink, margin: '4px 0 12px' }}>{skipped.length > 0 ? 'Resting until dry' : 'No skips today'}</div>
+              <div>
+                {skipped.map((p) => (
+                  <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '11px 0', borderBottom: `1px solid ${C.line2}` }}>
+                    <CIconBadge plant={{ ...p, _status: 'ok' }} size={40} radius={12} />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontFamily: C.serif, fontSize: 17, color: C.ink, lineHeight: 1.05 }}>{p.name}</div>
+                      <div style={{ fontFamily: C.sans, fontSize: 12, color: C.muted, fontStyle: 'italic' }}>{p.room}</div>
+                    </div>
+                    <CStatusChip status="ok">Deferred</CStatusChip>
+                  </div>
+                ))}
+                {skipped.length === 0 && <div style={{ fontFamily: C.serif, fontStyle: 'italic', fontSize: 15, color: C.muted, padding: '12px 0' }}>No plants deferred today.</div>}
+              </div>
+              <div style={{ marginTop: 'auto', paddingTop: 14 }}>
+                <div style={{ fontFamily: C.sans, fontSize: 13, color: C.muted, lineHeight: 1.55 }}>Weather-aware care is active for your <span style={{ fontFamily: C.serif, fontStyle: 'italic', color: C.terra, fontSize: 15 }}>outdoor plants</span>.</div>
+              </div>
+            </div>
+            <CBtn kind="ghost" full><CIcon d={IC.forecast} size={17} color={C.terra} w={1.7} /> Forecast settings</CBtn>
+          </aside>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/Garden.jsx
+++ b/src/conservatory/desktop/screens/Garden.jsx
@@ -1,0 +1,187 @@
+import React, { useMemo } from 'react'
+import { C, CSTAT } from '../../tokens.js'
+import { CIcon, IC } from '../../icons.jsx'
+import { CSwash, CKicker, CBtn, CStatusChip, CIconBadge, statusOf, pressProps } from '../../primitives.jsx'
+import { PlantIcon } from '../../PlantIcon.jsx'
+import { FloorPlan } from '../../FloorPlan.jsx'
+import { DesktopHeader } from '../DesktopHeader.jsx'
+
+const ROOM_FILL = {
+  kitchen: '#EFE7D0', bath: '#E5EFE6', bathroom: '#E5EFE6',
+  bedroom: '#F2E7D8', living: '#EFDDC8', 'living room': '#EFDDC8',
+  study: '#ECE4CD', office: '#ECE4CD',
+}
+function roomFill(r) {
+  return ROOM_FILL[(r.name || '').toLowerCase()] || ROOM_FILL[r.id] || '#F2EBDB'
+}
+
+function GardenMarker({ plant, isActive, wateredSet, openPlant }) {
+  const wet = wateredSet.has(plant.id)
+  const status = wet ? 'ok' : plant._status
+  const s = CSTAT[status] || CSTAT.ok
+  return (
+    <div {...pressProps((e) => { e.stopPropagation(); openPlant(plant.id) }, `Open ${plant.name}`)}
+      style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', cursor: 'pointer' }}>
+      <div style={{
+        width: isActive ? 17 : 12, height: isActive ? 17 : 12,
+        borderRadius: '50%', background: s.color,
+        boxShadow: `0 0 0 3px ${C.panel}, 0 1px 3px rgba(0,0,0,.3)`,
+        transition: 'all .2s',
+      }} />
+      {isActive && (
+        <div style={{
+          marginTop: 6, background: '#fff', borderRadius: 9, padding: '5px 10px',
+          boxShadow: '0 8px 22px rgba(80,50,20,.2)', display: 'flex',
+          alignItems: 'center', gap: 7, whiteSpace: 'nowrap',
+          border: `1px solid ${C.line}`,
+        }}>
+          <span style={{ width: 7, height: 7, borderRadius: '50%', background: s.color }} />
+          <span style={{ fontFamily: C.serif, fontSize: 13, fontStyle: 'italic', color: C.ink }}>{plant.name}</span>
+          <span style={{ fontFamily: C.sans, fontSize: 11, fontWeight: 700, color: s.color }}>
+            {status === 'overdue' ? `${Math.abs(plant._daysUntil)}d late` : status === 'today' ? 'today' : `${plant._daysUntil}d`}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function GARow({ plant, wateredSet, onWater, openPlant }) {
+  const wet = wateredSet.has(plant.id)
+  const status = wet ? 'ok' : plant._status
+  const s = CSTAT[status] || CSTAT.ok
+  const effectivePlant = { ...plant, _status: status }
+  return (
+    <div {...pressProps(() => openPlant(plant.id), `Open ${plant.name}`)}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 13,
+        padding: '12px 0', borderBottom: `1px solid ${C.line2}`, cursor: 'pointer',
+      }}>
+      <CIconBadge plant={effectivePlant} size={44} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontFamily: C.serif, fontSize: 18, color: C.ink, lineHeight: 1.05, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{plant.name}</div>
+        <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.muted, fontStyle: 'italic', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{plant.species || ''}</div>
+      </div>
+      <div style={{ textAlign: 'right', flexShrink: 0 }}>
+        <div style={{ fontFamily: C.sans, fontSize: 11, fontWeight: 700, color: s.color, whiteSpace: 'nowrap' }}>
+          {status === 'overdue' ? `${Math.abs(plant._daysUntil)}d late` : 'Due today'}
+        </div>
+        <button onClick={(e) => { e.stopPropagation(); onWater(plant.id) }}
+          style={{ border: 'none', background: 'none', padding: 0, fontFamily: C.serif, fontSize: 14, fontStyle: 'italic', color: C.terra, cursor: 'pointer' }}>
+          Water →
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function todayLabel() {
+  return new Date().toLocaleDateString('en-US', { weekday: 'long', day: 'numeric', month: 'long' })
+}
+
+export function Garden({ plants, floors, activeFloorId, weather, wateredSet, onWater, waterAll, openPlant, ctx }) {
+  const thirsty = plants.filter((p) => statusOf(p, wateredSet) !== 'ok')
+  const allDone = thirsty.length === 0
+
+  const activeFloor = floors.find((f) => f.id === activeFloorId) || floors[0]
+  const floorRooms = activeFloor?.rooms || []
+  const floorName = activeFloor?.name || 'Ground floor'
+  const firstThirsty = thirsty[0]
+
+  const thirstyCount = thirsty.length
+  const countWord = ['zero', 'one plant is', 'two plants are', 'three plants are', 'four plants are', 'five plants are'][thirstyCount] || `${thirstyCount} plants are`
+
+  const weatherDisplay = weather?.current
+    ? { temp: Math.round(weather.current.temp), condition: weather.current.condition?.sky || 'Clear' }
+    : null
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'flex', flexDirection: 'column' }}>
+      <DesktopHeader activeScreen="garden" onNav={ctx.navigate} user={ctx.user} weather={weatherDisplay} />
+      <div style={{
+        flex: 1, display: 'grid', gridTemplateColumns: '1fr 372px',
+        gap: 34, padding: '30px 34px', minHeight: 0, overflow: 'hidden',
+      }}>
+        {/* main floorplan */}
+        <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+          <div style={{ marginBottom: 22 }}>
+            <CKicker>{todayLabel()} · The morning round</CKicker>
+            <h1 style={{ fontFamily: C.serif, fontSize: 37, fontWeight: 400, lineHeight: 1.1, margin: '8px 0 0', letterSpacing: -0.3 }}>
+              {allDone
+                ? <>Every plant is <span style={{ fontStyle: 'italic', color: C.greenBright }}>happy.</span></>
+                : <>Good morning — <span style={{ fontStyle: 'italic', color: C.terra }}>{countWord} thirsty.</span></>}
+            </h1>
+            <div style={{ marginTop: 8, marginLeft: 2 }}><CSwash width={300} /></div>
+          </div>
+          <div style={{
+            flex: 1, background: C.card, borderRadius: 8,
+            border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)',
+            padding: 22, position: 'relative', overflow: 'hidden', display: 'flex', flexDirection: 'column',
+          }}>
+            {/* gold corner bracket */}
+            <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+            <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: 14 }}>
+              <div>
+                <CKicker>Plate I · The Home</CKicker>
+                <div style={{ fontFamily: C.serif, fontSize: 22, color: C.ink, marginTop: 2 }}>{floorName}</div>
+              </div>
+              <div style={{ display: 'flex', gap: 14, alignItems: 'center' }}>
+                {Object.values(CSTAT).map((v) => (
+                  <span key={v.label} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12.5, color: C.muted, fontFamily: C.sans, fontWeight: 600 }}>
+                    <span style={{ width: 8, height: 8, borderRadius: '50%', background: v.color }} />
+                    {v.label}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div style={{ flex: 1, background: C.panel, borderRadius: 8, border: `1px solid ${C.line2}`, padding: 18, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <FloorPlan
+                width={660} height={384}
+                bg={C.panel} rooms={floorRooms} plants={plants}
+                activeId={firstThirsty?.id || plants[0]?.id}
+                renderMarker={(p, isActive) => (
+                  <GardenMarker plant={p} isActive={isActive} wateredSet={wateredSet} openPlant={openPlant} />
+                )}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* right rail */}
+        <aside style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+          <div style={{ background: C.terraSoft, border: `1px solid ${C.terra}33`, borderRadius: 8, padding: '16px 18px', marginBottom: 18 }}>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 10 }}>
+              <span style={{ fontFamily: C.serif, fontSize: 56, lineHeight: 0.9, color: C.terra }}>{thirstyCount}</span>
+              <div>
+                <div style={{ fontFamily: C.serif, fontSize: 22, fontStyle: 'italic', color: C.ink }}>need water</div>
+                <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.muted }}>of {plants.length} plants · {[...new Set(plants.map(p => p.room).filter(Boolean))].length} rooms</div>
+              </div>
+            </div>
+          </div>
+          <div style={{ flex: 1, overflow: 'hidden' }}>
+            {thirsty.map((p) => (
+              <GARow key={p.id} plant={p} wateredSet={wateredSet} onWater={onWater} openPlant={openPlant} />
+            ))}
+            {allDone && (
+              <div style={{ padding: '30px 0', textAlign: 'center', fontFamily: C.serif, fontStyle: 'italic', fontSize: 17, color: C.muted }}>
+                Nothing on the round — nicely done.
+              </div>
+            )}
+          </div>
+          {weather?.rainSoon && (
+            <div style={{ margin: '14px 0', background: C.sageBg, borderLeft: `3px solid ${C.greenBright}`, borderRadius: 4, padding: '14px 16px' }}>
+              <div style={{ fontFamily: C.serif, fontSize: 17, fontStyle: 'italic', color: C.green, marginBottom: 3 }}>Rain is on the way.</div>
+              <div style={{ fontFamily: C.sans, fontSize: 13, color: C.muted, lineHeight: 1.5 }}>Your outdoor plants have been skipped today — the forecast will do the watering.</div>
+            </div>
+          )}
+          {!allDone && (
+            <CBtn kind="primary" full onClick={() => waterAll(thirsty.map((p) => p.id))}>
+              <CIcon d={IC.drop} size={18} color="#FFF6EE" fill="#FFF6EE" w={0} /> Water all {thirstyCount} →
+            </CBtn>
+          )}
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/Insights.jsx
+++ b/src/conservatory/desktop/screens/Insights.jsx
@@ -1,0 +1,182 @@
+import React, { useState, useMemo } from 'react'
+import { C, CSTAT } from '../../tokens.js'
+import { CKicker, pressProps, statusOf } from '../../primitives.jsx'
+import { CIconBadge } from '../../primitives.jsx'
+import { DesktopHeader } from '../DesktopHeader.jsx'
+
+function InHero({ value, label, sub, accent }) {
+  return (
+    <div style={{ flex: 1, background: C.card, borderRadius: 8, border: `1px solid ${C.line2}`, padding: '18px' }}>
+      <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.muted, marginBottom: 8 }}>{label}</div>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+        <span style={{ fontFamily: C.serif, fontSize: 38, lineHeight: 0.9, color: accent || C.ink }}>{value}</span>
+        {sub && <span style={{ fontFamily: C.sans, fontSize: 12.5, color: C.muted }}>{sub}</span>}
+      </div>
+    </div>
+  )
+}
+
+function TrendChart({ data, max }) {
+  const W = 560, H = 190, pad = 26
+  const bw = (W - pad * 2) / data.length
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`} role="img" aria-label="Waterings per week over the last 8 weeks">
+      {[0, 4, 8, 12, 16].map((g) => {
+        const y = H - pad - (g / max) * (H - pad * 2)
+        return <g key={g}><line x1={pad} y1={y} x2={W - pad} y2={y} stroke={C.line2} strokeWidth="1" /><text x={pad - 8} y={y + 4} textAnchor="end" fontFamily={C.sans} fontSize="10" fill={C.muted}>{g}</text></g>
+      })}
+      {data.map((v, i) => {
+        const h = (v / max) * (H - pad * 2)
+        const x = pad + i * bw + bw * 0.22
+        const last = i === data.length - 1
+        return (
+          <g key={i}>
+            <rect x={x} y={H - pad - h} width={bw * 0.56} height={h} rx="3" fill={last ? C.terra : C.terraSoft} />
+            {last && <rect x={x} y={H - pad - h} width={bw * 0.56} height={h} rx="3" fill="none" stroke={C.terra} strokeWidth="1.5" />}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+function Donut({ plants }) {
+  const healthy = plants.filter((p) => p._status === 'ok').length
+  const dueToday = plants.filter((p) => p._status === 'today').length
+  const overdue = plants.filter((p) => p._status === 'overdue').length
+  const total = plants.length
+  const segs = [['Healthy', healthy, CSTAT.ok.color], ['Due today', dueToday, CSTAT.today.color], ['Overdue', overdue, CSTAT.overdue.color]].filter((s) => s[1] > 0)
+  const r = 52, cir = 2 * Math.PI * r
+  let off = 0
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 22 }}>
+      <svg width="132" height="132" viewBox="0 0 132 132" role="img" aria-label={`${healthy} of ${total} plants healthy`}>
+        <circle cx="66" cy="66" r={r} fill="none" stroke={C.panel} strokeWidth="16" />
+        {segs.map(([name, n, col]) => {
+          const len = (n / total) * cir
+          const el = <circle key={name} cx="66" cy="66" r={r} fill="none" stroke={col} strokeWidth="16" strokeDasharray={`${len} ${cir - len}`} strokeDashoffset={-off} transform="rotate(-90 66 66)" />
+          off += len; return el
+        })}
+        <text x="66" y="62" textAnchor="middle" fontFamily={C.serif} fontSize="30" fill={C.ink}>{total}</text>
+        <text x="66" y="80" textAnchor="middle" fontFamily={C.sans} fontSize="11" fill={C.muted}>plants</text>
+      </svg>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {segs.map(([name, n, col]) => (
+          <div key={name} style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+            <span style={{ width: 10, height: 10, borderRadius: 3, background: col }} />
+            <span style={{ fontFamily: C.sans, fontSize: 13.5, color: C.muted, width: 78 }}>{name}</span>
+            <span style={{ fontFamily: C.serif, fontSize: 17, color: C.ink }}>{n}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function RoomBar({ name, n, max }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 0' }}>
+      <span style={{ fontFamily: C.sans, fontSize: 13, color: C.ink, width: 96 }}>{name}</span>
+      <div style={{ flex: 1, height: 9, background: C.panel, borderRadius: 5, overflow: 'hidden' }}>
+        <div style={{ width: `${max > 0 ? (n / max) * 100 : 0}%`, height: '100%', background: C.greenBright, borderRadius: 5 }} />
+      </div>
+      <span style={{ fontFamily: C.serif, fontSize: 15, color: C.ink, width: 20, textAlign: 'right' }}>{n}</span>
+    </div>
+  )
+}
+
+export function Insights({ plants, wateredSet, ctx }) {
+  const [range, setRange] = useState('season')
+  const effective = plants.map((p) => ({ ...p, _status: statusOf(p, wateredSet) }))
+  const thriving = effective.filter((p) => p._status === 'ok').length
+
+  const roomCounts = useMemo(() => {
+    const c = {}
+    plants.forEach((p) => { if (p.room) c[p.room] = (c[p.room] || 0) + 1 })
+    return Object.entries(c).sort((a, b) => b[1] - a[1])
+  }, [plants])
+  const maxRoom = Math.max(1, ...roomCounts.map(([, n]) => n))
+
+  const soonest = [...effective].filter((p) => p._status !== 'ok').sort((a, b) => a._daysUntil - b._daysUntil).slice(0, 4)
+
+  const totalWaterings = plants.reduce((acc, p) => acc + (p.wateringLog?.length || 0), 0)
+  const weeklyData = [6, 9, 7, 11, 8, 12, 10, totalWaterings > 0 ? Math.min(20, totalWaterings) : 14]
+
+  const wx = ctx.weather?.current ? { temp: Math.round(ctx.weather.current.temp), condition: ctx.weather.current.condition?.sky || 'Clear' } : null
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'flex', flexDirection: 'column' }}>
+      <DesktopHeader activeScreen="insights" onNav={ctx.navigate} user={ctx.user} weather={wx} />
+      <div style={{ flex: 1, padding: '28px 34px', display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
+        <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 18 }}>
+          <div>
+            <CKicker>How your garden is doing</CKicker>
+            <h1 style={{ fontFamily: C.serif, fontSize: 34, fontWeight: 400, margin: '6px 0 0', letterSpacing: -0.3 }}>
+              A season of <span style={{ fontStyle: 'italic', color: C.terra }}>good care.</span>
+            </h1>
+          </div>
+          <div style={{ display: 'inline-flex', background: C.panel, borderRadius: 9, padding: 3, border: `1px solid ${C.line2}` }}>
+            {[['Month', 'month'], ['Season', 'season'], ['Year', 'year']].map(([label, key]) => (
+              <span key={key} onClick={() => setRange(key)}
+                style={{ fontFamily: C.serif, fontSize: 14, fontStyle: 'italic', padding: '7px 16px', borderRadius: 7, cursor: 'pointer', background: range === key ? C.card : 'transparent', color: range === key ? C.terra : C.muted }}>
+                {label}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 14, marginBottom: 16 }}>
+          <InHero label="Waterings this season" value={totalWaterings || '—'} sub="+12% vs last" accent={C.terra} />
+          <InHero label="Care streak" value="—" sub="days" accent={C.gold} />
+          <InHero label="Skipped by rain" value="—" sub="this month" accent={C.greenBright} />
+          <InHero label="Plants thriving" value={`${thriving}/${plants.length}`} sub={plants.length > 0 ? `${Math.round(thriving / plants.length * 100)}%` : ''} accent={C.green} />
+        </div>
+
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1.5fr 1fr', gridTemplateRows: '1fr 1fr', gap: 16, minHeight: 0 }}>
+          <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line2}`, padding: 20, position: 'relative', overflow: 'hidden' }}>
+            <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+            <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+              <div><CKicker>Watering activity</CKicker><div style={{ fontFamily: C.serif, fontSize: 19, marginTop: 2 }}>Per week</div></div>
+              <span style={{ fontFamily: C.sans, fontSize: 12.5, color: C.muted }}>Last 8 weeks</span>
+            </div>
+            <TrendChart data={weeklyData} max={20} />
+          </div>
+
+          <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line2}`, padding: 20 }}>
+            <CKicker>Health right now</CKicker>
+            <div style={{ marginTop: 16 }}><Donut plants={effective} /></div>
+          </div>
+
+          <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line2}`, padding: 20 }}>
+            <CKicker>Plants per room</CKicker>
+            <div style={{ marginTop: 10 }}>
+              {roomCounts.map(([name, n]) => <RoomBar key={name} name={name} n={n} max={maxRoom} />)}
+              {roomCounts.length === 0 && <div style={{ fontFamily: C.serif, fontStyle: 'italic', fontSize: 15, color: C.muted }}>No room data yet.</div>}
+            </div>
+          </div>
+
+          <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line2}`, padding: 20 }}>
+            <CKicker>Needs you soonest</CKicker>
+            <div style={{ marginTop: 8 }}>
+              {soonest.length === 0
+                ? <div style={{ fontFamily: C.serif, fontStyle: 'italic', fontSize: 15, color: C.muted, padding: '12px 0' }}>All caught up.</div>
+                : soonest.map((p) => {
+                    const s = CSTAT[p._status] || CSTAT.ok
+                    const label = p._status === 'overdue' ? `${Math.abs(p._daysUntil)}d late` : p._status === 'today' ? 'today' : `${p._daysUntil}d`
+                    return (
+                      <div key={p.id} {...pressProps(() => ctx.openPlant(p.id), `Open ${p.name}`)}
+                        style={{ display: 'flex', alignItems: 'center', gap: 11, padding: '7px 0', borderBottom: `1px solid ${C.line2}`, cursor: 'pointer' }}>
+                        <CIconBadge plant={p} size={34} radius={10} />
+                        <span style={{ flex: 1, fontFamily: C.serif, fontSize: 16, color: C.ink }}>{p.name}</span>
+                        <span style={{ fontFamily: C.sans, fontSize: 12, fontWeight: 700, color: s.color }}>{label}</span>
+                      </div>
+                    )
+                  })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/Library.jsx
+++ b/src/conservatory/desktop/screens/Library.jsx
@@ -1,0 +1,103 @@
+import React, { useState, useMemo } from 'react'
+import { C, CSTAT } from '../../tokens.js'
+import { CIcon, IC } from '../../icons.jsx'
+import { CKicker, CBtn, pressProps, statusOf } from '../../primitives.jsx'
+import { PlantIcon } from '../../PlantIcon.jsx'
+import { DesktopHeader } from '../DesktopHeader.jsx'
+
+function LibCard({ plant, onOpen }) {
+  const s = CSTAT[plant._status] || CSTAT.ok
+  const daysLabel = plant._status === 'overdue'
+    ? `${Math.abs(plant._daysUntil)}d overdue`
+    : plant._status === 'today' ? 'Water today' : `Water in ${plant._daysUntil}d`
+  return (
+    <div {...pressProps(() => onOpen(plant.id), `Open ${plant.name}`)}
+      style={{ background: C.card, borderRadius: 10, border: `1px solid ${C.line2}`, boxShadow: '0 6px 20px -14px rgba(120,90,40,.35)', padding: 16, display: 'flex', flexDirection: 'column', cursor: 'pointer' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+        <div style={{ width: 64, height: 64, borderRadius: 16, background: C.panel, border: `1px solid ${C.line2}`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <PlantIcon type={plant.icon || 'monstera'} size={48} />
+        </div>
+        <span style={{ width: 9, height: 9, borderRadius: '50%', background: s.color, marginTop: 4 }} title={s.label} />
+      </div>
+      <div style={{ fontFamily: C.serif, fontSize: 20, color: C.ink, marginTop: 12, lineHeight: 1.05 }}>{plant.name}</div>
+      <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.muted, fontStyle: 'italic' }}>{plant.species || ''}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 10, fontFamily: C.sans, fontSize: 12, color: C.muted }}>
+        <CIcon d={IC.pin} size={13} color={C.muted} w={1.6} />{plant.room || '—'}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 14, paddingTop: 12, borderTop: `1px solid ${C.line2}` }}>
+        <span style={{ fontFamily: C.sans, fontSize: 12, color: s.color, fontWeight: 700 }}>{daysLabel}</span>
+        <span style={{ fontFamily: C.serif, fontSize: 14, fontStyle: 'italic', color: C.terra, cursor: 'pointer' }}>Open →</span>
+      </div>
+    </div>
+  )
+}
+
+export function Library({ plants, wateredSet, ctx }) {
+  const [filter, setFilter] = useState('all')
+  const [view, setView] = useState('list')
+
+  const rooms = useMemo(() => [...new Set(plants.map((p) => p.room).filter(Boolean))], [plants])
+
+  const filtered = useMemo(() => {
+    if (filter === 'water') return plants.filter((p) => statusOf(p, wateredSet) !== 'ok')
+    if (rooms.includes(filter)) return plants.filter((p) => p.room === filter)
+    return plants
+  }, [plants, wateredSet, filter, rooms])
+
+  const needsWater = plants.filter((p) => statusOf(p, wateredSet) !== 'ok').length
+  const wx = ctx.weather?.current ? { temp: Math.round(ctx.weather.current.temp), condition: ctx.weather.current.condition?.sky || 'Clear' } : null
+
+  const filters = [
+    { id: 'all', label: 'All plants', count: plants.length },
+    { id: 'water', label: 'Needs water', count: needsWater },
+    ...rooms.slice(0, 4).map((r) => ({ id: r, label: r, count: plants.filter((p) => p.room === r).length })),
+  ]
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'flex', flexDirection: 'column' }}>
+      <DesktopHeader activeScreen="garden" onNav={ctx.navigate} user={ctx.user} weather={wx} />
+      <div style={{ flex: 1, padding: '28px 34px', display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
+        <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 18 }}>
+          <div>
+            <CKicker>The whole collection</CKicker>
+            <h1 style={{ fontFamily: C.serif, fontSize: 34, fontWeight: 400, margin: '6px 0 0', letterSpacing: -0.3 }}>
+              Every plant you <span style={{ fontStyle: 'italic', color: C.terra }}>tend.</span>
+            </h1>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div style={{ display: 'inline-flex', background: C.panel, borderRadius: 9, padding: 3, border: `1px solid ${C.line2}` }}>
+              {[['Map', 'map'], ['List', 'list']].map(([label, key]) => (
+                <span key={key} onClick={() => setView(key)} style={{ display: 'flex', alignItems: 'center', gap: 6, fontFamily: C.serif, fontSize: 14, fontStyle: 'italic', padding: '7px 14px', borderRadius: 7, cursor: 'pointer', background: view === key ? C.card : 'transparent', color: view === key ? C.terra : C.muted, boxShadow: view === key ? '0 1px 2px rgba(0,0,0,.06)' : 'none' }}>
+                  <CIcon d={key === 'map' ? IC.pin : IC.grid} size={14} color={view === key ? C.terra : C.muted} w={1.7} />{label}
+                </span>
+              ))}
+            </div>
+            <CBtn kind="primary" style={{ borderRadius: 8, padding: '11px 16px', fontSize: 15 }} onClick={() => ctx.navigate('addplant')}>
+              <CIcon d={IC.plus} size={16} color="#FFF6EE" w={2} /> Add plant
+            </CBtn>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 9, marginBottom: 20, flexWrap: 'wrap' }}>
+          {filters.map(({ id, label, count }) => (
+            <span key={id} onClick={() => setFilter(id)}
+              style={{ display: 'flex', alignItems: 'center', gap: 7, fontFamily: C.sans, fontSize: 13.5, fontWeight: 600, padding: '8px 14px', borderRadius: 20, cursor: 'pointer', background: filter === id ? C.terra : C.card, color: filter === id ? '#FFF6EE' : C.muted, border: `1px solid ${filter === id ? C.terra : C.line}` }}>
+              {label} <span style={{ fontFamily: C.sans, fontSize: 11.5, fontWeight: 700, opacity: filter === id ? 0.85 : 0.7 }}>{count}</span>
+            </span>
+          ))}
+          <div style={{ flex: 1 }} />
+          <span style={{ display: 'flex', alignItems: 'center', gap: 7, fontFamily: C.sans, fontSize: 13.5, color: C.muted, padding: '8px 14px' }}>
+            <CIcon d={IC.sliders} size={15} color={C.muted} w={1.7} />Sort: next due
+          </span>
+        </div>
+
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gridAutoRows: 'min-content', gap: 16, alignContent: 'start', overflowY: 'auto' }}>
+          {filtered.map((p) => <LibCard key={p.id} plant={p} onOpen={ctx.openPlant} />)}
+          {filtered.length === 0 && (
+            <div style={{ gridColumn: '1/-1', padding: '40px 0', textAlign: 'center', fontFamily: C.serif, fontStyle: 'italic', fontSize: 17, color: C.muted }}>No plants match that filter.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/Login.jsx
+++ b/src/conservatory/desktop/screens/Login.jsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react'
+import { C } from '../../tokens.js'
+import { CIcon, IC } from '../../icons.jsx'
+import { CSwash, CKicker, CBtn } from '../../primitives.jsx'
+import { PlantIcon } from '../../PlantIcon.jsx'
+
+function GoogleG({ size = 18 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 48 48" aria-hidden="true">
+      <path fill="#EA4335" d="M24 9.5c3.5 0 6.6 1.2 9 3.6l6.7-6.7C35.6 2.4 30.1 0 24 0 14.6 0 6.5 5.4 2.5 13.2l7.9 6.1C12.3 13.2 17.7 9.5 24 9.5z" />
+      <path fill="#4285F4" d="M46.5 24.5c0-1.6-.1-3.2-.4-4.7H24v9h12.7c-.5 3-2.2 5.5-4.7 7.2l7.3 5.7C43.6 37.8 46.5 31.7 46.5 24.5z" />
+      <path fill="#FBBC05" d="M10.4 28.7c-.5-1.5-.8-3-.8-4.7s.3-3.2.8-4.7l-7.9-6.1C.9 16.5 0 20.1 0 24s.9 7.5 2.5 10.8l7.9-6.1z" />
+      <path fill="#34A853" d="M24 48c6.1 0 11.3-2 15-5.5l-7.3-5.7c-2 1.4-4.7 2.3-7.7 2.3-6.3 0-11.7-3.7-13.6-9.8l-7.9 6.1C6.5 42.6 14.6 48 24 48z" />
+    </svg>
+  )
+}
+
+export function Login({ onGoogleSignIn }) {
+  const [email, setEmail] = useState('')
+  const cluster = ['fern', 'monstera', 'snake', 'lily', 'succulent']
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'grid', gridTemplateColumns: '1.05fr 1fr' }}>
+      {/* brand panel */}
+      <div style={{ background: C.green, color: '#FBF7EE', padding: '54px 56px', display: 'flex', flexDirection: 'column', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ height: 5, width: 120, background: `linear-gradient(90deg, ${C.terra} 0%, ${C.terra} 55%, ${C.gold} 55%, ${C.gold} 100%)`, borderRadius: 3 }} />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 26 }}>
+          <div style={{ width: 40, height: 40, borderRadius: '50%', background: C.terra, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <CIcon d={IC.leaf} size={20} color={C.goldSoft} fill={C.goldSoft} w={0} />
+          </div>
+          <span style={{ fontFamily: C.serif, fontSize: 26, fontStyle: 'italic', fontWeight: 500 }}>Conservatory</span>
+        </div>
+        <div style={{ marginTop: 'auto', marginBottom: 'auto', paddingRight: 20 }}>
+          <div style={{ fontFamily: C.sans, fontSize: 12, letterSpacing: 2, textTransform: 'uppercase', color: C.goldSoft, fontWeight: 700, marginBottom: 14 }}>Your plants, mapped &amp; minded</div>
+          <h1 style={{ fontFamily: C.serif, fontSize: 46, fontWeight: 400, lineHeight: 1.12, margin: 0, letterSpacing: -0.5 }}>
+            A quiet home for<br /><span style={{ fontStyle: 'italic', color: C.gold }}>every living thing</span><br />you tend.
+          </h1>
+          <p style={{ fontFamily: C.serif, fontSize: 18, fontStyle: 'italic', color: '#E4ECDD', lineHeight: 1.5, margin: '20px 0 0', maxWidth: 380 }}>
+            Know what needs water, where each plant lives, and let the weather lend a hand.
+          </p>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'flex-end', gap: 4, marginTop: 30 }}>
+          {cluster.map((t) => <PlantIcon key={t} type={t} size={58} tint="#A9C0A2" pot="#C9784F" />)}
+          <div style={{ flex: 1, height: 2, background: 'rgba(255,255,255,0.18)', marginBottom: 10, marginLeft: 8 }} />
+        </div>
+      </div>
+
+      {/* sign-in card */}
+      <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', padding: '54px 80px' }}>
+        <div style={{ maxWidth: 360, width: '100%', margin: '0 auto' }}>
+          <CKicker>Welcome back</CKicker>
+          <h2 style={{ fontFamily: C.serif, fontSize: 34, fontWeight: 400, margin: '8px 0 0', letterSpacing: -0.3 }}>
+            Sign in to your <span style={{ fontStyle: 'italic', color: C.terra }}>garden.</span>
+          </h2>
+          <div style={{ marginTop: 8, marginBottom: 30 }}><CSwash width={170} /></div>
+
+          <button onClick={onGoogleSignIn}
+            style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 11, background: '#fff', border: `1px solid ${C.line}`, borderRadius: 6, padding: '14px', fontFamily: C.sans, fontSize: 15, fontWeight: 600, color: C.ink, cursor: 'pointer', boxShadow: '0 1px 2px rgba(40,30,20,.05)' }}>
+            <GoogleG size={19} /> Continue with Google
+          </button>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: 14, margin: '22px 0' }}>
+            <div style={{ flex: 1, height: 1, background: C.line }} />
+            <span style={{ fontFamily: C.serif, fontSize: 14, fontStyle: 'italic', color: C.muted }}>or with email</span>
+            <div style={{ flex: 1, height: 1, background: C.line }} />
+          </div>
+
+          <label style={{ fontFamily: C.sans, fontSize: 12.5, fontWeight: 600, color: C.muted }}>Email address</label>
+          <div style={{ display: 'flex', alignItems: 'center', border: `1px solid ${C.line}`, borderRadius: 6, padding: '12px 14px', marginTop: 6, marginBottom: 14, background: '#fff' }}>
+            <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@example.com"
+              style={{ border: 'none', outline: 'none', flex: 1, fontFamily: C.sans, fontSize: 14.5, color: C.ink, background: 'transparent' }} />
+          </div>
+          <CBtn kind="primary" full style={{ borderRadius: 6 }}>Continue →</CBtn>
+
+          <p style={{ fontFamily: C.sans, fontSize: 13, color: C.muted, textAlign: 'center', marginTop: 24, lineHeight: 1.5 }}>
+            New to Conservatory? <span style={{ fontFamily: C.serif, fontStyle: 'italic', color: C.terra, fontSize: 15, cursor: 'pointer' }}>Plant your first →</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/Members.jsx
+++ b/src/conservatory/desktop/screens/Members.jsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { C } from '../../tokens.js'
+import { CIcon, IC } from '../../icons.jsx'
+import { CKicker, CBtn } from '../../primitives.jsx'
+import { DesktopHeader } from '../DesktopHeader.jsx'
+
+const ROLE_STYLE = {
+  Owner:  { color: '#3E5641', soft: '#E4EDDD' },
+  Carer:  { color: '#5E9C4F', soft: '#DCEBCB' },
+  Viewer: { color: '#857F6E', soft: '#ECE6D8' },
+}
+
+function RolePill({ role }) {
+  const s = ROLE_STYLE[role] || ROLE_STYLE.Viewer
+  return <span style={{ fontFamily: C.sans, fontSize: 11.5, fontWeight: 700, color: s.color, background: s.soft, padding: '4px 11px', borderRadius: 20, whiteSpace: 'nowrap' }}>{role}</span>
+}
+
+const TINTS = ['#3E5641', '#C9784F', '#6E7F4E', '#D9A441', '#5E9C4F', '#857F6E']
+
+function MemberRow({ member, index, last }) {
+  const tint = TINTS[index % TINTS.length]
+  const roleKey = member.role === 'owner' ? 'Owner' : member.role === 'carer' ? 'Carer' : 'Viewer'
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 16, padding: '15px 0', borderBottom: last ? 'none' : `1px solid ${C.line2}` }}>
+      <div style={{ width: 48, height: 48, borderRadius: '50%', background: tint, color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: C.serif, fontSize: 20, flexShrink: 0 }}>
+        {(member.name || member.email || '?')[0].toUpperCase()}
+      </div>
+      <div style={{ width: 220, minWidth: 0 }}>
+        <div style={{ fontFamily: C.serif, fontSize: 18, color: C.ink, lineHeight: 1.05 }}>{member.name || 'Member'}</div>
+        <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.muted, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{member.email || ''}</div>
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontFamily: C.sans, fontSize: 11, color: C.muted, marginBottom: 2 }}>Access</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontFamily: C.serif, fontSize: 15, fontStyle: 'italic', color: C.ink }}>
+          <CIcon d={IC.pin} size={14} color={C.terra} w={1.7} />All rooms
+        </div>
+      </div>
+      <div style={{ width: 110 }}>
+        <div style={{ fontFamily: C.sans, fontSize: 11, color: C.muted, marginBottom: 2 }}>Last active</div>
+        <div style={{ fontFamily: C.sans, fontSize: 13, color: C.muted }}>Recently</div>
+      </div>
+      <RolePill role={roleKey} />
+      <CIcon d={IC.sliders} size={18} color={C.muted} w={1.7} style={{ cursor: 'pointer' }} />
+    </div>
+  )
+}
+
+export function Members({ household, ctx }) {
+  const members = household?.members || []
+  const invites = household?.pendingInvites || []
+  const wx = ctx.weather?.current ? { temp: Math.round(ctx.weather.current.temp), condition: ctx.weather.current.condition?.sky || 'Clear' } : null
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'flex', flexDirection: 'column' }}>
+      <DesktopHeader activeScreen="garden" onNav={ctx.navigate} user={ctx.user} weather={wx} />
+      <div style={{ flex: 1, padding: '28px 34px', display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
+        <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 20 }}>
+          <div>
+            <CKicker>Who tends this garden</CKicker>
+            <h1 style={{ fontFamily: C.serif, fontSize: 33, fontWeight: 400, margin: '6px 0 0', letterSpacing: -0.3, whiteSpace: 'nowrap' }}>
+              The <span style={{ fontStyle: 'italic', color: C.terra }}>household.</span>
+            </h1>
+          </div>
+          <CBtn kind="primary" style={{ borderRadius: 8, fontSize: 15 }}>
+            <CIcon d={IC.plus} size={16} color="#FFF6EE" w={2} /> Invite someone
+          </CBtn>
+        </div>
+
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 312px', gap: 26, minHeight: 0, overflow: 'hidden' }}>
+          <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)', padding: 24, position: 'relative', overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+            <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+            <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+            <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 6 }}>
+              <div>
+                <CKicker>Members</CKicker>
+                <div style={{ fontFamily: C.serif, fontSize: 21, marginTop: 2 }}>{members.length} people</div>
+              </div>
+              <span style={{ fontFamily: C.sans, fontSize: 12.5, color: C.muted }}>Greenhouse plan · up to 5</span>
+            </div>
+            <div style={{ flex: 1, overflow: 'auto' }}>
+              {members.length === 0 ? (
+                <div style={{ padding: '30px 0', textAlign: 'center', fontFamily: C.serif, fontStyle: 'italic', fontSize: 16, color: C.muted }}>No household members yet. Invite someone to share care.</div>
+              ) : (
+                members.map((m, i) => <MemberRow key={m.id || i} member={m} index={i} last={i === members.length - 1} />)
+              )}
+            </div>
+          </div>
+
+          <aside style={{ display: 'flex', flexDirection: 'column', gap: 16, minHeight: 0 }}>
+            <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05)', padding: 20 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+                <CKicker>Pending invites</CKicker>
+                <span style={{ fontFamily: C.serif, fontSize: 28, color: C.gold, lineHeight: 1 }}>{invites.length}</span>
+              </div>
+              {invites.length === 0 && <div style={{ fontFamily: C.serif, fontStyle: 'italic', fontSize: 15, color: C.muted }}>No pending invites.</div>}
+              {invites.map((inv, i) => (
+                <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 11, padding: '11px 0', borderBottom: i === invites.length - 1 ? 'none' : `1px solid ${C.line2}` }}>
+                  <div style={{ width: 36, height: 36, borderRadius: '50%', background: C.panel, border: `1px dashed ${C.line}`, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                    <CIcon d={IC.bell} size={15} color={C.muted} w={1.6} />
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontFamily: C.sans, fontSize: 13.5, color: C.ink, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{inv.email}</div>
+                    <div style={{ fontFamily: C.sans, fontSize: 12, color: C.muted, fontStyle: 'italic' }}>{inv.role || 'Viewer'}</div>
+                  </div>
+                  <span style={{ fontFamily: C.serif, fontSize: 13.5, fontStyle: 'italic', color: C.terra, cursor: 'pointer' }}>Resend</span>
+                </div>
+              ))}
+            </div>
+
+            <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05)', padding: 20, flex: 1 }}>
+              <CKicker>What roles can do</CKicker>
+              <div style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 14 }}>
+                {[['Owner', 'Manages plants, billing & people'], ['Carer', 'Logs care in their rooms'], ['Viewer', "Sees the garden, can't edit"]].map(([r, d]) => (
+                  <div key={r} style={{ display: 'flex', gap: 11, alignItems: 'flex-start' }}>
+                    <RolePill role={r} />
+                    <span style={{ flex: 1, fontFamily: C.sans, fontSize: 13, color: C.muted, lineHeight: 1.45 }}>{d}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/Plant.jsx
+++ b/src/conservatory/desktop/screens/Plant.jsx
@@ -1,0 +1,200 @@
+import React from 'react'
+import { C, CSTAT } from '../../tokens.js'
+import { CIcon, IC } from '../../icons.jsx'
+import { CKicker, CBtn, CStatusChip, pressProps } from '../../primitives.jsx'
+import { PlantIcon } from '../../PlantIcon.jsx'
+import { DesktopHeader } from '../DesktopHeader.jsx'
+
+const HIST_ICON = { water: 'drop', mist: 'rain', feed: 'leaf', note: 'bell' }
+const HIST_COLOR = (kind) => ({ water: C.terra, mist: C.greenBright, feed: C.gold, note: C.muted }[kind] || C.muted)
+
+function PDStat({ label, value, sub, accent }) {
+  return (
+    <div style={{ flex: 1, background: C.card, border: `1px solid ${C.line2}`, borderRadius: 8, padding: '14px 16px' }}>
+      <div style={{ fontFamily: C.sans, fontSize: 12, color: C.muted, marginBottom: 6 }}>{label}</div>
+      <div style={{ fontFamily: C.serif, fontSize: 25, color: accent || C.ink, lineHeight: 1 }}>{value}</div>
+      {sub && <div style={{ fontFamily: C.sans, fontSize: 12, color: C.muted, marginTop: 4 }}>{sub}</div>}
+    </div>
+  )
+}
+
+function PDEnv({ iconKey, iconColor, label, value, bar }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '11px 0', borderBottom: `1px solid ${C.line2}` }}>
+      <CIcon d={IC[iconKey]} size={18} color={iconColor} w={1.7} style={{ flexShrink: 0 }} />
+      <span style={{ fontFamily: C.sans, fontSize: 13.5, color: C.muted, width: 78 }}>{label}</span>
+      <div style={{ flex: 1, height: 6, borderRadius: 3, background: C.panel, overflow: 'hidden' }}>
+        <div style={{ width: `${bar}%`, height: '100%', background: iconColor, borderRadius: 3 }} />
+      </div>
+      <span style={{ fontFamily: C.serif, fontSize: 15, color: C.ink, width: 64, textAlign: 'right' }}>{value}</span>
+    </div>
+  )
+}
+
+function PDHistory({ h, isLast }) {
+  const col = HIST_COLOR(h.kind)
+  const iconKey = HIST_ICON[h.kind] || 'bell'
+  return (
+    <div style={{ display: 'flex', gap: 14 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <div style={{
+          width: 34, height: 34, borderRadius: '50%', background: C.card,
+          border: `1.5px solid ${col}`, display: 'flex', alignItems: 'center',
+          justifyContent: 'center', flexShrink: 0,
+        }}>
+          <CIcon d={IC[iconKey]} size={16} color={col} w={1.7} fill={h.kind === 'water' ? col : 'none'} />
+        </div>
+        {!isLast && <div style={{ width: 2, flex: 1, background: C.line, marginTop: 2 }} />}
+      </div>
+      <div style={{ paddingBottom: isLast ? 0 : 18 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 10 }}>
+          <span style={{ fontFamily: C.serif, fontSize: 17, color: C.ink }}>{h.label}</span>
+          <span style={{ fontFamily: C.sans, fontSize: 12, color: C.muted }}>{h.date}</span>
+        </div>
+        {h.detail && <div style={{ fontFamily: C.sans, fontSize: 13, color: C.muted, marginTop: 1 }}>{h.detail}</div>}
+      </div>
+    </div>
+  )
+}
+
+export function Plant({ plantId, plants, careHistory = [], onWater, ctx }) {
+  const plant = plants.find((p) => p.id === plantId) || plants[0]
+  if (!plant) return null
+
+  const wet = ctx.wateredSet?.has(plant.id)
+  const status = wet ? 'ok' : plant._status
+  const s = CSTAT[status] || CSTAT.ok
+
+  const statusLabel = status === 'overdue' ? `${Math.abs(plant._daysUntil)}d late`
+    : status === 'today' ? 'today' : 'Healthy'
+
+  const weatherDisplay = ctx.weather?.current
+    ? { temp: Math.round(ctx.weather.current.temp), condition: ctx.weather.current.condition?.sky || 'Clear' }
+    : null
+
+  // Build journal with optional "just watered" entry
+  const journal = wet
+    ? [{ date: 'Today', kind: 'water', label: 'Watered', detail: 'Just now · marked done' }, ...careHistory]
+    : careHistory
+
+  const sinceDays = plant._daysUntil < 0 ? Math.abs(plant._daysUntil) : 0
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'flex', flexDirection: 'column' }}>
+      <DesktopHeader activeScreen="garden" onNav={ctx.navigate} user={ctx.user} weather={weatherDisplay} />
+      <div style={{ flex: 1, padding: '22px 34px 30px', display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
+        {/* breadcrumb */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 18, fontFamily: C.sans, fontSize: 13, color: C.muted }}>
+          <button onClick={() => ctx.navigate('garden')} style={{ border: 'none', background: 'none', padding: 0, cursor: 'pointer', color: C.muted, fontFamily: C.sans, fontSize: 13 }}>Garden</button>
+          <CIcon d={IC.chevR} size={14} color={C.muted} />
+          <span style={{ whiteSpace: 'nowrap' }}>{plant.room || 'Living Room'}</span>
+          <CIcon d={IC.chevR} size={14} color={C.muted} />
+          <span style={{ color: C.ink, fontStyle: 'italic', fontFamily: C.serif, fontSize: 15 }}>{plant.name}</span>
+        </div>
+
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '380px 1fr', gap: 30, minHeight: 0, overflow: 'hidden' }}>
+          {/* left: profile + environment */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16, minHeight: 0 }}>
+            <div style={{
+              background: C.card, borderRadius: 8, border: `1px solid ${C.line}`,
+              boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)',
+              padding: 24, position: 'relative', overflow: 'hidden',
+            }}>
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
+                <div style={{
+                  width: 150, height: 150, borderRadius: '50%', background: C.panel,
+                  border: `1px solid ${C.line2}`, display: 'flex', alignItems: 'center',
+                  justifyContent: 'center', marginBottom: 16, position: 'relative',
+                }}>
+                  <PlantIcon type={plant.icon || 'monstera'} size={118} />
+                  <div style={{ position: 'absolute', bottom: 6, right: 14 }}>
+                    <CStatusChip status={status}>{statusLabel}</CStatusChip>
+                  </div>
+                </div>
+                <h1 style={{ fontFamily: C.serif, fontSize: 32, margin: 0, color: C.ink }}>{plant.name}</h1>
+                <div style={{ fontFamily: C.serif, fontSize: 16, fontStyle: 'italic', color: C.muted, marginTop: 2 }}>{plant.species || ''}</div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 10, fontFamily: C.sans, fontSize: 13, color: C.muted }}>
+                  <CIcon d={IC.pin} size={15} color={C.terra} w={1.7} />{plant.room || ''}
+                </div>
+              </div>
+              <div style={{ display: 'flex', gap: 9, marginTop: 20 }}>
+                <CBtn kind={wet ? 'green' : 'primary'} style={{ flex: 1, fontSize: 15, padding: '12px' }} onClick={() => onWater(plant.id)}>
+                  <CIcon d={wet ? IC.check : IC.drop} size={16} color="#FFF6EE" fill={wet ? 'none' : '#FFF6EE'} w={wet ? 2.4 : 0} />
+                  {wet ? ' Watered' : ' Water now'}
+                </CBtn>
+                <CBtn kind="ghost" style={{ fontSize: 15, padding: '12px 16px' }}>Edit</CBtn>
+              </div>
+            </div>
+
+            {/* environment card */}
+            <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)', padding: 20, flex: 1 }}>
+              <CKicker>Its corner of the home</CKicker>
+              <div style={{ marginTop: 12 }}>
+                <PDEnv iconKey="sun" iconColor={C.gold} label="Light" value="Bright" bar={72} />
+                <PDEnv iconKey="drop" iconColor={C.terra} label="Soil moist." value={wet ? 'Moist' : 'Dry'} bar={wet ? 70 : 24} />
+                <PDEnv iconKey="rain" iconColor={C.sage} label="Humidity" value="45%" bar={45} />
+                <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '11px 0' }}>
+                  <CIcon d={IC.clock} size={18} color={C.muted} w={1.7} style={{ flexShrink: 0 }} />
+                  <span style={{ fontFamily: C.sans, fontSize: 13.5, color: C.muted, flex: 1 }}>In your care</span>
+                  <span style={{ fontFamily: C.serif, fontSize: 15, color: C.ink }}>
+                    {plant.createdAt ? new Date(plant.createdAt).toLocaleDateString('en-US', { month: 'short', year: 'numeric' }) : '—'}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* right: stats + care journal */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16, minHeight: 0, overflow: 'hidden' }}>
+            <div style={{ display: 'flex', gap: 12 }}>
+              <PDStat label="Waters every" value={plant.frequencyDays ? `${plant.frequencyDays} days` : '—'} sub="Adjusts with season" />
+              <PDStat label="Last watered" value={plant.lastWatered ? `${sinceDays}d ago` : '—'} sub={plant.lastWatered ? new Date(plant.lastWatered).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : ''} />
+              <PDStat label="Next due" value={status === 'overdue' ? 'Overdue' : status === 'today' ? 'Today' : `${plant._daysUntil}d`} sub={status === 'overdue' ? `was ${Math.abs(plant._daysUntil)}d ago` : ''} accent={status !== 'ok' ? C.terra : undefined} />
+              <PDStat label="Health" value={plant.health || '—'} accent={C.green} />
+            </div>
+
+            {/* care journal */}
+            <div style={{
+              background: C.card, borderRadius: 8, border: `1px solid ${C.line}`,
+              boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)',
+              padding: 22, position: 'relative', overflow: 'hidden', flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0,
+            }}>
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+                <div>
+                  <CKicker>Care journal</CKicker>
+                  <div style={{ fontFamily: C.serif, fontSize: 22, color: C.ink, marginTop: 2, whiteSpace: 'nowrap' }}>Recent history</div>
+                </div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  {['All', 'Water', 'Notes'].map((t, i) => (
+                    <span key={t} style={{
+                      fontFamily: C.sans, fontSize: 13, fontWeight: 600, padding: '6px 13px',
+                      borderRadius: 20, cursor: 'pointer',
+                      background: i === 0 ? C.terraSoft : 'transparent',
+                      color: i === 0 ? C.terra : C.muted,
+                    }}>{t}</span>
+                  ))}
+                </div>
+              </div>
+              <div style={{ flex: 1, overflow: 'hidden' }}>
+                {journal.length === 0 ? (
+                  <div style={{ fontFamily: C.serif, fontStyle: 'italic', fontSize: 15, color: C.muted, padding: '12px 0' }}>No care events recorded yet.</div>
+                ) : (
+                  journal.slice(0, 6).map((h, i, a) => (
+                    <PDHistory key={i} h={h} isLast={i === a.length - 1} />
+                  ))
+                )}
+              </div>
+              <div style={{ paddingTop: 12, borderTop: `1px solid ${C.line2}`, marginTop: 4 }}>
+                <span style={{ fontFamily: C.serif, fontSize: 15, fontStyle: 'italic', color: C.terra, cursor: 'pointer' }}>View full journal →</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/Propagation.jsx
+++ b/src/conservatory/desktop/screens/Propagation.jsx
@@ -1,0 +1,142 @@
+import React, { useMemo } from 'react'
+import { C } from '../../tokens.js'
+import { CIcon, IC } from '../../icons.jsx'
+import { CSwash, CKicker, CBtn } from '../../primitives.jsx'
+import { PlantIcon } from '../../PlantIcon.jsx'
+import { DesktopHeader } from '../DesktopHeader.jsx'
+
+const STAGE_STYLE = {
+  sown:         { color: '#D99A2B', soft: '#F7E8C6', label: 'Callousing' },
+  rooted:       { color: '#5E9C4F', soft: '#DCEBCB', label: 'Rooting' },
+  transplanted: { color: '#3E5641', soft: '#E4EDDD', label: 'Established' },
+  failed:       { color: '#857F6E', soft: '#F0EBE0', label: 'Failed' },
+  Callousing:   { color: '#D99A2B', soft: '#F7E8C6', label: 'Callousing' },
+  Rooting:      { color: '#5E9C4F', soft: '#DCEBCB', label: 'Rooting' },
+  'Ready soon': { color: '#5C7E4F', soft: '#E4EDDD', label: 'Ready soon' },
+  Established:  { color: '#3E5641', soft: '#E4EDDD', label: 'Established' },
+}
+
+function speciesIcon(species = '') {
+  const s = species.toLowerCase()
+  if (s.includes('monstera')) return 'monstera'
+  if (s.includes('pothos')) return 'pothos'
+  if (s.includes('snake') || s.includes('sansevieria')) return 'snake'
+  if (s.includes('aloe')) return 'succulent'
+  if (s.includes('fern')) return 'fern'
+  if (s.includes('palm')) return 'palm'
+  if (s.includes('cactus')) return 'cactus'
+  return 'herb'
+}
+
+function PropCard({ prop }) {
+  const stKey = prop.stage || prop.status || 'rooted'
+  const st = STAGE_STYLE[stKey] || STAGE_STYLE.rooted
+  const pct = prop.pct ?? Math.min(1, prop.startDate ? (Date.now() - new Date(prop.startDate).getTime()) / (28 * 86400000) : 0.5)
+  const daysSince = prop.startDate ? Math.round((Date.now() - new Date(prop.startDate).getTime()) / 86400000) : 0
+  return (
+    <div style={{ background: C.card, borderRadius: 10, border: `1px solid ${C.line2}`, boxShadow: '0 8px 24px -16px rgba(120,70,30,.4)', padding: 18, display: 'flex', flexDirection: 'column' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 13, marginBottom: 14 }}>
+        <div style={{ width: 52, height: 52, borderRadius: 15, background: st.soft, display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: `inset 0 0 0 1.5px ${st.color}` }}>
+          <PlantIcon type={speciesIcon(prop.species || '')} size={38} />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontFamily: C.serif, fontSize: 20, color: C.ink, lineHeight: 1.05 }}>{prop.name || 'Cutting'}</div>
+          <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.muted, fontStyle: 'italic' }}>from {prop.species || '—'}</div>
+        </div>
+        <span style={{ fontFamily: C.sans, fontSize: 11.5, fontWeight: 700, color: st.color, background: st.soft, padding: '4px 10px', borderRadius: 20, whiteSpace: 'nowrap' }}>{st.label}</span>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
+        <span style={{ fontFamily: C.sans, fontSize: 12, color: C.muted }}>Day {daysSince} · {prop.method || 'Water'}</span>
+        <span style={{ fontFamily: C.serif, fontSize: 14, fontStyle: 'italic', color: st.color }}>{Math.round(pct * 100)}%</span>
+      </div>
+      <div style={{ height: 7, borderRadius: 4, background: C.panel, overflow: 'hidden', border: `1px solid ${C.line2}` }}>
+        <div style={{ width: `${pct * 100}%`, height: '100%', background: st.color, borderRadius: 4 }} />
+      </div>
+      {prop.notes && (
+        <div style={{ display: 'flex', gap: 9, marginTop: 14, alignItems: 'flex-start' }}>
+          <CIcon d={IC.leaf} size={16} color={C.sage} fill={C.sageBg} w={1.4} style={{ marginTop: 1, flexShrink: 0 }} />
+          <div style={{ fontFamily: C.sans, fontSize: 13, color: C.ink, lineHeight: 1.45 }}>{prop.notes}</div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function BenchStat({ n, label, color }) {
+  return (
+    <div style={{ flex: 1, background: C.panel, borderRadius: 7, border: `1px solid ${C.line2}`, padding: '12px 14px' }}>
+      <div style={{ fontFamily: C.serif, fontSize: 30, color, lineHeight: 1 }}>{n}</div>
+      <div style={{ fontFamily: C.sans, fontSize: 12, color: C.muted, marginTop: 3 }}>{label}</div>
+    </div>
+  )
+}
+
+export function Propagation({ propagations = [], ctx }) {
+  const active = propagations.filter((p) => p.status !== 'failed')
+  const ready = propagations.filter((p) => (p.pct ?? 0) >= 0.8 && p.status !== 'failed')
+  const methodCounts = useMemo(() => {
+    const c = {}
+    active.forEach((p) => { c[p.method || 'Water'] = (c[p.method || 'Water'] || 0) + 1 })
+    return Object.entries(c)
+  }, [active])
+  const wx = ctx.weather?.current ? { temp: Math.round(ctx.weather.current.temp), condition: ctx.weather.current.condition?.sky || 'Clear' } : null
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'flex', flexDirection: 'column' }}>
+      <DesktopHeader activeScreen="propagation" onNav={ctx.navigate} user={ctx.user} weather={wx} />
+      <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 320px', gap: 30, padding: '30px 34px', minHeight: 0, overflow: 'hidden' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: 20 }}>
+            <div>
+              <CKicker>The propagation bench</CKicker>
+              <h1 style={{ fontFamily: C.serif, fontSize: 34, fontWeight: 400, margin: '6px 0 0', letterSpacing: -0.3 }}>
+                {active.length > 0
+                  ? <>{active.length} cutting{active.length !== 1 ? 's' : ''} <span style={{ fontStyle: 'italic', color: C.terra }}>taking root.</span></>
+                  : <>Nothing on the <span style={{ fontStyle: 'italic', color: C.terra }}>bench yet.</span></>}
+              </h1>
+              <div style={{ marginTop: 8, marginLeft: 2 }}><CSwash width={200} /></div>
+            </div>
+            <CBtn kind="primary"><CIcon d={IC.scissors} size={17} color="#FFF6EE" w={1.8} /> New cutting</CBtn>
+          </div>
+          <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 1fr', gridAutoRows: 'min-content', gap: 16, alignContent: 'start', overflowY: 'auto' }}>
+            {active.length === 0
+              ? <div style={{ gridColumn: '1/-1', padding: '40px 0', textAlign: 'center', fontFamily: C.serif, fontStyle: 'italic', fontSize: 17, color: C.muted }}>Start a cutting to track its progress here.</div>
+              : active.map((p) => <PropCard key={p.id} prop={p} />)}
+          </div>
+        </div>
+
+        <aside style={{ display: 'flex', flexDirection: 'column', gap: 16, minHeight: 0 }}>
+          <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)', padding: 20, position: 'relative', overflow: 'hidden' }}>
+            <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+            <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+            <CKicker>On the bench</CKicker>
+            <div style={{ display: 'flex', gap: 10, marginTop: 14 }}>
+              <BenchStat n={active.length} label="propagating" color={C.terra} />
+              <BenchStat n={ready.length} label="ready to pot" color={C.greenBright} />
+            </div>
+            {methodCounts.length > 0 && (
+              <div style={{ marginTop: 16, paddingTop: 16, borderTop: `1px solid ${C.line2}` }}>
+                <div style={{ fontFamily: C.serif, fontSize: 17, fontStyle: 'italic', color: C.ink, marginBottom: 10 }}>Method mix</div>
+                {methodCounts.map(([method, n]) => (
+                  <div key={method} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 0' }}>
+                    <span style={{ width: 9, height: 9, borderRadius: '50%', background: C.terra }} />
+                    <span style={{ flex: 1, fontFamily: C.sans, fontSize: 13.5, color: C.muted }}>{method}</span>
+                    <span style={{ fontFamily: C.serif, fontSize: 16, color: C.ink }}>{n}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          {ready.length > 0 && (
+            <div style={{ background: C.goldSoft, borderLeft: `3px solid ${C.gold}`, borderRadius: 4, padding: '14px 16px' }}>
+              <div style={{ fontFamily: C.serif, fontSize: 17, fontStyle: 'italic', color: C.goldDeep, marginBottom: 3 }}>{ready[0].name} is ready.</div>
+              <div style={{ fontFamily: C.sans, fontSize: 13, color: C.muted, lineHeight: 1.5 }}>Roots are strong — pot it up this weekend to keep it thriving.</div>
+            </div>
+          )}
+          <div style={{ flex: 1 }} />
+          <CBtn kind="ghost" full><CIcon d={IC.prop} size={16} color={C.terra} w={1.7} /> Propagation guide</CBtn>
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/Settings.jsx
+++ b/src/conservatory/desktop/screens/Settings.jsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react'
+import { C, CSTAT } from '../../tokens.js'
+import { CIcon, IC } from '../../icons.jsx'
+import { CKicker, CBtn } from '../../primitives.jsx'
+import { DesktopHeader } from '../DesktopHeader.jsx'
+
+function Toggle({ on, onClick, label }) {
+  return (
+    <button onClick={onClick} role="switch" aria-checked={on} aria-label={label}
+      style={{ width: 44, height: 26, borderRadius: 20, background: on ? C.greenBright : C.line, padding: 3, display: 'flex', justifyContent: on ? 'flex-end' : 'flex-start', border: 'none', cursor: 'pointer', flexShrink: 0 }}>
+      <div style={{ width: 20, height: 20, borderRadius: '50%', background: '#fff', boxShadow: '0 1px 3px rgba(0,0,0,.25)' }} />
+    </button>
+  )
+}
+
+function SetRow({ title, desc, on, onToggle, last }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 16, padding: '15px 0', borderBottom: last ? 'none' : `1px solid ${C.line2}` }}>
+      <div style={{ flex: 1 }}>
+        <div style={{ fontFamily: C.serif, fontSize: 17, color: C.ink }}>{title}</div>
+        <div style={{ fontFamily: C.sans, fontSize: 13, color: C.muted, marginTop: 1, lineHeight: 1.45 }}>{desc}</div>
+      </div>
+      <Toggle on={on} onClick={onToggle} label={title} />
+    </div>
+  )
+}
+
+function SetField({ label, value, icon }) {
+  return (
+    <div style={{ flex: 1 }}>
+      <div style={{ fontFamily: C.sans, fontSize: 12.5, fontWeight: 600, color: C.muted, marginBottom: 6 }}>{label}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 9, border: `1px solid ${C.line}`, borderRadius: 6, padding: '11px 13px', background: C.card }}>
+        {icon && <CIcon d={IC[icon]} size={15} color={C.muted} w={1.7} />}
+        <span style={{ fontFamily: C.sans, fontSize: 14, color: C.ink }}>{value}</span>
+      </div>
+    </div>
+  )
+}
+
+export function Settings({ user, subscription, ctx }) {
+  const [prefs, setPrefs] = useState({ watering: true, weather: true, propagation: false, digest: true })
+  const toggle = (key) => setPrefs((p) => ({ ...p, [key]: !p[key] }))
+
+  const initial = user?.initial || (user?.name ? user.name[0].toUpperCase() : 'A')
+  const tierLabel = subscription?.tier === 'landscaper_pro' ? 'Glasshouse' : subscription?.tier === 'home_pro' ? 'Greenhouse' : 'Windowsill'
+  const wx = ctx.weather?.current ? { temp: Math.round(ctx.weather.current.temp), condition: ctx.weather.current.condition?.sky || 'Clear' } : null
+
+  const nav = [
+    ['Account', 'sliders', 'account'],
+    ['Notifications', 'bell', 'notifications'],
+    ['Weather & location', 'forecast', 'weather'],
+    ['Care defaults', 'drop', 'care'],
+    ['Plan & billing', 'star', 'billing'],
+  ]
+  const [activeNav, setActiveNav] = useState('account')
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'flex', flexDirection: 'column' }}>
+      <DesktopHeader activeScreen="garden" onNav={ctx.navigate} user={ctx.user} weather={wx} />
+      <div style={{ flex: 1, padding: '28px 34px', display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
+        <div style={{ marginBottom: 20 }}>
+          <CKicker>Preferences</CKicker>
+          <h1 style={{ fontFamily: C.serif, fontSize: 34, fontWeight: 400, margin: '6px 0 0', letterSpacing: -0.3 }}>
+            Settings &amp; <span style={{ fontStyle: 'italic', color: C.terra }}>care defaults.</span>
+          </h1>
+        </div>
+
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '236px 1fr', gap: 28, minHeight: 0, overflow: 'hidden' }}>
+          {/* sub-nav */}
+          <aside style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {nav.map(([label, ic, key]) => (
+              <div key={key} onClick={() => { setActiveNav(key); if (key === 'billing') ctx.navigate('billing') }}
+                style={{ display: 'flex', alignItems: 'center', gap: 11, padding: '11px 14px', borderRadius: 8, cursor: 'pointer', background: activeNav === key ? C.terraSoft : 'transparent', color: activeNav === key ? C.green : C.muted }}>
+                <CIcon d={IC[ic]} size={17} color={activeNav === key ? C.terra : C.muted} w={1.7} />
+                <span style={{ fontFamily: C.serif, fontSize: 16.5, fontStyle: activeNav === key ? 'italic' : 'normal' }}>{label}</span>
+              </div>
+            ))}
+            <div style={{ flex: 1 }} />
+            <div onClick={ctx.onSignOut}
+              style={{ display: 'flex', alignItems: 'center', gap: 11, padding: '11px 14px', borderRadius: 8, cursor: 'pointer', color: CSTAT.overdue.color }}>
+              <CIcon d={IC.logout} size={17} color={CSTAT.overdue.color} w={1.7} />
+              <span style={{ fontFamily: C.serif, fontSize: 16.5 }}>Sign out</span>
+            </div>
+          </aside>
+
+          {/* content */}
+          <div style={{ overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)', padding: 22, position: 'relative', overflow: 'hidden' }}>
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+              <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+              <CKicker>Account</CKicker>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 18, margin: '14px 0 18px' }}>
+                <div style={{ width: 66, height: 66, borderRadius: '50%', background: C.green, color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: C.serif, fontSize: 28, flexShrink: 0 }}>{initial}</div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontFamily: C.serif, fontSize: 22, color: C.ink }}>{user?.name || 'Plant Keeper'}</div>
+                  <div style={{ fontFamily: C.sans, fontSize: 13.5, color: C.muted }}>{user?.email || ''}</div>
+                </div>
+                <CBtn kind="ghost" style={{ borderRadius: 6, fontSize: 14, padding: '10px 16px' }}>Change photo</CBtn>
+              </div>
+              <div style={{ display: 'flex', gap: 14 }}>
+                <SetField label="Display name" value={user?.name || 'Plant Keeper'} />
+                <SetField label="Home location" value="—" icon="pin" />
+                <SetField label="Units" value="Metric · °C" />
+              </div>
+            </div>
+
+            <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)', padding: 22 }}>
+              <CKicker>Notifications</CKicker>
+              <div style={{ marginTop: 6 }}>
+                <SetRow title="Watering reminders" desc="A gentle nudge the morning a plant is due." on={prefs.watering} onToggle={() => toggle('watering')} />
+                <SetRow title="Weather-aware skips" desc="Tell me when rain pauses or shifts a watering." on={prefs.weather} onToggle={() => toggle('weather')} />
+                <SetRow title="Propagation milestones" desc="When a cutting is ready to pot up." on={prefs.propagation} onToggle={() => toggle('propagation')} />
+                <SetRow title="Weekly digest" desc="A Sunday summary of the week's care." on={prefs.digest} onToggle={() => toggle('digest')} last />
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', gap: 16 }}>
+              <div style={{ background: C.card, borderRadius: 8, border: `1px solid ${C.line}`, boxShadow: '0 1px 2px rgba(40,30,20,.05)', flex: 1, padding: 20, display: 'flex', alignItems: 'center', gap: 16 }}>
+                <div style={{ width: 46, height: 46, borderRadius: 13, background: C.goldSoft, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                  <CIcon d={IC.star} size={24} color={C.goldDeep} fill={C.goldSoft} w={1.6} />
+                </div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontFamily: C.serif, fontSize: 19, color: C.ink }}>Conservatory <span style={{ fontStyle: 'italic', color: C.gold }}>{tierLabel}</span></div>
+                  <div style={{ fontFamily: C.sans, fontSize: 13, color: C.muted }}>Unlimited plants · weather sync</div>
+                </div>
+                <CBtn kind="ghost" style={{ borderRadius: 6, fontSize: 14, padding: '10px 16px' }} onClick={() => ctx.navigate('billing')}>Manage plan</CBtn>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/desktop/screens/Today.jsx
+++ b/src/conservatory/desktop/screens/Today.jsx
@@ -1,0 +1,167 @@
+import React from 'react'
+import { C, CSTAT } from '../../tokens.js'
+import { CIcon, IC } from '../../icons.jsx'
+import { CSwash, CKicker, CBtn, CStatusChip, CIconBadge, statusOf, pressProps } from '../../primitives.jsx'
+import { DesktopHeader } from '../DesktopHeader.jsx'
+
+function Ring({ pct }) {
+  const r = 30, cir = 2 * Math.PI * r
+  return (
+    <svg width="76" height="76" viewBox="0 0 76 76" role="img" aria-label={`${pct}% of plants cared for`}>
+      <circle cx="38" cy="38" r={r} fill="none" stroke={C.line} strokeWidth="8" />
+      <circle cx="38" cy="38" r={r} fill="none" stroke={C.greenBright} strokeWidth="8"
+        strokeLinecap="round" strokeDasharray={cir}
+        strokeDashoffset={cir * (1 - pct / 100)}
+        transform="rotate(-90 38 38)"
+        style={{ transition: 'stroke-dashoffset .5s ease' }} />
+      <text x="38" y="43" textAnchor="middle" fontFamily={C.serif} fontSize="19" fill={C.ink}>{pct}%</text>
+    </svg>
+  )
+}
+
+function MiniStat({ n, label, color }) {
+  return (
+    <div style={{ flex: 1, background: C.panel, borderRadius: 6, border: `1px solid ${C.line2}`, padding: '10px 12px' }}>
+      <div style={{ fontFamily: C.serif, fontSize: 26, color, lineHeight: 1 }}>{n}</div>
+      <div style={{ fontFamily: C.sans, fontSize: 12, color: C.muted, marginTop: 2 }}>{label}</div>
+    </div>
+  )
+}
+
+function TDTask({ plant, isDone, onWater, openPlant }) {
+  const s = CSTAT[plant._status] || CSTAT.ok
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 14, padding: '12px 14px',
+      background: isDone ? 'transparent' : C.card, borderRadius: 8,
+      border: `1px solid ${isDone ? 'transparent' : C.line2}`, opacity: isDone ? 0.55 : 1,
+    }}>
+      <button onClick={() => !isDone && onWater(plant.id)}
+        aria-label={isDone ? 'Watered' : `Water ${plant.name}`}
+        style={{
+          width: 26, height: 26, borderRadius: '50%',
+          border: `2px solid ${isDone ? C.greenBright : s.color}`,
+          background: isDone ? C.greenBright : 'transparent',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          flexShrink: 0, cursor: isDone ? 'default' : 'pointer',
+          padding: 0,
+        }}>
+        {isDone && <CIcon d={IC.check} size={15} color="#fff" w={2.6} />}
+      </button>
+      <CIconBadge plant={isDone ? { ...plant, _status: 'ok' } : plant} size={44} radius={13} />
+      <div {...pressProps(() => openPlant(plant.id), `Open ${plant.name}`)}
+        style={{ flex: 1, minWidth: 0, cursor: 'pointer' }}>
+        <div style={{ fontFamily: C.serif, fontSize: 18, color: C.ink, lineHeight: 1.05, textDecoration: isDone ? 'line-through' : 'none' }}>{plant.name}</div>
+        <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.muted, fontStyle: 'italic' }}>{plant.species || ''}</div>
+      </div>
+      {isDone
+        ? <span style={{ fontFamily: C.sans, fontSize: 12, fontWeight: 700, color: C.greenBright }}>Watered</span>
+        : <>
+            <CStatusChip status={plant._status}>{plant._status === 'overdue' ? `${Math.abs(plant._daysUntil)}d late` : 'today'}</CStatusChip>
+            <CBtn kind="ghost" style={{ padding: '8px 16px', fontSize: 14 }} onClick={() => onWater(plant.id)}>Water</CBtn>
+          </>}
+    </div>
+  )
+}
+
+function TDGroup({ room, plants, wateredSet, onWater, openPlant }) {
+  return (
+    <div style={{ marginBottom: 22 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 10 }}>
+        <CIcon d={IC.pin} size={16} color={C.terra} w={1.7} />
+        <h3 style={{ fontFamily: C.serif, fontSize: 21, margin: 0, color: C.ink, whiteSpace: 'nowrap' }}>{room}</h3>
+        <div style={{ flex: 1, height: 1, background: C.line }} />
+        <span style={{ fontFamily: C.sans, fontSize: 12.5, color: C.muted }}>{plants.length} plant{plants.length === 1 ? '' : 's'}</span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {plants.map((p) => (
+          <TDTask key={p.id} plant={p} isDone={wateredSet.has(p.id)} onWater={onWater} openPlant={openPlant} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function Today({ plants, wateredSet, onWater, waterAll, openPlant, ctx }) {
+  const total = plants.length
+  const done = plants.filter((p) => statusOf(p, wateredSet) === 'ok').length
+  const dueCount = total - done
+  const pct = total > 0 ? Math.round((done / total) * 100) : 100
+
+  // Group plants by room
+  const roomMap = {}
+  plants.forEach((p) => {
+    if (!roomMap[p.room]) roomMap[p.room] = []
+    roomMap[p.room].push(p)
+  })
+  const groups = Object.entries(roomMap).map(([room, ps]) => ({ room, plants: ps }))
+
+  const weatherDisplay = ctx.weather?.current
+    ? { temp: Math.round(ctx.weather.current.temp), condition: ctx.weather.current.condition?.sky || 'Clear' }
+    : null
+
+  return (
+    <div style={{ height: '100%', background: C.paper, fontFamily: C.sans, color: C.ink, display: 'flex', flexDirection: 'column' }}>
+      <DesktopHeader activeScreen="today" onNav={ctx.navigate} user={ctx.user} weather={weatherDisplay} />
+      <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 360px', gap: 34, padding: '30px 34px', minHeight: 0, overflow: 'hidden' }}>
+        {/* main task list */}
+        <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
+          <div style={{ marginBottom: 20 }}>
+            <CKicker>{new Date().toLocaleDateString('en-US', { weekday: 'long', day: 'numeric', month: 'long' })}</CKicker>
+            <h1 style={{ fontFamily: C.serif, fontSize: 37, fontWeight: 400, lineHeight: 1.1, margin: '8px 0 0', letterSpacing: -0.3 }}>
+              The day's <span style={{ fontStyle: 'italic', color: C.terra }}>watering round.</span>
+            </h1>
+            <div style={{ marginTop: 8, marginLeft: 2 }}><CSwash width={210} /></div>
+          </div>
+          <div style={{ flex: 1, overflowY: 'auto' }}>
+            {groups.length === 0 ? (
+              <div style={{ padding: '40px 0', textAlign: 'center', fontFamily: C.serif, fontStyle: 'italic', fontSize: 18, color: C.muted }}>Every plant has been cared for today.</div>
+            ) : (
+              groups.map((g) => (
+                <TDGroup key={g.room} room={g.room} plants={g.plants} wateredSet={wateredSet} onWater={onWater} openPlant={openPlant} />
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* right rail */}
+        <aside style={{ display: 'flex', flexDirection: 'column', gap: 16, minHeight: 0 }}>
+          <div style={{
+            background: C.card, borderRadius: 8, border: `1px solid ${C.line}`,
+            boxShadow: '0 1px 2px rgba(40,30,20,.05), 0 18px 44px -30px rgba(120,60,30,.45)',
+            padding: 20, position: 'relative', overflow: 'hidden',
+          }}>
+            <div style={{ position: 'absolute', top: 0, left: 0, width: 60, height: 4, background: C.gold }} />
+            <div style={{ position: 'absolute', top: 0, left: 0, width: 4, height: 60, background: C.gold }} />
+            <CKicker>Today's progress</CKicker>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 18, marginTop: 14 }}>
+              <Ring pct={pct} />
+              <div>
+                <div style={{ fontFamily: C.serif, fontSize: 30, color: C.ink, lineHeight: 1 }}>
+                  {done} <span style={{ fontStyle: 'italic', color: C.muted, fontSize: 20 }}>/ {total}</span>
+                </div>
+                <div style={{ fontFamily: C.sans, fontSize: 13, color: C.muted, marginTop: 3 }}>plants cared for</div>
+              </div>
+            </div>
+            <div style={{ marginTop: 16, display: 'flex', gap: 8 }}>
+              <MiniStat n={dueCount} label="still due" color={C.terra} />
+              <MiniStat n={done} label="watered" color={C.greenBright} />
+            </div>
+          </div>
+
+          {ctx.weather?.rainSoon && (
+            <div style={{ background: C.sageBg, borderLeft: `3px solid ${C.greenBright}`, borderRadius: 4, padding: '14px 16px' }}>
+              <div style={{ fontFamily: C.serif, fontSize: 17, fontStyle: 'italic', color: C.green, marginBottom: 3 }}>Two plants skipped.</div>
+              <div style={{ fontFamily: C.sans, fontSize: 13, color: C.muted, lineHeight: 1.5 }}>Rain is forecast today, so your outdoor plants don't need watering.</div>
+            </div>
+          )}
+
+          <div style={{ flex: 1 }} />
+          <CBtn kind="primary" full onClick={() => waterAll(plants.map((p) => p.id))}>
+            <CIcon d={IC.check} size={17} color="#FFF6EE" w={2.4} /> Mark all as watered
+          </CBtn>
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/src/conservatory/icons.jsx
+++ b/src/conservatory/icons.jsx
@@ -26,4 +26,17 @@ export const IC = {
   star: <path d="M12 3.2l2.5 5.6 6.1.6-4.6 4 1.4 6L12 16.8 6.6 19.4 8 13.4 3.4 9.4l6.1-.6z" />,
   logout: <><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4" /><path d="M16 17l5-5-5-5M21 12H9" /></>,
   bloom: <><circle cx="12" cy="12" r="3" /><path d="M12 9c0-3 1-5 0-7-1 2 0 4 0 7zM12 15c0 3-1 5 0 7 1-2 0-4 0-7zM15 12c3 0 5-1 7 0-2 1-4 0-7 0zM9 12c-3 0-5 1-7 0 2-1 4 0 7 0z" /></>,
+  // Desktop additions
+  forecast: <><path d="M6 16a4 4 0 010-8 5 5 0 019.6-1.5A3.5 3.5 0 0118 16Z" /></>,
+  prop: <><circle cx="6" cy="6" r="2.5" /><circle cx="6" cy="18" r="2.5" /><path d="M20 4 8.5 16.5M14 4h6v6" /></>,
+  sun: <><circle cx="12" cy="12" r="4.2" /><path d="M12 2v2.4M12 19.6V22M2 12h2.4M19.6 12H22M4.6 4.6l1.7 1.7M17.7 17.7l1.7 1.7M19.4 4.6l-1.7 1.7M6.3 17.7l-1.7 1.7" /></>,
+  cloud: <path d="M6 18a4 4 0 010-8 5 5 0 019.6-1.5A3.5 3.5 0 0118 18Z" />,
+  clock: <><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 2" /></>,
+  camera: <><rect x="2.5" y="6.5" width="19" height="13" rx="2.5" /><circle cx="12" cy="13" r="3.6" /><path d="M8 6.5l1.4-2.5h5.2L16 6.5" /></>,
+  scissors: <><circle cx="6" cy="6" r="3" /><circle cx="6" cy="18" r="3" /><path d="M20 4 8.1 15.9M14.5 14.5 20 20M8.1 8.1 12 12" /></>,
+  sparkle: <><path d="M12 3l1.7 5.1L19 10l-5.3 1.9L12 17l-1.7-5.1L5 10l5.3-1.9z" /><path d="M19 14l.6 1.9 1.9.6-1.9.6-.6 1.9-.6-1.9-1.9-.6 1.9-.6z" /></>,
+  plus: <><path d="M12 5v14M5 12h14" /></>,
+  search: <><circle cx="11" cy="11" r="7" /><path d="M21 21l-4-4" /></>,
+  filter: <path d="M3 5h18l-7 8v6l-4-2v-4z" />,
+  upload: <><path d="M12 16V4M7 9l5-5 5 5" /><path d="M4 16v3a1 1 0 001 1h14a1 1 0 001-1v-3" /></>,
 }

--- a/src/layouts/DesktopConservatoryLayout.jsx
+++ b/src/layouts/DesktopConservatoryLayout.jsx
@@ -1,0 +1,31 @@
+import { Suspense } from 'react'
+import { Outlet, Navigate } from 'react-router'
+import { useAuth } from '../contexts/AuthContext.jsx'
+import { PlantProvider } from '../context/PlantContext.jsx'
+import ErrorBoundary from '../components/ErrorBoundary.jsx'
+
+function AuthGate() {
+  const { isLoading } = useAuth()
+  if (isLoading) {
+    return (
+      <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div className="spinner-border" role="status"><span className="visually-hidden">Loading…</span></div>
+      </div>
+    )
+  }
+  return <Outlet />
+}
+
+export default function DesktopConservatoryLayout() {
+  return (
+    <PlantProvider>
+      <ErrorBoundary context="Conservatory desktop">
+        <div style={{ height: '100dvh', overflow: 'hidden' }}>
+          <Suspense fallback={null}>
+            <AuthGate />
+          </Suspense>
+        </div>
+      </ErrorBoundary>
+    </PlantProvider>
+  )
+}

--- a/src/pages/DesktopConservatoryPage.jsx
+++ b/src/pages/DesktopConservatoryPage.jsx
@@ -1,0 +1,5 @@
+import { DesktopApp } from '../conservatory/desktop/DesktopApp.jsx'
+
+export default function DesktopConservatoryPage() {
+  return <DesktopApp />
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -3,6 +3,7 @@ import { Navigate } from 'react-router'
 import App from '../App.jsx'
 import MainLayout from '../layouts/MainLayout.jsx'
 import MobileLayout from '../layouts/MobileLayout.jsx'
+import DesktopConservatoryLayout from '../layouts/DesktopConservatoryLayout.jsx'
 import AuthLayout from '../layouts/AuthLayout.jsx'
 import { lazyWithRetry } from '../utils/lazyWithRetry.js'
 
@@ -33,6 +34,7 @@ const GiftPage = lazyWithRetry(() => import('../pages/GiftPage.jsx'))
 const CommunityPage = lazyWithRetry(() => import('../pages/CommunityPage.jsx'))
 const CommunityGuidelinesPage = lazyWithRetry(() => import('../pages/CommunityGuidelinesPage.jsx'))
 const MobilePage = lazyWithRetry(() => import('../pages/MobilePage.jsx'))
+const DesktopConservatoryPage = lazyWithRetry(() => import('../pages/DesktopConservatoryPage.jsx'))
 
 export const routes = [
   {
@@ -56,6 +58,13 @@ export const routes = [
         element: <MobileLayout />,
         children: [
           { index: true, element: <Suspense fallback={null}><MobilePage /></Suspense> },
+        ],
+      },
+      {
+        path: '/app',
+        element: <DesktopConservatoryLayout />,
+        children: [
+          { index: true, element: <Suspense fallback={null}><DesktopConservatoryPage /></Suspense> },
         ],
       },
       {


### PR DESCRIPTION
## Summary

Implements the full **Conservatory desktop design spec** as a parallel shell at `/app`, wired to the existing API and plant data. The Smart Admin desktop UI continues to work at `/`.

### Design system additions
- `icons.jsx`: 12 new icons (forecast, prop, sun, cloud, clock, camera, scissors, sparkle, plus, search, filter, upload)

### Desktop shell (`src/conservatory/desktop/`)
- **`DesktopHeader`** — gradient top rule + 66px nav bar with wordmark, 6-item primary nav (Garden/Today/Calendar/Forecast/Propagation/Insights), weather pill, bell, avatar
- **`DesktopApp`** — stateful root using `usePlantContext()` + `useAuth()` + `useSubscription()`; normalizes plants with `getWateringStatus()`, owns `wateredSet`, calls `handleWaterPlant()` optimistically, fetches propagations on mount, fetches journal on plant open

### 13 screens wired to real data

| Screen | Route key | Key features |
|---|---|---|
| Garden | `garden` | 660×384 SVG floorplan, thirsty list, Water-all CTA |
| Today | `today` | Room-grouped tasks, 76px animated ring, rain note |
| Plant detail | `plant` | Profile plate, environment bars, care journal timeline |
| Calendar | `calendar` | Month grid with plant dots, week rail, nav arrows |
| Forecast | `forecast` | 7-day strip, care-adapts cards, rain-skip rail |
| Propagation | `propagation` | 2-col card grid, progress bars, bench stats |
| Login | (unauthenticated) | Green brand panel + Google G sign-in |
| Library | `library` | 4-col grid, filter chips, Map/List toggle |
| Insights | `insights` | 4 stat heroes, bar trend, health donut, room bars |
| Add a plant | `addplant` | 3-step wizard, floorplan placement pin |
| Settings | `settings` | Left sub-nav, account fields, notification toggles |
| Billing | `billing` | 3 editorial plan cards, usage rail, invoices |
| Members | `members` | Member table, pending invites, roles legend |

### Routing
- `/app` added to router under `DesktopConservatoryLayout` (PlantProvider + auth-gate)
- `/app` added to E2E console-smoke authenticated routes

## Test plan
- [ ] Visit `https://plants.lopezcloud.dev/app` — see Garden screen with Conservatory header
- [ ] Navigate all 6 top-nav tabs (Garden/Today/Calendar/Forecast/Propagation/Insights)
- [ ] Click a plant marker on the floorplan → opens Plant detail
- [ ] Click "Water all" on Garden → status chips flip to Healthy
- [ ] Navigate to Settings → verify account info shown, toggles work
- [ ] Navigate to Billing → plan cards render, current tier highlighted
- [ ] CI build + tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)